### PR TITLE
Improve errors for unknown database

### DIFF
--- a/src/core/account/capabilities.pl
+++ b/src/core/account/capabilities.pl
@@ -492,7 +492,7 @@ check_descriptor_auth_(database_descriptor{ database_name : Database,
                                             organization_name : Organization},
                        Action, Auth, System_DB) :-
     do_or_die(organization_database_name_uri(System_DB, Organization, Database, URI),
-              error(database_does_not_exist(Organization, Database),_)),
+              error(unknown_database(Organization, Database),_)),
 
     assert_auth_action_scope(System_DB,Auth,Action, URI).
 check_descriptor_auth_(repository_descriptor{ database_descriptor : DB,

--- a/src/core/api/api_error.pl
+++ b/src/core/api/api_error.pl
@@ -59,11 +59,11 @@ api_error_jsonld(delete_db,error(unknown_organization(Organization_Name),_), JSO
              'api:error' : _{'@type' : 'api:UnknownOrganization',
                              'api:organization_name' : Organization_Name},
              'api:message' : Msg}.
-api_error_jsonld(delete_db,error(database_does_not_exist(Organization,Database), _), JSON) :-
-    format(string(Msg), "Database ~s/~s does not exist.", [Organization, Database]),
+api_error_jsonld(delete_db,error(unknown_database(Organization, Database), _), JSON) :-
+    format(string(Msg), "Unknown database: ~s/~s", [Organization, Database]),
     JSON = _{'@type' : 'api:DbDeleteErrorResponse',
-             'api:status' : 'api:failure',
-             'api:error' : _{'@type' : 'api:DatabaseDoesNotExist',
+             'api:status' : 'api:not_found',
+             'api:error' : _{'@type' : 'api:UnknownDatabase',
                              'api:database_name' : Database,
                              'api:organization_name' : Organization},
              'api:message' : Msg}.
@@ -644,18 +644,18 @@ api_error_jsonld(pull,error(pull_no_common_history(Head_Has_Updated), _), JSON) 
                             }
             }.
 api_error_jsonld(branch,error(invalid_target_absolute_path(Path),_), JSON) :-
-    format(string(Msg), "The following branch target absolute resource descriptor string is invalid: ~q", [Path]),
+    format(string(Msg), "Invalid target absolute resource descriptor: ~q", [Path]),
     JSON = _{'@type' : 'api:BranchErrorResponse',
              'api:status' : 'api:failure',
-             'api:error' : _{ '@type' : 'api:BadAbsoluteTargetDescriptor',
+             'api:error' : _{ '@type' : 'api:BadTargetAbsoluteDescriptor',
                               'api:absolute_descriptor' : Path},
              'api:message' : Msg
             }.
-api_error_jsonld(branch,error(invalid_source_absolute_path(Path),_), JSON) :-
-    format(string(Msg), "The following branch source absolute resource descriptor string is invalid: ~q", [Path]),
+api_error_jsonld(branch,error(invalid_origin_absolute_path(Path),_), JSON) :-
+    format(string(Msg), "Invalid origin absolute resource descriptor: ~q", [Path]),
     JSON = _{'@type' : 'api:BranchErrorResponse',
              'api:status' : 'api:failure',
-             'api:error' : _{ '@type' : 'api:BadAbsoluteSourceDescriptor',
+             'api:error' : _{ '@type' : 'api:BadOriginAbsoluteDescriptor',
                               'api:absolute_descriptor' : Path},
              'api:message' : Msg
             }.
@@ -677,14 +677,14 @@ api_error_jsonld(branch,error(source_not_a_valid_descriptor(Descriptor), _), JSO
              'api:error' : _{ '@type' : "api:NotASourceBranchDescriptorError",
                               'api:absolute_descriptor' : Path}
             }.
-api_error_jsonld(branch,error(source_database_does_not_exist(Org,DB), _), JSON) :-
-    format(string(Msg), "The source database '~s/~s' does not exist", [Org, DB]),
+api_error_jsonld(branch,error(unknown_origin_database(Organization, Database), _), JSON) :-
+    format(string(Msg), "Unknown origin database: ~s/~s", [Organization, Database]),
     JSON = _{'@type' : "api:BranchErrorResponse",
              'api:status' : "api:failure",
              'api:message' : Msg,
-             'api:error' : _{ '@type' : "api:DatabaseDoesNotExist",
-                              'api:database_name' : DB,
-                              'api:organization_name' : Org}
+             'api:error' : _{ '@type' : "api:UnknownOriginDatabase",
+                              'api:database_name' : Database,
+                              'api:organization_name' : Organization}
             }.
 api_error_jsonld(branch,error(repository_is_not_local(Descriptor), _), JSON) :-
     resolve_absolute_string_descriptor(Path, Descriptor),
@@ -720,13 +720,13 @@ api_error_jsonld(prefix,error(invalid_absolute_path(Path),_), JSON) :-
                               'api:absolute_descriptor' : Path},
              'api:message' : Msg
             }.
-api_error_jsonld(prefix,error(database_does_not_exist(Account,Name),_), JSON) :-
-    format(string(Msg), "The database '~w/~w' does not exist.", [Account, Name]),
+api_error_jsonld(prefix,error(unknown_database(Organization, Database),_), JSON) :-
+    format(string(Msg), "Unknown database: ~s/~s", [Organization, Database]),
     JSON = _{'@type' : 'api:PrefixErrorResponse',
-             'api:status' : 'api:failure',
-             'api:error' : _{ '@type' : 'api:DatabaseDoesNotExist',
-                              'api:database_name' : Name,
-                              'api:organization_name' : Account},
+             'api:status' : 'api:not_found',
+             'api:error' : _{ '@type' : 'api:UnknownDatabase',
+                              'api:database_name' : Database,
+                              'api:organization_name' : Organization},
              'api:message' : Msg
             }.
 api_error_jsonld(user_update,error(user_update_failed_without_error(Name,Document),_),JSON) :-
@@ -944,6 +944,14 @@ api_error_jsonld(remote,error(remote_exists(Name),_), JSON) :-
              'api:error' : _{ '@type' : "api:RemoteExists",
                               'api:remote_name' : Name}
             }.
