### PR TITLE
fix foreign type test that was failing due to new id scheme

### DIFF
--- a/src/core/document/json.pl
+++ b/src/core/document/json.pl
@@ -7490,19 +7490,18 @@ test(foreign_type,
     ),
 
     get_document(Finance_Desc, Payroll_Doc_Id, New_Payroll),
-    writeq(New_Payroll),
     New_Payroll =
     json{'@id':'Payroll/standard',
          '@type':'Payroll',
-         payroll:[json{'@id':'Payroll/standard/payroll/PayRecord/http%3A%2F%2Fsomewhere.for.now%2Fdocument%2FEmployee%2Fjane_1995-05-03',
+         payroll:[json{'@id':'Payroll/standard/payroll/PayRecord/http%3A%2F%2Fsomewhere.for.now%2Fdocument%2FEmployee%2Fjane%2B1995-05-03',
                        '@type':'PayRecord',
-                       employee:'Employee/jane_1995-05-03',
-                       pay:(32.85),
+                       employee:'Employee/jane+1995-05-03',
+                       pay:32.85,
                        pay_period:"P1M"},
-                  json{'@id':'Payroll/standard/payroll/PayRecord/http%3A%2F%2Fsomewhere.for.now%2Fdocument%2FEmployee%2Fjoe_2012-05-03','@type':'PayRecord',
-                       employee:'Employee/joe_2012-05-03',
-                       pay:(12.3),
+                  json{'@id':'Payroll/standard/payroll/PayRecord/http%3A%2F%2Fsomewhere.for.now%2Fdocument%2FEmployee%2Fjoe%2B2012-05-03',
+                       '@type':'PayRecord',
+                       employee:'Employee/joe+2012-05-03',
+                       pay:12.3,
                        pay_period:"P1M"}]}.
-
 
 :- end_tests(foreign_types).


### PR DESCRIPTION
This fixes the unit test that was failing due to id changes.

However, there's something weird going on here. The id references in the document do not match the actual ids, as one has the + escaped and the other does not. This is probably unintended behavior so I'm not yet merging.

@GavinMendelGleason please have a look.