### PR TITLE
Dockerfile: remove default env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ FROM terminusdb/terminus_store_prolog:v0.19.1
 WORKDIR /app/terminusdb
 COPY ./ /app/terminusdb
 COPY --from=0 /usr/share/swi-prolog/pack/ /usr/share/swi-prolog/pack
-ENV TERMINUSDB_JWT_ENABLED=true
 RUN apt-get update && apt-get install -y --no-install-recommends libjwt0 make openssl \
         && swipl -g "ignore(pack_install('https://github.com/terminusdb-labs/jwt_io.git', [interactive(false)]))" \
     && rm -rf /var/cache/apt/* && rm -rf /var/lib/apt/lists/* && make


### PR DESCRIPTION
We need to be able to override this one. It caused issues when running the TerminusDB Docker image when running:

```
sudo docker run -d -it --rm --name "terminusdb-server" -e TERMINUSDB_SERVER_JWKS_ENDPOINT="" -e TERMINUSDB_JWT_ENABLED="false" terminusdb/terminusdb-server:dev
```