### PR TITLE
Error for missing/bad Content-type

### DIFF
--- a/src/core/api/api_error.pl
+++ b/src/core/api/api_error.pl
@@ -1251,6 +1251,16 @@ generic_exception_jsonld(bad_api_document(Document,Expected),JSON) :-
                              'api:expected' : Expected,
                              'api:document' : Document},
              'api:message' : Msg}.
+generic_exception_jsonld(missing_content_type(Expected), JSON) :-
+    format(string(Msg), "Missing 'Content-Type' header. Expected value: ~q", [Expected]),
+    JSON = _{'@type' : 'api:MissingContentTypeErrorResponse',
+             'api:status' : 'api:failure',
+             'api:message' : Msg}.
+generic_exception_jsonld(bad_content_type(ContentType, Expected), JSON) :-
+    format(string(Msg), "Bad 'Content-Type' header value: ~q. Expected value: ~q", [ContentType, Expected]),
+    JSON = _{'@type' : 'api:BadContentTypeErrorResponse',
+             'api:status' : 'api:failure',
+             'api:message' : Msg}.
 generic_exception_jsonld(syntax_error(M),JSON) :-
     format(atom(OM), '~q', [M]),
     JSON = _{'api:status' : 'api:failure',

--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -197,6 +197,7 @@ ok_handler(_Method, _Request, _System_DB, _Auth) :-
  */
 db_handler(post, Organization, DB, Request, System_DB, Auth) :-
     /* POST: Create database */
+    check_content_type_json(Request),
     get_payload(Database_Document,Request),
     do_or_die(
         (_{ comment : Comment,
@@ -3694,6 +3695,19 @@ try_get_param(Key,_Request,_Value) :-
 json_content_type(Request) :-
     memberchk(content_type(CT), Request),
     re_match('^application/json', CT, []).
+
+check_content_type(Request, Expected, ContentType) :-
+    do_or_die(
+        memberchk(content_type(ContentType), Request),
+        error(missing_content_type(Expected), _)).
+
+check_content_type_json(Request) :-
+    Expected = 'application/json',
+    check_content_type(Request, Expected, ContentType),
+    atom_concat('^', Expected, RE),
+    do_or_die(
+        re_match(RE, ContentType, []),
+        error(bad_content_type(ContentType, Expected), _)).
 
 json_mime_type(Mime) :-
     memberchk(type(CT),Mime),


### PR DESCRIPTION
This adds error responses thrown for `Content-Type` issues in the `/api/db` route. I'm guessing this check could be added elsewhere, too, but I'm not sure where.