### PR TITLE
Prefixes auth fix

### DIFF
--- a/src/core/account/capabilities.pl
+++ b/src/core/account/capabilities.pl
@@ -455,7 +455,7 @@ assert_read_access(_System, _Auth, Collection, _Filter) :-
 assert_auth_action_scope(DB, Auth, Action, Scope) :-
     (   auth_action_scope(DB, Auth, Action, Scope)
     ->  true
-    ;   throw(error(access_not_authorised(Auth,Action,Scope)))).
+    ;   throw(error(access_not_authorised(Auth,Action,Scope), _))).
 
 /**
  * authorisation_capabilities(DB,Auth_ID,Capabilities) is det.

--- a/src/core/api/api_prefixes.pl
+++ b/src/core/api/api_prefixes.pl
@@ -61,7 +61,8 @@ test(get_prefixes_auth_failure,
       cleanup(teardown_temp_store(State)),
       error(access_not_authorised('terminusdb://system/data/User_Doug',
                                   '@schema':'Action_instance_read_access',
-                                  _))
+                                  _),
+            _)
      ]) :-
 
     add_user("Doug", some("password"), User_URI),

--- a/src/core/api/api_remote.pl
+++ b/src/core/api/api_remote.pl
@@ -19,7 +19,7 @@ add_remote(SystemDB, Auth, Path, Remote_Name, Remote_Location) :-
         error(invalid_absolute_path(Repo_Path),_)),
 
     check_descriptor_auth(SystemDB, Descriptor,
-                          system:meta_write_access, Auth),
+                          '@schema':'Action_meta_write_access', Auth),
 
     do_or_die(
         create_context(Descriptor, Context),
@@ -43,7 +43,7 @@ remove_remote(SystemDB, Auth, Path, Remote_Name) :-
         error(invalid_absolute_path(Repo_Path),_)),
 
     check_descriptor_auth(SystemDB, Descriptor,
-                          system:meta_write_access, Auth),
+                          '@schema':'Action_meta_write_access', Auth),
 
     do_or_die(
         create_context(Descriptor, Context),
@@ -67,7 +67,7 @@ update_remote(SystemDB, Auth, Path, Remote_Name, Remote_Location) :-
         error(invalid_absolute_path(Repo_Path),_)),
 
     check_descriptor_auth(SystemDB, Descriptor,
-                          system:meta_write_access, Auth),
+                          '@schema':'Action_meta_write_access', Auth),
 
     do_or_die(
         create_context(Descriptor, Context),
@@ -91,7 +91,7 @@ show_remote(SystemDB, Auth, Path, Remote_Name, Remote_Location) :-
         error(invalid_absolute_path(Repo_Path),_)),
 
     check_descriptor_auth(SystemDB, Descriptor,
-                          system:meta_write_access, Auth),
+                          '@schema':'Action_meta_write_access', Auth),
 
     do_or_die(
         create_context(Descriptor, Context),
@@ -111,7 +111,7 @@ list_remotes(SystemDB, Auth, Path, Remote_Names) :-
         error(invalid_absolute_path(Repo_Path),_)),
 
     check_descriptor_auth(SystemDB, Descriptor,
-                          system:meta_write_access, Auth),
+                          '@schema':'Action_meta_write_access', Auth),
 
     do_or_die(
         create_context(Descriptor, Context),

--- a/src/core/api/api_squash.pl
+++ b/src/core/api/api_squash.pl
@@ -21,7 +21,7 @@ api_squash(System_DB, Auth, Path, Commit_Info, Commit_Path, Old_Commit_Path) :-
         branch_descriptor{} :< Descriptor,
         error(not_a_branch_descriptor(Descriptor),_)),
 
-    check_descriptor_auth(System_DB, Descriptor, system:commit_write_access, Auth),
+    check_descriptor_auth(System_DB, Descriptor, '@schema':'Action_commit_write_access', Auth),
 
     do_or_die(
         open_descriptor(Descriptor,_),

--- a/src/core/api/db_branch.pl
+++ b/src/core/api/db_branch.pl
@@ -171,7 +171,7 @@ branch_delete(System_DB, Auth, Path) :-
         }:< Descriptor,
         error(not_a_branch_descriptor(Descriptor), _)),
 
-    check_descriptor_auth(System_DB, Descriptor, system:branch, Auth),
+    check_descriptor_auth(System_DB, Descriptor, '@schema':'Action_branch', Auth),
 
     do_or_die(
         has_branch(Repository_Descriptor, Branch_Name),

--- a/src/core/api/db_pull.pl
+++ b/src/core/api/db_pull.pl
@@ -17,8 +17,8 @@ pull(System_DB, Local_Auth, Our_Branch_Path, Remote_Name, Remote_Branch_Name, Fe
         resolve_absolute_string_descriptor(Our_Branch_Path,Our_Branch_Descriptor),
         error(invalid_absolute_path(Our_Branch_Path),_)),
 
-    check_descriptor_auth(System_DB, Our_Branch_Descriptor, system:schema_write_access, Local_Auth),
-    check_descriptor_auth(System_DB, Our_Branch_Descriptor, system:instance_write_access, Local_Auth),
+    check_descriptor_auth(System_DB, Our_Branch_Descriptor, '@schema':'Action_schema_write_access', Local_Auth),
+    check_descriptor_auth(System_DB, Our_Branch_Descriptor, '@schema':'Action_instance_write_access', Local_Auth),
 
     do_or_die((branch_descriptor{} :< Our_Branch_Descriptor,
                open_descriptor(Our_Branch_Descriptor, _)),

--- a/src/core/api/db_unpack.pl
+++ b/src/core/api/db_unpack.pl
@@ -34,7 +34,7 @@ unpack(System_DB, Auth, Path, Payload_or_Resource) :-
         error(not_a_repository_descriptor(Repository_Descriptor))),
 
     check_descriptor_auth(System_DB, Repository_Descriptor,
-                          system:commit_write_access,
+                          '@schema':'Action_commit_write_access',
                           Auth),
 
     % 0. Get Payload


### PR DESCRIPTION
Some problems with 'system:' prefix still being used in auth.