+api_error_jsonld(remote,error(unknown_database(Organization, Database), _), JSON) :-
+    format(string(Msg), "Unknown database: ~s/~s", [Organization, Database]),
+    JSON = _{'@type' : 'api:RemoteErrorResponse',
+             'api:status' : 'api:not_found',
+             'api:error' : _{'@type' : 'api:UnknownDatabase',
+                             'api:database_name' : Database,
+                             'api:organization_name' : Organization},
+             'api:message' : Msg}.
 api_error_jsonld(rollup,error(invalid_absolute_path(Path),_), JSON) :-
     format(string(Msg), "The following absolute resource descriptor string is invalid: ~q", [Path]),
     JSON = _{'@type' : 'api:RollupErrorResponse',
@@ -1058,12 +1066,12 @@ api_document_error_jsonld(Type, error(invalid_path(Path), _), JSON) :-
                               'api:resource_path' : Path },
              'api:message' : Msg
             }.
-api_document_error_jsonld(Type,error(database_does_not_exist(Organization,Database), _), JSON) :-
+api_document_error_jsonld(Type,error(unknown_database(Organization, Database), _), JSON) :-
     document_error_type(Type, JSON_Type),
-    format(string(Msg), "Database ~s/~s does not exist.", [Organization, Database]),
+    format(string(Msg), "Unknown database: ~s/~s", [Organization, Database]),
     JSON = _{'@type' : JSON_Type,
-             'api:status' : 'api:failure',
-             'api:error' : _{'@type' : 'api:DatabaseDoesNotExist',
+             'api:status' : 'api:not_found',
+             'api:error' : _{'@type' : 'api:UnknownDatabase',
                              'api:database_name' : Database,
                              'api:organization_name' : Organization},
              'api:message' : Msg}.
@@ -1440,10 +1448,6 @@ generic_exception_jsonld(schema_check_failure(Witnesses),JSON) :-
 generic_exception_jsonld(database_not_found(DB),JSON) :-
     format(atom(MSG), 'Database ~s could not be destroyed', [DB]),
     JSON = _{'api:message' : MSG,
-             'api:status' : 'api:failure'}.
-generic_exception_jsonld(database_does_not_exist(DB),JSON) :-
-    format(atom(M), 'Database does not exist with the name ~q', [DB]),
-    JSON = _{'api:message' : M,
              'api:status' : 'api:failure'}.
 generic_exception_jsonld(database_files_do_not_exist(DB),JSON) :-
     format(atom(M), 'Database fields do not exist for database with the name ~q', [DB]),

--- a/src/core/api/api_remote.pl
+++ b/src/core/api/api_remote.pl
@@ -16,7 +16,7 @@ add_remote(SystemDB, Auth, Path, Remote_Name, Remote_Location) :-
 
     do_or_die(
         resolve_absolute_string_descriptor(Repo_Path, Descriptor),
-        error(invalid_absolute_path(Repo_Path),_)),
+        error(invalid_absolute_path(Path),_)),
 
     check_descriptor_auth(SystemDB, Descriptor,
                           '@schema':'Action/meta_write_access', Auth),
