### PR TITLE
Adding key type restriction for subdocuments

### DIFF
--- a/src/core/document/json.pl
+++ b/src/core/document/json.pl
@@ -5402,7 +5402,7 @@ test(insert_employee, [
          cleanup(
              teardown_temp_store(State)
          ),
-         error(subdocument_key_type_restriction,_)
+         error(schema_check_failure([witness{'@type':instance_not_cardinality_one,class:'http://s/Coordinate',instance:'http://i/Country_760fca065482d4e1f64c8bc85e4a5bad525d859b',predicate:'http://s/perimeter'}]),_)
      ]) :-
 
     D1 = _{'@type': "Country",

--- a/src/core/document/json.pl
+++ b/src/core/document/json.pl
@@ -380,7 +380,14 @@ json_elaborate(DB,JSON,Context,Path,JSON_ID) :-
     json_context_elaborate(DB,JSON,New_Context,[node(JSON_ID)|Path],Elaborated),
 
     (   is_subdocument(DB, TypeEx)
-    ->  Id_Path = Path
+    ->  Id_Path = Path,
+        do_or_die(
+            (   global_prefix_expand(sys:key, KeyP),
+                get_dict(KeyP, Elaborated, Key),
+                (   global_prefix_expand(sys:'ValueHash',Key_Type)
+                ;   global_prefix_expand(sys:'Random',Key_Type)),
+                get_dict('@type', Key, Key_Type)),
+            error(subdocument_key_type_restriction,_))
     ;   Id_Path = []),
 
     json_assign_id(Elaborated,DB,Context,Id_Path,JSON_ID).
@@ -5382,7 +5389,7 @@ test(insert_employee, [
          cleanup(
              teardown_temp_store(State)
          ),
-         blocked(unable_to_do_lexical_subdocuments)
+         error(subdocument_key_type_restriction,_)
      ]) :-
 
     D1 = _{'@type': "Country",


### PR DESCRIPTION
This will ensure that subdocuments have a viable key type so we don't end up with complex and difficult to find errors which might result from manually defined keys.