### PR TITLE
raise default max transaction retries to multiple of worker count

### DIFF
--- a/src/config/terminus_config.pl
+++ b/src/config/terminus_config.pl
@@ -45,8 +45,12 @@ server_port(Value) :-
 worker_amount(Value) :-
     getenv_default_number('TERMINUSDB_SERVER_WORKERS', 8, Value).
 
+:- table max_transaction_retries/1.
 max_transaction_retries(Value) :-
-    getenv_default_number('TERMINUSDB_SERVER_MAX_TRANSACTION_RETRIES', 3, Value).
+    (   getenv('TERMINUSDB_SERVER_MAX_TRANSACTION_RETRIES', Atom_Value)
+    ->  atom_number(Atom_Value, Value)
+    ;   worker_amount(Num_Workers),
+        Value is Num_Workers * 2).
 
 :- dynamic index_template_/1.
 


### PR DESCRIPTION
Transaction retry count, when not supplied through an environment variable at startup, is now computed by doubling the worker count. With the default settings, this will now result in a retry count of 16.

Furthermore, since this configuration setting is retrieved every time a transaction is started, I figured that re-parsing the environment variables and/or recomputing this retry count is a bit silly, so the config predicate is now also tabled, ensuring this happens only once.

Fixes #486.