### PR TITLE
jwt: support jwks endpoint instead of pub/private key files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ENV TUS_VERSION v0.0.5
 WORKDIR /app/pack
 RUN export BUILD_DEPS="git build-essential make libjwt-dev libssl-dev pkg-config" \
         && apt-get update && apt-get install $BUILD_DEPS -y --no-install-recommends \
-        && git clone --single-branch --branch v0.0.3-fix-make https://github.com/terminusdb-labs/jwt_io.git jwt_io \
+        && git clone --single-branch --branch v0.0.4 https://github.com/terminusdb-labs/jwt_io.git jwt_io \
         && git clone --single-branch --branch $TUS_VERSION https://github.com/terminusdb/tus.git tus \
         && swipl -g "pack_install('file:///app/pack/jwt_io', [interactive(false)])" \
         && swipl -g "pack_install('file:///app/pack/tus', [interactive(false)])"

--- a/src/config/terminus_config.pl
+++ b/src/config/terminus_config.pl
@@ -94,7 +94,7 @@ jwt_enabled :-
     Value = true.
 
 jwt_jwks_endpoint(Value) :-
-    getenv_default('TERMINUSDB_SERVER_JWKS_ENDPOINT', '', Value).
+    getenv('TERMINUSDB_SERVER_JWKS_ENDPOINT', Value).
 
 console_base_url(Value) :-
     getenv_default('TERMINUSDB_CONSOLE_BASE_URL', 'https://cdn.terminusdb.com/js_libs/terminusdb_console/canary', Value).

--- a/src/config/terminus_config.pl
+++ b/src/config/terminus_config.pl
@@ -8,8 +8,7 @@
               max_transaction_retries/1,
               index_template/1,
               default_database_path/1,
-              jwt_public_key_path/1,
-              jwt_public_key_id/1,
+              jwt_jwks_endpoint/1,
               jwt_enabled/0,
               registry_path/1,
               console_base_url/1,
@@ -94,11 +93,8 @@ jwt_enabled :-
     getenv_default('TERMINUSDB_JWT_ENABLED', false, Value),
     Value = true.
 
-jwt_public_key_path(Value) :-
-    getenv_default('TERMINUSDB_SERVER_JWT_PUBLIC_KEY_PATH', '', Value).
-
-jwt_public_key_id(Value) :-
-    getenv_default('TERMINUSDB_SERVER_JWT_PUBLIC_KEY_ID', '', Value).
+jwt_jwks_endpoint(Value) :-
+    getenv_default('TERMINUSDB_SERVER_JWKS_ENDPOINT', '', Value).
 
 console_base_url(Value) :-
     getenv_default('TERMINUSDB_CONSOLE_BASE_URL', 'https://cdn.terminusdb.com/js_libs/terminusdb_console/canary', Value).

--- a/src/core/util/test_utils.pl
+++ b/src/core/util/test_utils.pl
@@ -422,7 +422,8 @@ spawn_server_1(Path, URL, PID, Options) :-
 
         'TERMINUSDB_SERVER_PORT'=Port,
         'TERMINUSDB_SERVER_DB_PATH'=Path,
-        'TERMINUSDB_HTTPS_ENABLED'='false'
+        'TERMINUSDB_HTTPS_ENABLED'='false',
+        'TERMINUSDB_SERVER_JWKS_ENDPOINT'='https://cdn.terminusdb.com/jwks.json'
     ],
 
     inherit_env_vars(Env_List_1,
@@ -433,10 +434,7 @@ spawn_server_1(Path, URL, PID, Options) :-
                          'TEMP', % Again...
                          'TERMINUSDB_ADMIN_PASSWD',
                          'TERMINUSDB_SERVER_PACK_DIR',
-                         'TERMINUSDB_SERVER_JWT_PUBLIC_KEY_PATH',
-                         'TERMINUSDB_SERVER_JWT_PUBLIC_KEY_ID',
                          'TERMINUSDB_JWT_ENABLED',
-                         'TERMINUSDB_SERVER_JWKS_ENDPOINT',
                          'TERMINUSDB_SERVER_TMP_PATH'
                      ],
                      Env_List),

--- a/src/core/util/test_utils.pl
+++ b/src/core/util/test_utils.pl
@@ -412,7 +412,6 @@ spawn_server_1(Path, URL, PID, Options) :-
     ),
 
     format(string(URL), "http://127.0.0.1:~d", [Port]),
-    expand_file_search_path(terminus_home('test/public_key_test.key.pub'), Pub_Key),
     Env_List_1 = [
         'LANG'='en_US.UTF-8',
         'LC_TIME'='en_US.UTF-8',
@@ -423,9 +422,7 @@ spawn_server_1(Path, URL, PID, Options) :-
 
         'TERMINUSDB_SERVER_PORT'=Port,
         'TERMINUSDB_SERVER_DB_PATH'=Path,
-        'TERMINUSDB_HTTPS_ENABLED'='false',
-        'TERMINUSDB_SERVER_JWT_PUBLIC_KEY_PATH'=Pub_Key,
-        'TERMINUSDB_SERVER_JWT_PUBLIC_KEY_ID'='testkey'
+        'TERMINUSDB_HTTPS_ENABLED'='false'
     ],
 
     inherit_env_vars(Env_List_1,
@@ -439,6 +436,7 @@ spawn_server_1(Path, URL, PID, Options) :-
                          'TERMINUSDB_SERVER_JWT_PUBLIC_KEY_PATH',
                          'TERMINUSDB_SERVER_JWT_PUBLIC_KEY_ID',
                          'TERMINUSDB_JWT_ENABLED',
+                         'TERMINUSDB_SERVER_JWKS_ENDPOINT',
                          'TERMINUSDB_SERVER_TMP_PATH'
                      ],
                      Env_List),

--- a/src/server/main.pl
+++ b/src/server/main.pl
@@ -33,9 +33,8 @@
 :- endif.
 
 load_jwt_conditionally :-
-    (   config:jwt_enabled
-    ->  config:jwt_jwks_endpoint(Endpoint),
-        jwt_io:setup_jwks(Endpoint)
+    (   config:jwt_enabled, config:jwt_jwks_endpoint(Endpoint)
+    ->  jwt_io:setup_jwks(Endpoint)
     ; true).
 
 

--- a/src/server/main.pl
+++ b/src/server/main.pl
@@ -34,12 +34,8 @@
 
 load_jwt_conditionally :-
     (   config:jwt_enabled
-    ->  config:jwt_public_key_id(Public_Key_Id),
-        config:jwt_public_key_path(JWTPubKeyPath),
-        set_setting(jwt_io:keys, [_{kid: Public_Key_Id,
-                                    type: 'RSA',
-                                    algorithm: 'RS256',
-                                    public_key: JWTPubKeyPath}])
+    ->  config:jwt_jwks_endpoint(Endpoint),
+        jwt_io:setup_jwks(Endpoint)
     ; true).
 
 


### PR DESCRIPTION
The JWKS endpoints consists of sets of keys. This makes it easier
to rotate keys without losing functionality. I updated the
jwt_io lib accordingly, see the tagged 0.0.4 release.

See:
https://github.com/terminusdb-labs/jwt_io/compare/v0.0.3-fix-make...v0.0.4

For a comparison

Please read https://github.com/terminusdb/terminus-server/blob/master/docs/CONTRIBUTING.md
before submitting a pull request.