@@ -40,7 +40,7 @@ remove_remote(SystemDB, Auth, Path, Remote_Name) :-
 
     do_or_die(
         resolve_absolute_string_descriptor(Repo_Path, Descriptor),
-        error(invalid_absolute_path(Repo_Path),_)),
+        error(invalid_absolute_path(Path),_)),
 
     check_descriptor_auth(SystemDB, Descriptor,
                           '@schema':'Action/meta_write_access', Auth),
@@ -64,7 +64,7 @@ update_remote(SystemDB, Auth, Path, Remote_Name, Remote_Location) :-
 
     do_or_die(
         resolve_absolute_string_descriptor(Repo_Path, Descriptor),
-        error(invalid_absolute_path(Repo_Path),_)),
+        error(invalid_absolute_path(Path),_)),
 
     check_descriptor_auth(SystemDB, Descriptor,
                           '@schema':'Action/meta_write_access', Auth),
@@ -88,7 +88,7 @@ show_remote(SystemDB, Auth, Path, Remote_Name, Remote_Location) :-
 
     do_or_die(
         resolve_absolute_string_descriptor(Repo_Path, Descriptor),
-        error(invalid_absolute_path(Repo_Path),_)),
+        error(invalid_absolute_path(Path),_)),
 
     check_descriptor_auth(SystemDB, Descriptor,
                           '@schema':'Action/meta_write_access', Auth),
@@ -108,7 +108,7 @@ list_remotes(SystemDB, Auth, Path, Remote_Names) :-
 
     do_or_die(
         resolve_absolute_string_descriptor(Repo_Path, Descriptor),
-        error(invalid_absolute_path(Repo_Path),_)),
+        error(invalid_absolute_path(Path),_)),
 
     check_descriptor_auth(SystemDB, Descriptor,
                           '@schema':'Action/meta_write_access', Auth),

