### PR TITLE
Properly handle key fields that are type containers

### DIFF
--- a/src/core/document/json.pl
+++ b/src/core/document/json.pl
@@ -60,7 +60,7 @@ encode_id_fragment(Elt, Encoded) :-
     ground(Elt),
     !,
     (   Elt = optional(none)
-    ->  Encoded = "+"
+    ->  Encoded = "+none+"
     ;   Elt = list(List)
     ->  maplist(encode_id_fragment, List, List_Encoded),
         merge_separator_split(Encoded, '++', List_Encoded)
@@ -3134,7 +3134,7 @@ test(idgen_lexical_optional,
                           )),
 
     Uri1 = 'http://somewhere.for.now/document/Thing/foo',
-    Uri2 = 'http://somewhere.for.now/document/Thing/+'.
+    Uri2 = 'http://somewhere.for.now/document/Thing/+none+'.
 
 test(idgen_lexical_set,
      [setup((setup_temp_store(State),
@@ -3185,8 +3185,8 @@ test(idgen_lexical_set,
     Uri1 = 'http://somewhere.for.now/document/Thing/bar++foo',
     Uri2 = 'http://somewhere.for.now/document/Thing/bar++foo',
     Uri3 = 'http://somewhere.for.now/document/Thing/quux',
-    Uri4 = 'http://somewhere.for.now/document/Thing/+',
-    Uri5 = 'http://somewhere.for.now/document/Thing/+'.
+    Uri4 = 'http://somewhere.for.now/document/Thing/+none+',
+    Uri5 = 'http://somewhere.for.now/document/Thing/+none+'.
 
 test(idgen_lexical_list,
      [setup((setup_temp_store(State),
@@ -3233,7 +3233,7 @@ test(idgen_lexical_list,
     Uri1 = 'http://somewhere.for.now/document/Thing/foo++bar',
     Uri2 = 'http://somewhere.for.now/document/Thing/bar++foo',
     Uri3 = 'http://somewhere.for.now/document/Thing/quux',
-    Uri4 = 'http://somewhere.for.now/document/Thing/+'.
+    Uri4 = 'http://somewhere.for.now/document/Thing/+none+'.
 
 test(idgen_lexical_array,
      [setup((setup_temp_store(State),
@@ -3284,8 +3284,8 @@ test(idgen_lexical_array,
     Uri1 = 'http://somewhere.for.now/document/Thing/foo++bar',
     Uri2 = 'http://somewhere.for.now/document/Thing/bar++foo',
     Uri3 = 'http://somewhere.for.now/document/Thing/quux',
-    Uri4 = 'http://somewhere.for.now/document/Thing/+',
-    Uri5 = 'http://somewhere.for.now/document/Thing/+'.
+    Uri4 = 'http://somewhere.for.now/document/Thing/+none+',
+    Uri5 = 'http://somewhere.for.now/document/Thing/+none+'.
 
 test(idgen_random,
      [

--- a/src/core/document/json.pl
+++ b/src/core/document/json.pl
@@ -3287,6 +3287,46 @@ test(idgen_lexical_array,
     Uri4 = 'http://somewhere.for.now/document/Thing/+none+',
     Uri5 = 'http://somewhere.for.now/document/Thing/+none+'.
 
+test(idgen_find_collision,
+     [setup((setup_temp_store(State),
+             create_db_with_empty_schema("admin", "testdb"),
+             resolve_absolute_string_descriptor("admin/testdb", Desc))),
+      cleanup(teardown_temp_store(State))]) :-
+
+    with_test_transaction(Desc,
+                          C1,
+                          insert_schema_document(
+                              C1,
+                              _{'@type': "Class",
+                                '@id': "Thing",
+                                '@key': _{'@type': "Lexical",
+                                          '@fields': ["field"]},
+                                field: _{'@type': "Array",
+                                         '@class': "xsd:string"}})
+                          ),
+
+    with_test_transaction(Desc,
+                          C2,
+                          (   insert_document(
+                                  C2,
+                                  _{'@type': "Thing",
+                                    field: ["", "none", ""]},
+                                  Uri1),
+                              insert_document(
+                                  C2,
+                                  _{'@type': "Thing",
+                                    field: []},
+                                  Uri2),
+                              insert_document(
+                                  C2,
+                                  _{'@type': "Thing",
+                                    field: ["none"]},
+                                  Uri3)
+                          )),
+    Uri1 = 'http://somewhere.for.now/document/Thing/++none++',
+    Uri2 = 'http://somewhere.for.now/document/Thing/+none+',
+    Uri2 = 'http://somewhere.for.now/document/Thing/none'.
+
 test(idgen_random,
      [
          setup(

--- a/src/core/document/json.pl
+++ b/src/core/document/json.pl
@@ -3325,7 +3325,7 @@ test(idgen_find_collision,
                           )),
     Uri1 = 'http://somewhere.for.now/document/Thing/++none++',
     Uri2 = 'http://somewhere.for.now/document/Thing/+none+',
-    Uri2 = 'http://somewhere.for.now/document/Thing/none'.
+    Uri3 = 'http://somewhere.for.now/document/Thing/none'.
 
 test(idgen_random,
      [


### PR DESCRIPTION
Optionals, sets, arrays and lists were not working properly with key generation.

This now follows the following algorithm:
- For all 4, if there's just a single value, it is treated exactly as if this was a required field. This ensures that the same id is generated, so that in the future, it may be possible to switch between key strategies without having to convert existing objects that are already in line with the new format, such as when going from optional to set, or from required to optional.
- For all 4, if there is no value, the out-of-band value ~~'+'~~ '+none+' (unencoded) is used
- For the list-like types with more than one value, the values are concatenated with an unencoded '++' between them. In case of sets, the list is first sorted to ensure that documents who order the list differently but contain the same values still get the same id.

Work in progress as I explore some more edge cases.

Resolves #570.