### PR TITLE
allow TERMINUSDB_ADMIN_PASS from a file, especially for Docker's secrets feature

### DIFF
--- a/distribution/init_docker.sh
+++ b/distribution/init_docker.sh
@@ -1,8 +1,27 @@
 #!/bin/sh
-TERMINUSDB_ADMIN_PASS=${TERMINUSDB_ADMIN_PASS:-root}
 TERMINUSDB_SERVER_PORT=${TERMINUSDB_SERVER_PORT:-6363}
 TERMINUSDB_AUTOLOGIN=${TERMINUSDB_AUTOLOGIN:-false}
 TERMINUSDB_ENABLE_WELCOME_SCREEN=${TERMINUSDB_WELCOME_SCREEN:-false}
+
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+file_env 'TERMINUSDB_ADMIN_PASS'
+TERMINUSDB_ADMIN_PASS=${TERMINUSDB_ADMIN_PASS:-root}
 
 if [ ! -d /app/terminusdb/storage/db ] && [ "$TERMINUSDB_ENABLE_WELCOME_SCREEN" = false ]; then
     /app/terminusdb/terminusdb store init --key "$TERMINUSDB_ADMIN_PASS"


### PR DESCRIPTION
I lifted [docker-library's `file_env` shell function](https://github.com/docker-library/mongo/blob/b3edd5aacba7e89144cec6020ab34c13116ab44c/4.4/docker-entrypoint.sh#L34) to facilitate the common convention of allowing a `*_FILE` env var, i.e. `TERMINUSDB_ADMIN_PASS_FILE` in this case.

This makes it easier in my case to safely use version control for deployment configuration.