### PR TITLE
properly parse count/skip both for input documents and query params

### DIFF
--- a/src/core/api/api_error.pl
+++ b/src/core/api/api_error.pl
@@ -1205,19 +1205,19 @@ api_document_error_jsonld(Type, error(casting_error(Value, Destination_Type, Doc
                               'api:document' : Document },
              'api:message' : Msg
             }.
-api_document_error_jsonld(get_documents, error(skip_is_not_a_number(Skip_Atom), _), JSON) :-
-    format(string(Msg), "specified skip count is not a number: ~q", [Skip_Atom]),
+api_document_error_jsonld(get_documents, error(skip_is_not_an_integer(Skip_Atom), _), JSON) :-
+    format(string(Msg), "specified skip count is not an integer: ~q", [Skip_Atom]),
     JSON = _{'@type' : 'api:GetDocumentErrorResponse',
              'api:status' : "api:failure",
-             'api:error' : _{ '@type' : 'api:SkipNotANumber',
+             'api:error' : _{ '@type' : 'api:SkipNotAnInteger',
                               'api:skip' : Skip_Atom },
              'api:message' : Msg
             }.
-api_document_error_jsonld(get_documents, error(count_is_not_a_number(Count_Atom), _), JSON) :-
-    format(string(Msg), "specified retrieval count is not a number: ~q", [Count_Atom]),
+api_document_error_jsonld(get_documents, error(count_is_not_an_integer(Count_Atom), _), JSON) :-
+    format(string(Msg), "specified retrieval count is not an integer: ~q", [Count_Atom]),
     JSON = _{'@type' : 'api:GetDocumentErrorResponse',
              'api:status' : "api:failure",
-             'api:error' : _{ '@type' : 'api:CountNotANumber',
+             'api:error' : _{ '@type' : 'api:CountNotAnInteger',
                               'api:count' : Count_Atom },
              'api:message' : Msg
             }.

--- a/src/core/util.pl
+++ b/src/core/util.pl
@@ -126,6 +126,7 @@
               datetime_to_internal_datetime/2,
               json_read_dict_stream/2,
               skip_generate_nsols/3,
+              input_to_integer/2,
 
               % speculative_parse.pl
               %guess_date/2,

--- a/src/core/util/utils.pl
+++ b/src/core/util/utils.pl
@@ -63,7 +63,8 @@
               time_to_internal_time/2,
               datetime_to_internal_datetime/2,
               json_read_dict_stream/2,
-              skip_generate_nsols/3
+              skip_generate_nsols/3,
+              input_to_integer/2
           ]).
 
 /** <module> Utils
@@ -893,3 +894,10 @@ skip_generate_nsols(Goal, Skip, Count) :-
     (   Count = unlimited
     ->  offset(Skip, Goal)
     ;   limit(Count, offset(Skip, Goal))).
+
+input_to_integer(Atom, Integer) :-
+    (   integer(Atom)
+    ->  Integer = Atom
+    ;   error:text(Atom)
+    ->  atom_number(Atom, Integer),
+        integer(Integer)).

--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -767,14 +767,14 @@ document_handler(get, Path, Request, System_DB, Auth) :-
             (   (   get_dict(skip, Posted, Skip_Atom)
                 ->  true
                 ;   memberchk(skip=Skip_Atom, Search))
-            ->  do_or_die(atom_number(Skip_Atom, Skip),
-                          error(skip_is_not_a_number(Skip_Atom), _))
+            ->  do_or_die(input_to_integer(Skip_Atom, Skip),
+                          error(skip_is_not_an_integer(Skip_Atom),_))
             ;   Skip = 0),
             (   (   get_dict(count, Posted, Count_Atom)
                 ->  true
                 ;   memberchk(count=Count_Atom, Search))
-            ->  do_or_die(atom_number(Count_Atom, Count),
-                          error(count_is_not_a_number(Count_Atom), _))
+            ->  do_or_die(input_to_integer(Count_Atom, Count),
+                          error(count_is_not_an_integer(Count_Atom),_))
             ;   Count = unlimited),
 
             (   (   get_dict(minimized, Posted, true)


### PR DESCRIPTION
Numerical parameters to the document interface were not properly parsed for get requests with a posted query document. A string was expected, which would fail on the numerical representation in a json document.

Furthermore, the existing code did not properly check that the resulting number was an integer. This is now also checked.

Fixes #532.