--- a/src/core/api/db_branch.pl
+++ b/src/core/api/db_branch.pl
@@ -99,7 +99,7 @@ branch_create(System_DB, Auth, Path, Origin_Option, Branch_Uri) :-
 
     do_or_die(
         resolve_absolute_string_descriptor(Path, Destination_Descriptor),
-        error(invalid_target_absolute_descriptor(Path),_)),
+        error(invalid_target_absolute_path(Path),_)),
 
     do_or_die(
         (branch_descriptor{
@@ -111,7 +111,7 @@ branch_create(System_DB, Auth, Path, Origin_Option, Branch_Uri) :-
     (   Origin_Option = some(Origin_Path)
     ->  do_or_die(
             resolve_absolute_string_descriptor(Origin_Path, Origin_Descriptor),
-            error(invalid_source_absolute_descriptor(Origin_Path),_)),
+            error(invalid_origin_absolute_path(Origin_Path),_)),
 
         do_or_die(
             (   get_dict(repository_descriptor, Origin_Descriptor, Origin_Repository_Descriptor),
@@ -122,7 +122,7 @@ branch_create(System_DB, Auth, Path, Origin_Option, Branch_Uri) :-
 
         do_or_die(
             organization_database_name_uri(System_DB, Organization_Name, Database_Name, Scope_Iri),
-            error(origin_database_does_not_exist(Organization_Name, Database_Name),_))
+            error(unknown_origin_database(Organization_Name, Database_Name),_))
     ;   Origin_Option = none
     ->  Origin_Descriptor = empty
     ;   throw(error(bad_origin_path_option(Origin_Option),_))),
@@ -162,7 +162,7 @@ branch_delete(System_DB, Auth, Path) :-
 
     do_or_die(
         resolve_absolute_string_descriptor(Path, Descriptor),
-        error(invalid_target_absolute_descriptor(Path),_)),
+        error(invalid_target_absolute_path(Path),_)),
 
     do_or_die(
         branch_descriptor{

--- a/src/core/api/db_delete.pl
+++ b/src/core/api/db_delete.pl
@@ -57,7 +57,7 @@ delete_db(System, Auth, Organization,DB_Name, Force) :-
             assert_auth_action_scope(System_Context, Auth, '@schema':'Action/delete_database', Organization_Uri),
 
             do_or_die(database_exists(System_Context,Organization,DB_Name),
-                      error(database_does_not_exist(Organization,DB_Name), _)),
+                      error(unknown_database(Organization,DB_Name), _)),
             % Do something here? User may need to know what went wrong
 
             (   Force \= true

--- a/src/core/query/resolve_query_resource.pl
+++ b/src/core/query/resolve_query_resource.pl
@@ -103,6 +103,12 @@ resolve_absolute_descriptor([Organization, Database, Repository, "commit", Commi
     ->  Commit = Commit_String
     ;   text_to_string(Commit, Commit_String)),
     resolve_absolute_descriptor([Organization, Database, Repository, "_commits"], Repository_Descriptor).
+resolve_absolute_descriptor([_, "_meta"], _) :-
+    % This happens when we append '/_meta' to the incoming path before splitting
+    % it into segments. If the incoming path doesn't have a /, it doesn't get
+    % split, and we end up with two things in the list, one of which is _meta.
+    !,
+    fail.
 resolve_absolute_descriptor([Organization, Database],
                             Descriptor) :-
     !,

--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -484,9 +484,9 @@ test(db_delete_nonexistent_errors, [
                  authorization(basic(admin, Key)),
                  status_code(Status)]),
 
-    Status = 400,
+    Status = 404,
 
-    _{'api:status' : "api:failure"} :< Result.
+    _{'api:status' : "api:not_found"} :< Result.
 
 
 test(db_auth_test, [


### PR DESCRIPTION
* Change `database_does_not_exist` to `unknown_database`
* Fix `resolve_absolute_descriptor` when given a name and `_meta`
* Use input path instead of modified path for `invalid_absolute_path`
* Use `api:not_found` instead of `api:failure`
* Improve branch errors for db and desc
* Fixes #567

I have integration tests:

```js
  describe('bad descriptor', (t) => {
    const r = http.get('/api/remote/unknowndesc')
    t.expect(r.status).as('status').toEqual(400)
      .and(r).toHaveValidJson()
      .and(r.json('@type')).as('@type').toEqual('api:RemoteErrorResponse')
      .and(r.json('api:status')).as('api:status').toEqual('api:failure')
      .and(r.json('api:error.@type')).as('api:error.@type').toEqual('api:BadAbsoluteDescriptor')
      .and(r.json('api:error.api:absolute_descriptor')).as('api:error.api:absolute_descriptor').toEqual('unknowndesc')
  })

  describe('unknown database', (t) => {
    const r = http.get('/api/remote/unknownorg/unknowndb')
    t.expect(r.status).as('status').toEqual(404)
      .and(r).toHaveValidJson()
      .and(r.json('@type')).as('@type').toEqual('api:RemoteErrorResponse')
      .and(r.json('api:status')).as('api:status').toEqual('api:not_found')
      .and(r.json('api:error.@type')).as('api:error.@type').toEqual('api:UnknownDatabase')
      .and(r.json('api:error.api:organization_name')).as('api:error.api:organization_name').toEqual('unknownorg')
      .and(r.json('api:error.api:database_name')).as('api:error.api:database_name').toEqual('unknowndb')
  })
```