### PR TITLE
fix: schema and public arguments were swapped in call to db creation

### DIFF
--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -220,7 +220,7 @@ db_handler(post, Organization, DB, Request, System_DB, Auth) :-
     api_report_errors(
         create_db,
         Request,
-        (   create_db(System_DB, Auth, Organization, DB, Label, Comment, Public, Schema, Prefixes),
+        (   create_db(System_DB, Auth, Organization, DB, Label, Comment, Schema, Public, Prefixes),
             cors_reply_json(Request, _{'@type' : 'api:DbCreateResponse',
                                        'api:status' : 'api:success'}))).
 db_handler(delete,Organization,DB,Request, System_DB, Auth) :-


### PR DESCRIPTION
We were improperly creating databases, causing them to become schemaless by accident.
The 'public' argument was being treated as the 'schema' argument and vice versa. So any database created as nonpublic schema-checking would become public and schemaless.

Fixes #461.