### PR TITLE
More document error handling

### DIFF
--- a/src/core/api/api_document.pl
+++ b/src/core/api/api_document.pl
@@ -140,14 +140,33 @@ api_get_document(SystemDB, Auth, Path, Schema_Or_Instance, Prefixed, Unfold, Id,
               error(unresolvable_collection(Descriptor), _)),
     api_get_document_(Schema_Or_Instance, Transaction, Prefixed, Unfold, Id, Document).
 
+embed_document_in_error(Error, Document, New_Error) :-
+    Error =.. Error_List,
+    append(Error_List, [Document], New_Error_List),
+    New_Error =.. New_Error_List.
+
+known_document_error(type_not_found(_)).
+known_document_error(can_not_insert_existing_object_with_id(_)).
+
+:- meta_predicate call_catch_document_mutation(+, :).
+call_catch_document_mutation(Document, Goal) :-
+    catch(Goal,
+          error(E, Context),
+          (   known_document_error(E)
+          ->  embed_document_in_error(E, Document, New_E),
+              throw(error(New_E, _))
+          ;   throw(error(E, Context)))).
+
 api_insert_document_(schema, Transaction, Stream, Id) :-
     json_read_dict_stream(Stream, JSON),
     (   is_list(JSON)
     ->  !,
         member(Document, JSON)
     ;   Document = JSON),
-    do_or_die(insert_schema_document(Transaction, Document),
-              error(document_insertion_failed_unexpectedly(Document), _)),
+    call_catch_document_mutation(
+        Document,
+        do_or_die(insert_schema_document(Transaction, Document),
+                  error(document_insertion_failed_unexpectedly(Document), _))),
 
     do_or_die(Id = (Document.get('@id')),
               error(document_has_no_id_somehow, _)).
@@ -157,8 +176,10 @@ api_insert_document_(instance, Transaction, Stream, Id) :-
     ->  !,
         member(Document, JSON)
     ;   Document = JSON),
-    do_or_die(insert_document(Transaction, Document, Id),
-              error(document_insertion_failed_unexpectedly(Document), _)).
+    call_catch_document_mutation(
+        Document,
+        do_or_die(insert_document(Transaction, Document, Id),
+                  error(document_insertion_failed_unexpectedly(Document), _))).
 
 replace_existing_graph(schema, Transaction, Stream) :-
     replace_json_schema(Transaction, Stream).

--- a/src/core/api/api_document.pl
+++ b/src/core/api/api_document.pl
@@ -147,6 +147,7 @@ embed_document_in_error(Error, Document, New_Error) :-
 
 known_document_error(type_not_found(_)).
 known_document_error(can_not_insert_existing_object_with_id(_)).
+known_document_error(unrecognized_property(_,_,_)).
 
 :- meta_predicate call_catch_document_mutation(+, :).
 call_catch_document_mutation(Document, Goal) :-

--- a/src/core/api/api_error.pl
+++ b/src/core/api/api_error.pl
@@ -1039,6 +1039,15 @@ api_document_error_jsonld(Type, error(invalid_path(Path), _), JSON) :-
                               'api:resource_path' : Path },
              'api:message' : Msg
             }.
+api_document_error_jsonld(Type,error(database_does_not_exist(Organization,Database), _), JSON) :-
+    document_error_type(Type, JSON_Type),
+    format(string(Msg), "Database ~s/~s does not exist.", [Organization, Database]),
+    JSON = _{'@type' : JSON_Type,
+             'api:status' : 'api:failure',
+             'api:error' : _{'@type' : 'api:DatabaseDoesNotExist',
+                             'api:database_name' : Database,
+                             'api:organization_name' : Organization},
+             'api:message' : Msg}.
 api_document_error_jsonld(Type,error(unresolvable_collection(Descriptor),_), JSON) :-
     document_error_type(Type, JSON_Type),
     resolve_absolute_string_descriptor(Path, Descriptor),
