### PR TITLE
Updated link to Diátaxis authoring framework

### DIFF
--- a/docs/EXPLANATION.md
+++ b/docs/EXPLANATION.md
@@ -6,4 +6,4 @@ What matters here is context, explanation, examples built into broader text, sug
 
 We are always trying to improve, so let us know if the content can be better or if you have a contribution.
 
-We use the ['The documentation system'](https://documentation.divio.com/) to organise the TerminusDB docs.
+We use the ['The documentation system'](https://documentation.We use the ['The Diátaxis documentation system'](https://diataxis.fr/) to organise the TerminusDB docs..com/) to organise the TerminusDB docs.

--- a/docs/EXPLANATION.md
+++ b/docs/EXPLANATION.md
@@ -6,4 +6,4 @@ What matters here is context, explanation, examples built into broader text, sug
 
 We are always trying to improve, so let us know if the content can be better or if you have a contribution.
 
-We use the ['The documentation system'](https://documentation.We use the ['The Diátaxis documentation system'](https://diataxis.fr/) to organise the TerminusDB docs..com/) to organise the TerminusDB docs.
+We use the ['The Diátaxis documentation system'](https://diataxis.fr/) to organise the TerminusDB docs.

--- a/docs/How_To/Intro.md
+++ b/docs/How_To/Intro.md
@@ -4,7 +4,7 @@ How To Guides are problem driven and are designed to be a source of quick inform
 
 The idea is to provide a series of steps with a focus on the goal (getting something done!). They should address a particular problem and have no unnecessary explanation. Practical usability and not completeness is key. How Tos will not give you everything, they are like a recipe that you can alter according to your need or taste.
 
-We use the ['The documentation system'](https://documentation.We use the ['The Diátaxis documentation system'](https://diataxis.fr/) to organise the TerminusDB docs..com/) to organise the TerminusDB docs.
+We use the ['The Diátaxis documentation system'](https://diataxis.fr/) to organise the TerminusDB docs.
 
 
 

--- a/docs/How_To/Intro.md
+++ b/docs/How_To/Intro.md
@@ -4,7 +4,7 @@ How To Guides are problem driven and are designed to be a source of quick inform
 
 The idea is to provide a series of steps with a focus on the goal (getting something done!). They should address a particular problem and have no unnecessary explanation. Practical usability and not completeness is key. How Tos will not give you everything, they are like a recipe that you can alter according to your need or taste.
 
-We use the ['The documentation system'](https://documentation.divio.com/) to organise the TerminusDB docs.
+We use the ['The documentation system'](https://documentation.We use the ['The Diátaxis documentation system'](https://diataxis.fr/) to organise the TerminusDB docs..com/) to organise the TerminusDB docs.
 
 
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -4,4 +4,4 @@ This section is designed to help you understand TerminusDB and TerminusHub. It i
 
 What matters here is technical description of the machinary so you can work out what to do while you are working. It should be consistent and austere. This is not the place for discussion of problems or conceptual explanations.
 
-We use the ['The documentation system'](https://documentation.We use the ['The Diátaxis documentation system'](https://diataxis.fr/) to organise the TerminusDB docs..com/) to organise the TerminusDB' docs.
+We use the ['The Diátaxis documentation system'](https://diataxis.fr/) to organise the TerminusDB docs.

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -4,4 +4,4 @@ This section is designed to help you understand TerminusDB and TerminusHub. It i
 
 What matters here is technical description of the machinary so you can work out what to do while you are working. It should be consistent and austere. This is not the place for discussion of problems or conceptual explanations.
 
-We use the ['The documentation system'](https://documentation.divio.com/) to organise the TerminusDB' docs.
+We use the ['The documentation system'](https://documentation.We use the ['The Diátaxis documentation system'](https://diataxis.fr/) to organise the TerminusDB docs..com/) to organise the TerminusDB' docs.

--- a/docs/TUTORIALS.md
+++ b/docs/TUTORIALS.md
@@ -8,4 +8,4 @@ We are always trying to improve so let us know if this section could be better. 
 
 There is also a [tutorial repo](https://github.com/terminusdb/terminusdb-tutorials) - check it out for more examples
 
-We use the ['The documentation system'](https://documentation.divio.com/) to organise the TerminusDB docs.
+We use the ['The documentation system'](https://documentation.We use the ['The Diátaxis documentation system'](https://diataxis.fr/) to organise the TerminusDB docs..com/) to organise the TerminusDB docs.

--- a/docs/TUTORIALS.md
+++ b/docs/TUTORIALS.md
@@ -8,4 +8,4 @@ We are always trying to improve so let us know if this section could be better. 
 
 There is also a [tutorial repo](https://github.com/terminusdb/terminusdb-tutorials) - check it out for more examples
 
-We use the ['The documentation system'](https://documentation.We use the ['The Diátaxis documentation system'](https://diataxis.fr/) to organise the TerminusDB docs..com/) to organise the TerminusDB docs.
+We use the ['The Diátaxis documentation system'](https://diataxis.fr/) to organise the TerminusDB docs.


### PR DESCRIPTION
The documentation system now has a new home of its own at https://diataxis.fr/.

