### PR TITLE
Refactor and optimize list db

### DIFF
--- a/src/cli/main.pl
+++ b/src/cli/main.pl
@@ -675,7 +675,9 @@ run_command(serve,_Positional,Opts) :-
     ;   terminus_server([serve|Opts], true)).
 run_command(list,Databases,_Opts) :-
     super_user_authority(Auth),
-    list_databases(system_descriptor{}, Auth, Databases, Database_Objects),
+    (   Databases = []
+    ->  list_databases(system_descriptor{}, Auth, Database_Objects)
+    ;   list_existing_databases(Databases, Database_Objects)),
     pretty_print_databases(Database_Objects).
 run_command(optimize,Databases,_Opts) :-
     super_user_authority(Auth),

--- a/src/core/api.pl
+++ b/src/core/api.pl
@@ -88,7 +88,8 @@
               get_prefixes/4,
 
               % api_db
-              list_databases/4,
+              list_databases/3,
+              list_existing_databases/2,
               pretty_print_databases/1,
 
               % api_error.pl

--- a/src/core/api/api_db.pl
+++ b/src/core/api/api_db.pl
@@ -1,5 +1,6 @@
 :- module(api_db, [
-              list_databases/4,
+              list_databases/3,
+              list_existing_databases/2,
               pretty_print_databases/1
           ]).
 
@@ -8,6 +9,22 @@
 :- use_module(core(account)).
 :- use_module(core(query)).
 :- use_module(core(transaction)).
+
+get_all_databases(System_DB, Databases) :-
+    create_context(System_DB, Context),
+    findall(
+        Path,
+        (
+            ask(Context,
+                (
+                    t(Organization_Uri, system:resource_name, Organization^^xsd:string),
+                    t(Organization_Uri, rdf:type, system:'Organization'),
+                    t(Organization_Uri, system:resource_includes, Db_Uri),
+                    t(Db_Uri, rdf:type, system:'Database'),
+                    t(Db_Uri, system:resource_name, Name^^xsd:string)
+            )),
+            format(string(Path),"~s/~s",[Organization,Name])),
+        Databases).
 
 get_user_databases(System_DB, Auth, User_Databases) :-
     create_context(System_DB, Context),
@@ -22,19 +39,21 @@ get_user_databases(System_DB, Auth, User_Databases) :-
         (   member(DB,Scope),
             get_dict('@type',DB,'system:Database'),
             get_dict('@id',DB,ID),
+            Name = DB.'system:resource_name'.'@value',
             prefix_expand(ID, Prefixes, Ex_ID),
-            organization_database_name_uri(Context, Organization, Name, Ex_ID),
+            db_uri_organization(Context, Ex_ID, Organization),
             format(string(Path),"~s/~s",[Organization,Name])),
         User_Databases).
 
-list_databases(System_DB ,Auth, Databases, Database_Objects) :-
+list_databases(System_DB, Auth, Database_Objects) :-
+    (   is_super_user(Auth)
+    ->  get_all_databases(System_DB, User_Databases)
+    ;   get_user_databases(System_DB, Auth, User_Databases)),
+    list_existing_databases(User_Databases, Database_Objects).
 
-    (   Databases = []
-    ->  get_user_databases(System_DB, Auth, User_Databases)
-    ;   User_Databases = Databases),
-
+list_existing_databases(Databases, Database_Objects) :-
     findall(Database_Object,
-            (   member(DB, User_Databases),
+            (   member(DB, Databases),
                 list_database(DB, Database_Object)),
             Database_Objects).
 
@@ -86,9 +105,22 @@ test(list_all,
       cleanup(teardown_temp_store(State))]) :-
 
     super_user_authority(Auth),
-    list_databases(system_descriptor{}, Auth, [], Database_Objects),
+    list_databases(system_descriptor{}, Auth, Database_Objects),
     Expected_Objects = [_{branch_name:["main"],database_name:"admin/bar"},
                         _{branch_name:["main"],database_name:"admin/foo"}],
+
+    forall(member(Object, Database_Objects),
+           member(Object, Expected_Objects)).
+
+test(list_existing,
+     [setup((setup_temp_store(State),
+             create_db_without_schema("admin","foo2"),
+             create_db_without_schema("admin","bar2"))),
+      cleanup(teardown_temp_store(State))]) :-
+
+    list_existing_databases(["admin/foo2", "admin/bar2"], Database_Objects),
+    Expected_Objects = [_{branch_name:["main"],database_name:"admin/bar2"},
+                        _{branch_name:["main"],database_name:"admin/foo2"}],
 
     forall(member(Object, Database_Objects),
            member(Object, Expected_Objects)).

--- a/src/core/transaction.pl
+++ b/src/core/transaction.pl
@@ -104,6 +104,7 @@
               % system_entity.pl
               database_exists/2,
               database_exists/3,
+              db_uri_organization/3,
               organization_database_name_uri/4,
               organization_name_uri/3,
               organization_name_exists/2,

--- a/src/core/transaction/system_entity.pl
+++ b/src/core/transaction/system_entity.pl
@@ -1,6 +1,7 @@
 :- module(system_entity, [
               database_exists/2,
               database_exists/3,
+              db_uri_organization/3,
               organization_database_name_uri/4,
               organization_name_uri/3,
               organization_name_exists/2,
@@ -25,19 +26,14 @@ database_exists(Organization,DB) :-
 database_exists(Askable, Organization, DB) :-
     organization_database_name_uri(Askable, Organization, DB, _).
 
-% First check if the Db_Uri is ground, if it is ground
-% the following query is much faster
-organization_database_name_uri(Askable, Organization, DB, Db_Uri) :-
-    ground(Db_Uri),
-    !,
+db_uri_organization(Askable, Db_Uri, Organization) :-
     once(ask(Askable,
              (
                  t(Organization_Uri, system:resource_includes, Db_Uri),
-                 t(Organization_Uri, system:resource_name, Organization^^xsd:string),
                  t(Organization_Uri, rdf:type, system:'Organization'),
-                 t(Db_Uri, system:resource_name, DB^^xsd:string),
-                 t(Db_Uri, rdf:type, system:'Database')
+                 t(Organization_Uri, system:resource_name, Organization^^xsd:string)
              ))).
+
 organization_database_name_uri(Askable, Organization, DB, Db_Uri) :-
     once(ask(Askable,
              (


### PR DESCRIPTION
Increased performance further. If the account requesting the list
is the super_user/admin, there is no need to get the user object
and query the organization of *every* database.

However, even when a specific user wants a list of their DBs
it is also faster now. Since the name of the database is already
in the user object itself, it does not need to be queried.
This saves addiontal time and also removes the need for the
ground check of the DB URI.

Time went from:
./terminusdb list  6.30s user 1.87s system 103% cpu 7.912 total

To:
./terminusdb list  2.37s user 1.21s system 107% cpu 3.316 total

I also added an extra unit test for existing databases.