@@ -1048,6 +1057,16 @@ api_document_error_jsonld(Type,error(unresolvable_collection(Descriptor),_), JSO
              'api:error' : _{ '@type' : 'api:UnresolvableAbsoluteDescriptor',
                               'api:absolute_descriptor' : Path},
              'api:message' : Msg
+            }.
+api_document_error_jsonld(Type,error(branch_does_not_exist(Descriptor), _), JSON) :-
+    document_error_type(Type, JSON_Type),
+    resolve_absolute_string_descriptor(Path, Descriptor),
+    format(string(Msg), "The branch does not exist for ~q", [Path]),
+    JSON = _{'@type' : JSON_Type,
+             'api:status' : "api:failure",
+             'api:message' : Msg,
+             'api:error' : _{ '@type' : "api:UnresolvableAbsoluteDescriptor",
+                              'api:absolute_descriptor' : Path}
             }.
 api_document_error_jsonld(Type, error(no_commit_author, _), JSON) :-
     document_error_type(Type, JSON_Type),
@@ -1072,6 +1091,63 @@ api_document_error_jsonld(Type, error(same_ids_in_one_transaction(Ids, _)), JSON
              'api:status' : "api:failure",
              'api:error' : _{ '@type' : 'api:SameDocumentIdsMutatedInOneTransaction',
                               'api:document_ids' : Ids},
+             'api:message' : Msg
+            }.
+api_document_error_jsonld(Type, error(document_access_impossible(Descriptor, Graph_Type, Read_Write), _), JSON) :-
+    document_error_type(Type, JSON_Type),
+    resolve_absolute_string_descriptor(Descriptor_String, Descriptor),
+    format(string(Msg), "action '~q' on graph type ~q is impossible on resource ~q", [Read_Write, Graph_Type, Descriptor_String]),
+    JSON = _{'@type' : JSON_Type,
+             'api:status' : "api:failure",
+             'api:error' : _{ '@type' : 'api:DocumentAccessImpossible',
+                              'api:resource_path' : Descriptor_String,
+                              'api:graph_type': Graph_Type,
+                              'api:access_type': Read_Write},
+             'api:message' : Msg
+            }.
+api_document_error_jsonld(Type, error(syntax_error(json(_)), _), JSON) :-
+    document_error_type(Type, JSON_Type),
+    format(string(Msg), "Submitted JSON data is invalid", []),
+    JSON = _{'@type' : JSON_Type,
+             'api:status' : "api:failure",
+             'api:error' : _{ '@type' : 'api:JSONInvalid'},
+             'api:message' : Msg
+            }.
+api_document_error_jsonld(Type, error(type_not_found(Document_Type, Document), _), JSON) :-
+    document_error_type(Type, JSON_Type),
+    format(string(Msg), "Type in submitted document not found in the schema: ~q", [Document_Type]),
+    JSON = _{'@type' : JSON_Type,
+             'api:status' : "api:failure",
+             'api:error' : _{ '@type' : 'api:TypeNotFound',
+                              'api:type' : Document_Type,
+                              'api:document' : Document},
+             'api:message' : Msg
+            }.
+api_document_error_jsonld(Type, error(schema_check_failure(Witnesses),_),JSON) :-
+    document_error_type(Type, JSON_Type),
+    format(string(Msg), "Schema check failure", []),
+    JSON = _{'@type' : JSON_Type,
+             'api:status' : "api:failure",
+             'api:error' : _{ '@type' : 'api:SchemaCheckFailure',
+                              'api:witnesses' : Witnesses },
+             'api:message' : Msg
+            }.
+api_document_error_jsonld(Type, error(no_id_in_document(Document),_),JSON) :-
+    document_error_type(Type, JSON_Type),
+    format(string(Msg), "No '@id' field found in document, but it was required", []),
+    JSON = _{'@type' : JSON_Type,
+             'api:status' : "api:failure",
+             'api:error' : _{ '@type' : 'api:NoIdInDocument',
+                              'api:Document' : Document },
+             'api:message' : Msg
+            }.
+api_document_error_jsonld(Type, error(id_could_not_be_elaborated(Document),_),JSON) :-
+    document_error_type(Type, JSON_Type),
+    format(string(Msg), "No '@id' field found in document, and it could not be determined from its type definition", []),
+    JSON = _{'@type' : JSON_Type,
+             'api:status' : "api:failure",
+             'api:error' : _{ '@type' : 'api:IdCouldNotBeDetermined',
+                              'api:Document' : Document },
              'api:message' : Msg
             }.
 api_document_error_jsonld(get_documents, error(skip_is_not_a_number(Skip_Atom), _), JSON) :-
