### PR TITLE
implement support for starting TerminusDB in in-memory mode

### DIFF
--- a/src/cli/main.pl
+++ b/src/cli/main.pl
@@ -68,13 +68,20 @@ opt_spec(serve,'terminusdb serve OPTIONS',
            shortflags([h]),
            longflags([help]),
            default(false),
-           help('print help for `serve` command')],
+           help('Print help for `serve` command')],
           [opt(interactive),
            type(boolean),
            shortflags([i]),
            longflags([interactive]),
            default(false),
-           help('run server in interactive mode')]]).
+           help('Run server in interactive mode')],
+          [opt(memory),
+           type(atom),
+           shortflags([m]),
+           longflags([memory]),
+           meta(password),
+           default('_'),
+           help('Run server in-memory, without a persistent store. Takes a password as an optional argument. The in-memory store will be initialized with an admin account with the given password. If absent, the admin account will have \'root\' as a password.')]]).
 opt_spec(list,'terminusdb list OPTIONS',
          'List databases.',
          [[opt(help),
@@ -669,7 +676,7 @@ run_command(test,_Positional,Opts) :-
     ->  halt(0)
     ;   halt(1)).
 run_command(serve,_Positional,Opts) :-
-    (   option(interactive(true),Opts)
+    (   option(interactive(true), Opts)
     ->  terminus_server([serve|Opts], false),
         prolog
     ;   terminus_server([serve|Opts], true)).

--- a/src/core/triple.pl
+++ b/src/core/triple.pl
@@ -98,6 +98,7 @@
               local_triple_store/1,
               retract_local_triple_store/1,
               default_triple_store/1,
+              memory_triple_store/1,
               with_triple_store/2,
 
               % turtle_utils.pl

--- a/src/core/triple/triplestore.pl
+++ b/src/core/triple/triplestore.pl
@@ -14,6 +14,7 @@
               local_triple_store/1,
               retract_local_triple_store/1,
               default_triple_store/1,
+              memory_triple_store/1,
               with_triple_store/2
           ]).
 
@@ -62,6 +63,14 @@ checkpoint(_DB_ID,_Graph_ID) :-
 default_triple_store(Triple_Store) :-
     db_path(Path),
     open_directory_store(Path,Triple_Store).
+
+/**
+ * memory_triple_store(-Triple_Store) is det.
+ *
+ * Opens an in-memory triple store.
+ */
+memory_triple_store(Triple_Store) :-
+    open_memory_store(Triple_Store).
 
 :- dynamic global_triple_store_var/1.
 

--- a/src/server/main.pl
+++ b/src/server/main.pl
@@ -68,6 +68,17 @@ terminus_server(Argv,Wait) :-
                    time_limit(infinite),
                    prefix
                  ]),
+    % initialize the global store as an in-memory store if the memory flag is set
+    (   option(memory(Memory_Password),Argv),
+        ground(Memory_Password)
+    ->  memory_triple_store(Store),
+        (   Memory_Password = ''
+        ->  Password = root
+        ;   Password = Memory_Password),
+        initialize_database_with_store(Password, Store),
+        global_triple_store(Store)
+    ;   true),
+
     (   triple_store(_Store), % ensure triple store has been set up by retrieving it once
         http_delete_handler(id(busy_loading)),
         welcome_banner(Server,Argv),


### PR DESCRIPTION
This patch implements feature request #266. A new flag, -m or --memory with the `terminus serve` command, will start the server with a freshly initialized store that is fully in-memory. optionally, this flag takes an argument which will be used as the password for the admin account. If absent, the admin account will be initialized with password 'root'.

Examples:
```
./terminusdb serve -i -m
./terminusdb serve -i -m my_secret_password
./terminusdb serve -i --memory=my_secret_password
```