### PR TITLE
jwt: use agent name as username

### DIFF
--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -3581,7 +3581,7 @@ fetch_jwt_data(Token, Username) :-
     do_or_die(
         (   atom_json_dict(Payload, PayloadDict, []),
             % replace with dict key get (or whatever it is called)
-            get_dict('sub', PayloadDict, UsernameString),
+            get_dict('http://terminusdb.com/schema/system#agent_name', PayloadDict, UsernameString),
             atom_string(Username, UsernameString)),
         error(malformed_jwt_payload(Payload))).
 :- else.


### PR DESCRIPTION
'sub' can't be changed as easy as a custom entry in the token.
