### PR TITLE
Adding better woql syntax error checking

### DIFF
--- a/src/core/api/api_woql.pl
+++ b/src/core/api/api_woql.pl
@@ -28,8 +28,5 @@ woql_query_json(System_DB, Auth, Path_Option, Query, Commit_Info, Files, All_Wit
     context_extend_prefixes(Context,Woql_Prefixes,Final_Context),
 
     json_woql(Query, Final_Context.prefixes, AST),
-    
-    profile(
-        run_context_ast_jsonld_response(Final_Context,AST,JSON)
-    ).
+    run_context_ast_jsonld_response(Final_Context,AST,JSON).
 

--- a/src/core/api/api_woql.pl
+++ b/src/core/api/api_woql.pl
@@ -28,6 +28,8 @@ woql_query_json(System_DB, Auth, Path_Option, Query, Commit_Info, Files, All_Wit
     context_extend_prefixes(Context,Woql_Prefixes,Final_Context),
 
     json_woql(Query, Final_Context.prefixes, AST),
-
-    run_context_ast_jsonld_response(Final_Context,AST,JSON).
+    
+    profile(
+        run_context_ast_jsonld_response(Final_Context,AST,JSON)
+    ).
 

--- a/src/terminus-schema/api.owl.ttl
+++ b/src/terminus-schema/api.owl.ttl
@@ -1065,7 +1065,7 @@ api:WOQLSyntaxError
   a owl:Class ;
   rdfs:label "WOQL Syntax Error"@en ;
   rdfs:comment "Syntax error in WOQL term."@en ;
-  rdfs:subClassOf api:Error, api:WithErrorTerm .
+  rdfs:subClassOf api:Error, api:WithErrorTerm, api:WithPath, api:WithBody .
 
 api:WithErrorTerm
   a owl:Class .
@@ -1074,6 +1074,26 @@ api:error_term
   a owl:DatatypeProperty ;
   rdfs:label "error term"@en ;
   rdfs:comment "Points to an error term."@en ;
+  rdfs:domain api:WOQLSyntaxError ;
+  rdfs:range xsd:string .
+
+api:WithPath
+  a owl:Class .
+
+api:path
+  a owl:DatatypeProperty ;
+  rdfs:label "path"@en ;
+  rdfs:comment "Gives the path to an error term."@en ;
+  rdfs:domain api:WOQLSyntaxError ;
+  rdfs:range xsd:string .
+
+api:WithBody
+  a owl:Class .
+
+api:body
+  a owl:DatatypeProperty ;
+  rdfs:label "body"@en ;
+  rdfs:comment "The body of the term with syntax error."@en ;
   rdfs:domain api:WOQLSyntaxError ;
   rdfs:range xsd:string .
 


### PR DESCRIPTION
Currently woql syntax errors are not reporting with program navigable errors. This patch fixes the problem.