### PR TITLE
appimage: dont clone our own repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,12 +216,7 @@ jobs:
         cd distribution/appimage
         wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
         chmod +x linuxdeploy-x86_64.AppImage
-        if [[ $(echo "${{ github.ref }}" | grep "refs/pull") ]]; then
-           BRANCH=$(echo "${{ github.base_ref }}" | sed -e 's,.*/\(.*\),\1,')
-        else
-           BRANCH=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-        fi
-        ./build_script.sh "$BRANCH" "$TERMINUSDB_STORE_PROLOG_VERSION" "$TUS_VERSION"
+        ./build_script.sh "$TERMINUSDB_STORE_PROLOG_VERSION" "$TUS_VERSION"
         mv "TerminusDB-$(echo $GITHUB_SHA | cut -c 1-7)-x86_64.AppImage" TerminusDB-amd64.AppImage
 
     - name: Run AppImage tests

--- a/distribution/appimage/build_script.sh
+++ b/distribution/appimage/build_script.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 CURRENT_DIR=$(pwd)
-TERMINUSDB_BRANCH=$1
-TERMINUSDB_STORE_PROLOG_VERSION=$2
-TUS_VERSION=$3
+TERMINUSDB_STORE_PROLOG_VERSION=$1
+TUS_VERSION=$2
 TERMINUSDB_STORE_PROLOG_DIR="app_dir/usr/lib/swi-prolog/pack/terminus_store_prolog"
 TUS_DIR="app_dir/usr/lib/swi-prolog/pack/tus"
 SOURCE="${BASH_SOURCE[0]}"
@@ -10,9 +9,7 @@ mkdir -p app_dir/usr/share/terminusdb
 mkdir -p app_dir/usr/bin
 mkdir -p app_dir/usr/lib/swi-prolog/pack
 mkdir -p app_dir/usr/lib/x86_64-linux-gnu
-git clone https://github.com/terminusdb/terminusdb.git
-cd terminusdb && git checkout $TERMINUSDB_BRANCH && cd ..
-cp -r terminusdb/* app_dir/usr/share/terminusdb/
+cp -r ../../src app_dir/usr/share/terminusdb/
 cp -r /usr/lib/swi-prolog app_dir/usr/lib/
 cp -L /usr/lib/x86_64-linux-gnu/libedit.so.2 app_dir/usr/lib/swi-prolog/lib/x86_64-linux/
 cp -L /lib/x86_64-linux-gnu/libpcre.so.3 app_dir/usr/lib/swi-prolog/lib/x86_64-linux/


### PR DESCRIPTION
The AppImage is being created inside the TerminusDB repo itself.
Therefore it does not make sense to clone it again!