### PR TITLE
Idempotent insert

### DIFF
--- a/src/core/api.pl
+++ b/src/core/api.pl
@@ -115,7 +115,7 @@
               api_generate_documents_by_type/10,
               api_generate_documents_by_query/11,
               api_get_document/8,
-              api_insert_documents/9,
+              api_insert_documents/10,
               api_delete_documents/7,
               api_delete_document/7,
               api_replace_documents/8,

--- a/src/core/document.pl
+++ b/src/core/document.pl
@@ -33,6 +33,7 @@
               get_schema_document_uri_by_type/3,
               delete_document/2,
               insert_document/3,
+              insert_document/4,
               replace_document/2,
               replace_document/3,
               nuke_documents/1,

--- a/src/core/document/json.pl
+++ b/src/core/document/json.pl
@@ -1878,7 +1878,7 @@ check_existing_document_status(Transaction, Document, Ignore_Duplicates, Status)
         ->  (   Document = Existing_Document_Elaborated
             ->  Status = equivalent
             ;   Status = present)
-        ;   status = not_present)
+        ;   Status = not_present)
     ;   (   xrdf(Instance, Id, _, _)
         ->  Status = present
         ;   Status = not_present)

--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -858,9 +858,13 @@ document_handler(post, Path, Request, System_DB, Auth) :-
             ->  true
             ;   Full_Replace = false),
 
+            (   memberchk(ignore_duplicates=Ignore_Duplicates, Search)
+            ->  true
+            ;   Ignore_Duplicates = false),
+
             http_read_data(Request, Data, [to(string)]),
             open_string(Data, Stream),
-            api_insert_documents(System_DB, Auth, Path, Graph_Type, Author, Message, Full_Replace, Stream, Ids),
+            api_insert_documents(System_DB, Auth, Path, Graph_Type, Author, Message, Full_Replace, Ignore_Duplicates, Stream, Ids),
 
             write_cors_headers(Request),
             reply_json(Ids),


### PR DESCRIPTION
This is still a work in progress.

Currently this will still fail if subdocuments have random ids but are otherwise equivalent.

Resolves #544.