@@ -1106,7 +1182,7 @@ api_document_error_jsonld(get_documents,error(query_is_only_supported_for_instan
              'api:message' : Msg
             }.
 api_document_error_jsonld(insert_documents,error(document_insertion_failed_unexpectedly(Document),_), JSON) :-
-    format(string(Msg), "Query documents are currently only supported for instance graphs", []),
+    format(string(Msg), "Document insertion failed unexpectedly", []),
     JSON = _{'@type' : 'api:InsertDocumentErrorResponse',
              'api:status' : 'api:server_error',
              'api:error' : _{ '@type' : 'api:DocumentInsertionFailedUnexpectedly',
@@ -1119,6 +1195,15 @@ api_document_error_jsonld(insert_documents,error(document_insertion_failed_unexp
              'api:status' : 'api:server_error',
              'api:error' : _{ '@type' : 'api:DocumentInsertionFailedUnexpectedly',
                               'api:document': Document},
+             'api:message' : Msg
+            }.
+api_document_error_jsonld(insert_documents, error(can_not_insert_existing_object_with_id(Id, Document), _), JSON) :-
+    format(string(Msg), "Tried to insert a new document with id ~q, but an object with that id already exists", [Id]),
+    JSON = _{'@type' : 'api:InsertDocumentErrorResponse',
+             'api:status' : "api:failure",
+             'api:error' : _{ '@type' : 'api:DocumentIdAlreadyExists',
+                              'api:document_id' : Id,
+                              'api:document' : Document},
              'api:message' : Msg
             }.
 

--- a/src/core/api/api_error.pl
+++ b/src/core/api/api_error.pl
@@ -1138,7 +1138,7 @@ api_document_error_jsonld(Type, error(no_id_in_document(Document),_),JSON) :-
     JSON = _{'@type' : JSON_Type,
              'api:status' : "api:failure",
              'api:error' : _{ '@type' : 'api:NoIdInDocument',
-                              'api:Document' : Document },
+                              'api:document' : Document },
              'api:message' : Msg
             }.
 api_document_error_jsonld(Type, error(id_could_not_be_elaborated(Document),_),JSON) :-
@@ -1147,7 +1147,18 @@ api_document_error_jsonld(Type, error(id_could_not_be_elaborated(Document),_),JS
     JSON = _{'@type' : JSON_Type,
              'api:status' : "api:failure",
              'api:error' : _{ '@type' : 'api:IdCouldNotBeDetermined',
-                              'api:Document' : Document },
+                              'api:document' : Document },
+             'api:message' : Msg
+            }.
+api_document_error_jsonld(Type, error(unrecognized_property(Document_Type, Property, _Value, Document),_),JSON) :-
+    document_error_type(Type, JSON_Type),
+    format(string(Msg), "Submitted document contained unrecognized property ~q for type ~q", [Property, Document_Type]),
+    JSON = _{'@type' : JSON_Type,
+             'api:status' : "api:failure",
+             'api:error' : _{ '@type' : 'api:IdCouldNotBeDetermined',
+                              'api:property': Property,
+                              'api:type': Document_Type,
+                              'api:document' : Document },
              'api:message' : Msg
             }.
 api_document_error_jsonld(get_documents, error(skip_is_not_a_number(Skip_Atom), _), JSON) :-

--- a/src/core/document/instance.pl
+++ b/src/core/document/instance.pl
@@ -390,7 +390,11 @@ refute_typed_subject(Validation_Object,Subject,Class,Witness) :-
     subject_predicate_changed(Validation_Object,Subject,Predicate),
     % We also need to check arrays / lists for coherence here?
     (   is_built_in(Predicate)
-    ->  refute_built_in(Validation_Object,Subject,Predicate,Witness)
+    ->  (   refute_built_in(Validation_Object,Subject,Predicate,Witness)
+        ;   global_prefix_expand(rdf:type, Predicate),
+            (   refute_subject_deletion(Validation_Object, Subject, Witness)
+            ;   refute_subject_type_change(Validation_Object,Subject,Witness)
+            ;   refute_cardinality(Validation_Object,Subject,Predicate,Class,Witness)))
     ;   is_abstract(Validation_Object,Class)
     ->  refute_abstract(Subject, Class, Witness)
     ;   refute_subject_deletion(Validation_Object,Subject,Witness)

--- a/src/core/document/instance.pl
+++ b/src/core/document/instance.pl
@@ -200,8 +200,8 @@ range_term_list(Validation_Object, S, P, L) :-
 
 refute_cardinality(Validation_Object,S,P,C,Witness) :-
     type_descriptor(Validation_Object, C, tagged_union(TU,TC)),
-    class_predicate_type(Validation_Object,C,P,_),
     !,
+    class_predicate_type(Validation_Object,C,P,_),
     (   refute_cardinality_(tagged_union(TU,TC),Validation_Object,S,P,Witness)
     ;   class_predicate_type(Validation_Object,C,Q,_),
         P \= Q,

--- a/src/core/document/json.pl
+++ b/src/core/document/json.pl
@@ -577,7 +577,7 @@ json_assign_id(JSON,DB,Context,Path,JSON_ID) :-
     ->  JSON_ID = JSON
     ;   json_idgen(JSON,DB,Context,Path,ID)
     ->  JSON_ID = (JSON.put(json{'@id' : ID}))
-    ;   throw(error(no_id(JSON),_))
+    ;   throw(error(id_could_not_be_elaborated(JSON), _))
     ).
 
 json_prefix_access(JSON,Edge,Type) :-
@@ -1003,7 +1003,7 @@ json_triple_(JSON,Context,Triple) :-
 
     (   get_dict('@id', JSON, ID)
     ->  true
-    ;   throw(error(no_id(JSON), _))
+    ;   throw(error(no_id_in_document(JSON), _))
     ),
 
     member(Key, Keys),
@@ -1752,11 +1752,8 @@ insert_document(Transaction, Document, ID) :-
     is_transaction(Transaction),
     !,
     json_elaborate(Transaction, Document, Elaborated),
-
-    (   get_dict('@id', Elaborated, ID)
-    ->  true
-    ;   throw(error(no_id_in_document(Elaborated), _))
-    ),
+    % After elaboration, the Elaborated document will have an '@id'
+    get_dict('@id', Elaborated, ID),
 
     check_existing_document_status(Transaction, Elaborated, Status),
     (   Status = not_present
@@ -1979,7 +1976,7 @@ insert_schema_document(Transaction, Document) :-
 
     (   get_dict('@id', Document, Id)
     ->  true
-    ;   throw(error(no_id_in_schema_document(Document), _))
+    ;   throw(error(no_id_in_document(Document), _))
     ),
     database_schema(Transaction, Schema),
 
@@ -2084,7 +2081,7 @@ replace_schema_document(Transaction, Document, Id) :-
     ;   get_dict('@type', Document, "@context")
     ->  delete_schema_document(Transaction, 'terminusdb://context'),
         insert_context_document(Transaction, Document)
-    ;   throw(error(no_id_in_schema_document(Document),_))
+    ;   throw(error(no_id_in_document(Document),_))
     ).
 replace_schema_document(Query_Context, Document, Id) :-
     is_query_context(Query_Context),

--- a/src/core/document/json.pl
+++ b/src/core/document/json.pl
@@ -2728,6 +2728,10 @@ schema2('
   "mother" : "Human",
   "father" : "Human" }
 
+{ "@id" : "Moo",
+  "@type" : "Class",
+  "name" : "xsd:string" }
+
 ').
 
 test(schema_key_elaboration1, []) :-
@@ -4710,6 +4714,32 @@ test(subdocument_key_problem,
         _
     ).
 
+test(document_with_no_required_field,
+     [
+         setup(
+             (   setup_temp_store(State),
+                 test_document_label_descriptor(Desc),
+                 write_schema(schema2,Desc)
+             )),
+         cleanup(
+             teardown_temp_store(State)
+         ),
+         error(schema_check_failure(
+                   [witness{'@type':instance_not_cardinality_one,
+                            class:'http://www.w3.org/2001/XMLSchema#string',
+                            instance:'http://i/doug',predicate:'http://s/name'}]), _)
+     ]) :-
+
+    Document = _{ '@id' : "doug",
+                  '@type' : "Moo"},
+
+    open_descriptor(Desc, DB),
+    create_context(DB, _{ author : "me", message : "Have you tried bitcoin?" }, Context),
+    with_transaction(
+        Context,
+        insert_document(Context, Document, _Id),
+        _
+    ).
 
 :- end_tests(json).
 


### PR DESCRIPTION
Most/all insert errors should now give a nice looking error message, and not a stack trace or an incomprehensible json object.