### PR TITLE
Makefile: fail on error or warning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,16 @@ jobs:
           sudo apt-get update
           sudo apt-get install swi-prolog
 
+      - name: Check out tus
+        uses: actions/checkout@v2
+        with:
+          repository: terminusdb/tus
+          path: tus
+          ref: v0.0.5
+
+      - name: Install tus
+        run: swipl -g "pack_install('file://$GITHUB_WORKSPACE/tus', [interactive(false)])"
+
       - name: Install terminus_store_prolog
         run: swipl -g "pack_install(terminus_store_prolog, [interactive(false), upgrade(true)])"
 
@@ -38,6 +48,16 @@ jobs:
         run: |
           # Installing swipl on macOS: https://www.swi-prolog.org/build/macos.html
           brew install swi-prolog
+
+      - name: Check out tus
+        uses: actions/checkout@v2
+        with:
+          repository: terminusdb/tus
+          path: tus
+          ref: v0.0.5
+
+      - name: Install tus
+        run: swipl -g "pack_install('file://$GITHUB_WORKSPACE/tus', [interactive(false)])"
 
       - name: Install terminus_store_prolog
         run: swipl -g "pack_install(terminus_store_prolog, [interactive(false), upgrade(true)])"

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,11 @@ TARGET=terminusdb
 all: bin deb docs
 
 $(TARGET):
-	$(SWIPL_DIR)swipl -t 'main,halt.' -O -q -f src/bootstrap.pl
+	# Build the target and fail for errors and warnings. Ignore warnings
+	# having "qsave(strip_failed(..." that occur on macOS.
+	LANG=C.UTF-8 $(SWIPL_DIR)swipl -t 'main,halt.' -O -q -f src/bootstrap.pl 2>&1 | \
+	  grep -v 'qsave(strip_failed' | \
+	  (! grep -e ERROR -e Warning)
 
 bin: $(TARGET)
 


### PR DESCRIPTION
Currently, `make` doesn't fail if there is an error or warning while building the target with `swipl`. This adds a few `grep`s to do that.