### PR TITLE
Fix very slow query when using ./terminusdb list with many dbs

### DIFF
--- a/src/core/transaction/system_entity.pl
+++ b/src/core/transaction/system_entity.pl
@@ -25,14 +25,29 @@ database_exists(Organization,DB) :-
 database_exists(Askable, Organization, DB) :-
     organization_database_name_uri(Askable, Organization, DB, _).
 
+% First check if the Db_Uri is ground, if it is ground
+% the following query is much faster
+organization_database_name_uri(Askable, Organization, DB, Db_Uri) :-
+    ground(Db_Uri),
+    !,
+    once(ask(Askable,
+             (
+                 t(Organization_Uri, system:resource_includes, Db_Uri),
+                 t(Organization_Uri, system:resource_name, Organization^^xsd:string),
+                 t(Organization_Uri, rdf:type, system:'Organization'),
+                 t(Db_Uri, system:resource_name, DB^^xsd:string),
+                 t(Db_Uri, rdf:type, system:'Database')
+             ))).
 organization_database_name_uri(Askable, Organization, DB, Db_Uri) :-
     once(ask(Askable,
-             (   t(Organization_Uri, system:resource_name, Organization^^xsd:string),
+             (
+                 t(Organization_Uri, system:resource_name, Organization^^xsd:string),
                  t(Organization_Uri, rdf:type, system:'Organization'),
                  t(Organization_Uri, system:resource_includes, Db_Uri),
                  t(Db_Uri, system:resource_name, DB^^xsd:string),
                  t(Db_Uri, rdf:type, system:'Database')
              ))).
+
 
 organization_name_uri(Askable,Organization, Uri) :-
     once(ask(Askable,


### PR DESCRIPTION
I created 388 DBs and it took 90 seconds to list them. But when I fix this query, it takes around 6 seconds. The reason is that the
original query is very slow because it does not take account that Db_Uri could be ground already.

To reproduce the bad performance, create: 388 DBs or something similar:

```python
#!/usr/bin/env python3
from terminusdb_client import WOQLClient, WOQLQuery

amount = 388
client = WOQLClient('https://127.0.0.1:6363')
client.connect(user='admin', account='admin', key='root')

for x in range(0, amount):
    db_name = f'db{str(x)}'
    client.create_database(db_name, accountid="admin")
```

Then run `./terminusdb list`. As you can see it is very slow.

Apply my commit and it runs way faster.