### PR TITLE
Fix docs workflow for new branch names

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,10 +2,12 @@ name: Docs
 on:
   push:
     branches:
-      - master
+      - main
       - rc
       - canary
-      - dev
+    tags:
+      - v* # Environment variables available to all jobs and steps in this workflow
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -19,11 +21,7 @@ jobs:
       - name: Extract branch name
         shell: bash
         run: |
-          if [[ $GITHUB_REF == 'refs/heads/master' ]]; then
-            echo "##[set-output name=branch;]$(echo '')"
-          else
-            echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-          fi
+            echo "##[set-output name=branch;]$(echo ${GITHUB_REF##*/})"
         id: extract_branch
 
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,7 @@ on:
       - rc
       - canary
     tags:
-      - v* # Environment variables available to all jobs and steps in this workflow
+      - v*
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
The docs workflow did not reflect the branch name changes from `master` to `main`. It also did not include tagged releases.

For now, the workflow creates a folder in docs based on its version. For instance:

- A push to main will save the docs to a folder called `main`
- A tagged release will make a folder containing its version

Am I missing something? I've been thinking that the latest tagged release should always be moved to the root as well.