### PR TITLE
better error handling for put and delete

### DIFF
--- a/src/core/api/api_error.pl
+++ b/src/core/api/api_error.pl
@@ -1269,6 +1269,16 @@ api_document_error_jsonld(insert_documents, error(no_context_found_in_schema, _)
              'api:error' : _{ '@type' : 'api:NoContextFoundInSchema'},
              'api:message' : Msg
             }.
+api_document_error_jsonld(replace_documents, error(document_does_not_exist(Id, Document), _), JSON) :-
+    format(string(Msg), "Document submitted for replacement, but original is not found for ID ~q", [Id]),
+    JSON = _{'@type' : 'api:ReplaceDocumentErrorResponse',
+             'api:status' : "api:not_found",
+             'api:error' : _{ '@type' : 'api:OriginalDocumentNotFound',
+                              'api:document_id' : Id,
+                              'api:replacement_document': Document
+                            },
+             'api:message' : Msg
+            }.
 api_document_error_jsonld(delete_documents, error(document_does_not_exist(Id), _), JSON) :-
     format(string(Msg), "Document with id ~q was not found", [Id]),
     JSON = _{'@type' : 'api:DeleteDocumentErrorResponse',

--- a/src/core/document/json.pl
+++ b/src/core/document/json.pl
@@ -1922,7 +1922,9 @@ replace_document(Transaction, Document, Id) :-
     !,
     json_elaborate(Transaction, Document, Elaborated),
     get_dict('@id', Elaborated, Id),
-    delete_document(Transaction, Id),
+    catch(delete_document(Transaction, Id),
+          error(document_does_not_exist(_),_),
+          throw(error(document_does_not_exist(Id, Document),_))),
     insert_document_expanded(Transaction, Elaborated, Id).
 replace_document(Query_Context, Document, Id) :-
     is_query_context(Query_Context),


### PR DESCRIPTION
These error conditions are now properly checked and return a good error to the user:
- PUT instance/schema documents for which no version currently exists in the db
- DELETE schema documents that do not exist

Fixes #552.