### PR TITLE
Implement a new logging strategy

### DIFF
--- a/src/bootstrap.pl
+++ b/src/bootstrap.pl
@@ -18,7 +18,6 @@
 :- use_module(core(query)).
 :- use_module(core(api)).
 
-:- use_module(library(http/http_log)).
 :- use_module(library(qsave)).
 
 

--- a/src/config/terminus_config.pl
+++ b/src/config/terminus_config.pl
@@ -36,8 +36,11 @@ initialize_system_ssl_certs :-
 server_protocol(Value) :-
     Value = http.
 
+:- table server_name/1 as shared.
 server_name(Value) :-
-    getenv_default('TERMINUSDB_SERVER_NAME', '127.0.0.1', Value).
+    (   getenv('TERMINUSDB_SERVER_NAME', Value)
+    ->  true
+    ;   random_string(Value)).
 
 server_port(Value) :-
     getenv_default_number('TERMINUSDB_SERVER_PORT', 6363, Value).
@@ -45,7 +48,7 @@ server_port(Value) :-
 worker_amount(Value) :-
     getenv_default_number('TERMINUSDB_SERVER_WORKERS', 8, Value).
 
-:- table max_transaction_retries/1.
+:- table max_transaction_retries/1 as shared.
 max_transaction_retries(Value) :-
     (   getenv('TERMINUSDB_SERVER_MAX_TRANSACTION_RETRIES', Atom_Value)
     ->  atom_number(Atom_Value, Value)

--- a/src/config/terminus_config.pl
+++ b/src/config/terminus_config.pl
@@ -18,7 +18,10 @@
               server_worker_options/1,
               http_options/1,
               ignore_ref_and_repo_schema/0,
-              file_upload_storage_path/1
+              file_upload_storage_path/1,
+              log_level/1,
+              set_log_level/1,
+              clear_log_level/0
           ]).
 
 :- use_module(core(util)).
@@ -136,7 +139,7 @@ server_worker_options([]).
 
 http_options([]).
 
-:- table ignore_ref_and_repo_schema/0.
+:- table ignore_ref_and_repo_schema/0 as shared.
 ignore_ref_and_repo_schema :-
     getenv('TERMINUSDB_IGNORE_REF_AND_REPO_SCHEMA', true).
 
@@ -144,3 +147,24 @@ ignore_ref_and_repo_schema :-
 
 % Turn off mavis
 :- set_prolog_flag(optimise, true).
+
+:- dynamic log_level_override/1.
+
+:- table log_level_env/1 as shared.
+log_level_env(Log_Level) :-
+    getenv_default('TERMINUSDB_LOG_LEVEL', 'INFO', Log_Level_Lower),
+    upcase_atom(Log_Level_Lower, Log_Level).
+
+log_level(Log_Level) :-
+    log_level_override(Log_Level),
+    !.
+log_level(Log_Level) :-
+    log_level_env(Log_Level).
+
+set_log_level(Log_Level) :-
+    memberchk(Log_Level, ['ERROR', 'WARNING', 'NOTICE', 'INFO', 'DEBUG']),
+    clear_log_level,
+    asserta(log_level_override(Log_Level)).
+
+clear_log_level :-
+    retractall(log_level_override(_)).

--- a/src/config/terminus_config.pl
+++ b/src/config/terminus_config.pl
@@ -21,7 +21,10 @@
               file_upload_storage_path/1,
               log_level/1,
               set_log_level/1,
-              clear_log_level/0
+              clear_log_level/0,
+              log_format/1,
+              set_log_format/1,
+              clear_log_format/0
           ]).
 
 :- use_module(core(util)).
@@ -152,14 +155,19 @@ ignore_ref_and_repo_schema :-
 
 :- table log_level_env/1 as shared.
 log_level_env(Log_Level) :-
-    getenv_default('TERMINUSDB_LOG_LEVEL', 'INFO', Log_Level_Lower),
-    upcase_atom(Log_Level_Lower, Log_Level).
+    getenv('TERMINUSDB_LOG_LEVEL', Log_Level_Lower),
+    upcase_atom(Log_Level_Lower, Log_Level),
+    memberchk(Log_Level, ['ERROR', 'WARNING', 'NOTICE', 'INFO', 'DEBUG']),
+    !.
+log_level_env('INFO').
 
 log_level(Log_Level) :-
-    log_level_override(Log_Level),
-    !.
+    log_level_override(Found_Log_Level),
+    !,
+    Log_Level = Found_Log_Level.
 log_level(Log_Level) :-
-    log_level_env(Log_Level).
+    log_level_env(Found_Log_Level),
+    Log_Level = Found_Log_Level.
 
 set_log_level(Log_Level) :-
     memberchk(Log_Level, ['ERROR', 'WARNING', 'NOTICE', 'INFO', 'DEBUG']),
@@ -168,3 +176,29 @@ set_log_level(Log_Level) :-
 
 clear_log_level :-
     retractall(log_level_override(_)).
+
+:- table log_format_env/1 as shared.
+log_format_env(Log_Format) :-
+    getenv('TERMINUSDB_LOG_FORMAT', Log_Format),
+    memberchk(Log_Format, [text, json]),
+    !.
+log_format_env(text).
+
+:- dynamic log_format_override/1.
+
+log_format(Log_Format) :-
+    log_format_override(Found_Log_Format),
+    !,
+    Log_Format = Found_Log_Format.
+log_format(Log_Format) :-
+    log_format_env(Found_Log_Format),
+    !,
+    Log_Format = Found_Log_Format.
+
+set_log_format(Log_Format) :-
+    memberchk(Log_Format, ['text', 'json']),
+    clear_log_format,
+    asserta(log_format_override(Log_Format)).
+
+clear_log_format :-
+    retractall(log_format_override(_)).

--- a/src/core/query/query_response.pl
+++ b/src/core/query/query_response.pl
@@ -24,10 +24,10 @@ run_context_ast_jsonld_response(Context, AST, JSON) :-
             findall(JSON_Binding,
                     (   woql_compile:Prog,
                         get_dict(bindings, Output_Context, Bindings),
-                        * http_log('~N[Bindings] ~q~n', [Bindings]),
+                        * json_log_info_formatted('~N[Bindings] ~q~n', [Bindings]),
                         json_transform_binding_set(Output_Context, Bindings, JSON_Binding)),
                     Binding_Set),
-            * http_log('~N[Binding Set] ~q~n', [Binding_Set])
+            * json_log_info_formatted('~N[Binding Set] ~q~n', [Binding_Set])
         ),
         Meta_Data
     ),

--- a/src/core/query/woql_compile.pl
+++ b/src/core/query/woql_compile.pl
@@ -35,8 +35,6 @@
 :- use_module(library(http/json)).
 :- use_module(library(http/json_convert)).
 :- use_module(library(solution_sequences)).
-:- use_module(library(http/http_log)).
-
 
 :- use_module(library(csv)).
 :- use_module(library(isub)).
@@ -1609,7 +1607,7 @@ compile_wf(triple_count(Path,Count),Goal) -->
                     unliterally(Numerical_Count,CountE))
         )
     }.
-compile_wf(debug_log(Format_String, Arguments), http_log(Format_String, ArgumentsE)) -->
+compile_wf(debug_log(Format_String, Arguments), json_log_info_formatted(Format_String, ArgumentsE)) -->
     resolve(Arguments, ArgumentsE).
 compile_wf(typeof(X,T), typeof(XE,TE)) -->
     resolve(X,XE),

--- a/src/core/transaction/descriptor.pl
+++ b/src/core/transaction/descriptor.pl
@@ -382,7 +382,7 @@ read_write_obj_builder(Read_Write_Obj, Layer_Builder) :-
         open_write(Store, Layer_Builder),
         Layer = (Read_Write_Obj.read),
         nb_apply_delta(Layer_Builder, Layer),
-        json_log_trace_formatted("applied delta!~n", [])
+        json_log_debug_formatted("applied delta!~n", [])
     ;   open_write(Read_Write_Obj.read, Layer_Builder)),
 
     nb_set_dict(write,Read_Write_Obj,Layer_Builder).
@@ -656,6 +656,11 @@ open_descriptor(Descriptor, Commit_Info, Transaction_Object) :-
 open_descriptor(Descriptor, Transaction_Object) :-
     open_descriptor(Descriptor, commit_info{}, Transaction_Object).
 
+log_descriptor_open(_Descriptor) :-
+    % Skip all work if the debug log is not enabled
+    \+ debug_log_enabled,
+    !,
+    true.
 log_descriptor_open(Descriptor) :-
     layer_descriptor{} :< Descriptor,
     % We ignore this type as it's often used as part of an internal
@@ -667,7 +672,7 @@ log_descriptor_open(Descriptor) :-
     ;   Message = "open unprintable descriptor"),
     do_or_die(descriptor_to_loggable(Descriptor, Loggable),
               error(descriptor_sanitize_failed(Descriptor), _)),
-    json_log_trace(_{
+    json_log_debug(_{
                        message: Message,
                        descriptorAction: open,
                        descriptor: Loggable

--- a/src/core/transaction/descriptor.pl
+++ b/src/core/transaction/descriptor.pl
@@ -381,7 +381,7 @@ read_write_obj_builder(Read_Write_Obj, Layer_Builder) :-
         open_write(Store, Layer_Builder),
         Layer = (Read_Write_Obj.read),
         nb_apply_delta(Layer_Builder, Layer),
-        http_log("applied delta!~n", [])
+        json_log_trace_formatted("applied delta!~n", [])
     ;   open_write(Read_Write_Obj.read, Layer_Builder)),
 
     nb_set_dict(write,Read_Write_Obj,Layer_Builder).

--- a/src/core/transaction/validate.pl
+++ b/src/core/transaction/validate.pl
@@ -17,6 +17,7 @@
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+:- use_module(descriptor).
 :- use_module(database).
 :- use_module(layer_entity).
 :- use_module(repo_entity).
@@ -414,8 +415,7 @@ commit_validation_objects_([Object|Objects]) :-
         ;   true),
         append(Validation_Objects, Objects, New_Objects),
         predsort(commit_order, New_Objects, Sorted_Objects),
-        commit_validation_objects_(Sorted_Objects),
-        log_commits(Sorted_Objects)).
+        commit_validation_objects_(Sorted_Objects)).
 commit_validation_objects_([Object|Objects]) :-
     % we know it is a validation object
     commit_validation_object(Object, Transaction_Objects),
@@ -431,7 +431,8 @@ commit_validation_objects(Unsorted_Objects) :-
     % of a commit (adding commit information and repo change info for
     % instance).
     predsort(commit_order,Unsorted_Objects, Sorted_Objects),
-    commit_validation_objects_(Sorted_Objects).
+    commit_validation_objects_(Sorted_Objects),
+    log_commits(Sorted_Objects).
 
 log_commits([]).
 log_commits([First|Rest]) :-

--- a/src/core/transaction/validate.pl
+++ b/src/core/transaction/validate.pl
@@ -35,9 +35,6 @@
 
 :- use_module(library(terminus_store)).
 
-% For debugging
-:- use_module(library(http/http_log)).
-
 /*
  * graph_validation_obj { descriptor: graph_descriptor, read: layer, changed: bool }
  *

--- a/src/core/transaction/validate.pl
+++ b/src/core/transaction/validate.pl
@@ -434,6 +434,11 @@ commit_validation_objects(Unsorted_Objects) :-
     commit_validation_objects_(Sorted_Objects),
     log_commits(Sorted_Objects).
 
+log_commits(_) :-
+    % Skip logging work if debug log is not enabled
+    \+ debug_log_enabled,
+    !,
+    true.
 log_commits([]).
 log_commits([First|Rest]) :-
     Descriptor = (First.descriptor),
@@ -441,7 +446,7 @@ log_commits([First|Rest]) :-
     ->  format(string(Message), "commit descriptor: ~w", [S])
     ;   Message = "commit unprintable descriptor"),
     descriptor_to_loggable(Descriptor, Loggable),
-    json_log_trace(_{
+    json_log_debug(_{
                        message: Message,
                        descriptorAction: commit,
                        descriptor: Loggable

--- a/src/core/util.pl
+++ b/src/core/util.pl
@@ -197,6 +197,8 @@
               json_log_error_formatted/2,
               json_log_warning/1,
               json_log_warning_formatted/2,
+              json_log_notice/1,
+              json_log_notice_formatted/2,
               json_log_info/1,
               json_log_info_formatted/2,
               json_log_debug/1,

--- a/src/core/util.pl
+++ b/src/core/util.pl
@@ -199,8 +199,13 @@
               json_log_warning_formatted/2,
               json_log_info/1,
               json_log_info_formatted/2,
-              json_log_trace/1,
-              json_log_trace_formatted/2
+              json_log_debug/1,
+              json_log_debug_formatted/2,
+              error_log_enabled/0,
+              warning_log_enabled/0,
+              notice_log_enabled/0,
+              info_log_enabled/0,
+              debug_log_enabled/0
           ]).
 
 % note: test_utils is intentionally omitted

--- a/src/core/util.pl
+++ b/src/core/util.pl
@@ -190,7 +190,17 @@
               benchmark/0,
 
               % http_utils.pl
-              basic_authorization/3
+              basic_authorization/3,
+
+              % json_log.pl
+              json_log_error/1,
+              json_log_error_formatted/2,
+              json_log_warning/1,
+              json_log_warning_formatted/2,
+              json_log_info/1,
+              json_log_info_formatted/2,
+              json_log_trace/1,
+              json_log_trace_formatted/2
           ]).
 
 % note: test_utils is intentionally omitted
@@ -204,3 +214,5 @@
 :- use_module(util/benchmark).
 :- use_module(util/http_utils).
 %:- use_module(util/plunit_patch).
+
+:- use_module(util/json_log).

--- a/src/core/util/json_log.pl
+++ b/src/core/util/json_log.pl
@@ -1,0 +1,195 @@
+:- module(json_log, [
+              json_log_error/1,
+              json_log_error_formatted/2,
+              json_log_warning/1,
+              json_log_warning_formatted/2,
+              json_log_info/1,
+              json_log_info_formatted/2,
+              json_log_trace/1,
+              json_log_trace_formatted/2
+          ]).
+
+:- use_module(utils).
+
+:- use_module(library(http/json)).
+:- use_module(library(http/http_stream)).
+:- use_module(library(broadcast)).
+
+:- listen(http(Term), http_request_logger(Term)).
+
+json_log_raw_error(E, Dict) :-
+    % oh no! something went wrong while writing a log entry!
+    % This is usually a programming error, where a variable is fed
+    % into the json writer. We'll log an error here in a known good
+    % format.
+
+    Error_Dict = _{
+                     message: "Error while trying to write a log entry",
+                     loggable: Dict_String,
+                     error: E_String,
+                     severity: "ERROR"
+                 },
+    term_string(Dict, Dict_String),
+    term_string(E, E_String),
+
+    json_write_dict(user_error,
+                    Error_Dict,
+                    [width(0)]),
+    with_output_to(user_error,
+                   nl).
+
+json_log_raw(Dict) :-
+    catch((with_output_to(string(Result),
+                          json_write_dict(current_output,
+                                          Dict,
+                                          [width(0)])),
+           with_output_to(user_error,
+                          (   write(Result),
+                              nl))),
+          E,
+          json_log_raw_error(E, Dict)).
+
+generate_time(Time) :-
+    get_time(Now),
+    format_time(string(Time), '%FT%T.%f%:z', Now).
+
+expand_json_log(Dict, Operation_Id, Severity, Output) :-
+    generate_time(Time),
+    (   var(Operation_Id)
+    ->  Aux = _{
+                  severity: Severity,
+                  timestamp: Time
+              }
+    ;  Aux = _{
+              'logging.googleapis.com/operation': Operation_Id,
+              severity: Severity,
+              timestamp: Time
+          }),
+
+    put_dict(Dict, Aux, Output).
+
+generate_operation_id(Local_Id, Operation_Id) :-
+    server_name(Server_Name),
+    format(string(Operation_Id), "~w-~w", [Server_Name, Local_Id]).
+generate_operation_id_from_stream(CGI, Operation_Id) :-
+    cgi_property(CGI, id(Local_Id)),
+    !,
+    generate_operation_id(Local_Id, Operation_Id).
+generate_operation_id_from_stream(_, _).
+
+generate_operation_id(Operation_Id) :-
+    current_output(Stream),
+    (   is_cgi_stream(Stream)
+    ->  generate_operation_id_from_stream(Stream, Operation_Id)
+    ;   Operation_Id = _).
+
+json_log(Operation_Id, Severity, Loggable) :-
+    \+ is_dict(Loggable),
+    !,
+    format(string(Message), "~w", [Loggable]),
+    Dict = _{message: Message},
+    json_log(Operation_Id, Severity, Dict).
+json_log(Operation_Id, Severity, Dict) :-
+    expand_json_log(Dict, Operation_Id, Severity, Output),
+    json_log_raw(Output).
+json_log(Severity, Loggable) :-
+    generate_operation_id(Operation_Id),
+    json_log(Operation_Id, Severity, Loggable).
+
+json_log_error(Operation_Id, Loggable) :-
+    json_log(Operation_Id, 'ERROR', Loggable).
+json_log_error(Loggable) :-
+    json_log('ERROR', Loggable).
+
+json_log_error_formatted(Format, Arguments) :-
+    format(string(Message), Format, Arguments),
+    json_log_error(Message).
+
+json_log_warning(Operation_Id, Loggable) :-
+    json_log(Operation_Id, 'WARNING', Loggable).
+json_log_warning(Loggable) :-
+    json_log('WARNING', Loggable).
+
+json_log_warning_formatted(Format, Arguments) :-
+    format(string(Message), Format, Arguments),
+    json_log_warning(Message).
+
+json_log_info(Operation_Id, Loggable) :-
+    json_log(Operation_Id, 'INFO', Loggable).
+json_log_info(Loggable) :-
+    json_log('INFO', Loggable).
+
+json_log_info_formatted(Format, Arguments) :-
+    format(string(Message), Format, Arguments),
+    json_log_info(Message).
+
+json_log_trace(Operation_Id, Loggable) :-
+    json_log(Operation_Id, 'TRACE', Loggable).
+json_log_trace(Loggable) :-
+    json_log('TRACE', Loggable).
+
+json_log_trace_formatted(Format, Arguments) :-
+    format(string(Message), Format, Arguments),
+    json_log_trace(Message).
+
+match_http_info(method(Method), Method_Upper, _Protocol, _Host, _Port, _Url_Suffix, _Remote_Ip, _User_Agent, _Size) :-
+    string_upper(Method, Method_Upper).
+match_http_info(protocol(Protocol), _Method, Protocol, _Host, _Port, _Url_Suffix, _Remote_Ip, _User_Agent, _Size).
+match_http_info(host(Host), _Method, _Protocol, Host, _Port, _Url_Suffix, _Remote_Ip, _User_Agent, _Size).
+match_http_info(port(Port), _Method, _Protocol, _Host, Port, _Url_Suffix, _Remote_Ip, _User_Agent, _Size).
+match_http_info(request_uri(Url_Suffix), _Method, _Protocol, _Host, _Port, Url_Suffix, _Remote_Ip, _User_Agent, _Size).
+match_http_info(peer(Peer), _Method, _Protocol, _Host, _Port, _Url_Suffix, Remote_Ip, _User_Agent, _Size) :-
+    % what about ipv6 though?
+    % is there any other sort of peer possible?
+    Peer = ip(N1,N2,N3,N4),
+    format(string(Remote_Ip), "~w.~w.~w.~w", [N1, N2, N3, N4]).
+match_http_info(user_agent(User_Agent), _Method, _Protocol, _Host, _Port, _Url_Suffix, _Remote_Ip, User_Agent, _Size).
+match_http_info(content_length(Size), _Method, _Protocol, _Host, _Port, _Url_Suffix, _Remote_Ip, _User_Agent, Size_String) :-
+    term_string(Size, Size_String).
+match_http_info(_, _Method, _Protocol, _Host, _Port, _Url_Suffix, _Remote_Ip, _User_Agent, _Size).
+
+extract_http_info_([], _Method, _Protocol, _Host, _Port, _Url_Suffix, _Remote_Ip, _User_Agent, _Size).
+extract_http_info_([First|Rest], Method, Protocol, Host, Port, Url_Suffix, Remote_Ip, User_Agent, Size) :-
+    match_http_info(First, Method, Protocol, Host, Port, Url_Suffix, Remote_Ip, User_Agent, Size),
+    !,
+    extract_http_info_(Rest, Method, Protocol, Host, Port, Url_Suffix, Remote_Ip, User_Agent, Size).
+
+extract_http_info(Request, Method, Url, Path, Remote_Ip, User_Agent, Size) :-
+    extract_http_info_(Request, Method, Protocol, Host, Port, Path, Remote_Ip, User_Agent, Size),
+
+    (   var(Port)
+    ->  format(string(Url), "~w://~w~w", [Protocol, Host, Path])
+    ;   format(string(Url), "~w://~w:~w~w", [Protocol, Host, Port, Path])).
+
+http_request_logger(request_start(Local_Id, Request)) :-
+    extract_http_info(Request, Method, Url, Path, Remote_Ip, User_Agent, Size),
+    include([_-V]>>(nonvar(V)), [requestMethod-Method,
+                                 requestUrl-Url,
+                                 requestSize-Size,
+                                 remoteIp-Remote_Ip,
+                                 userAgent-User_Agent
+                                ],
+           Http_Pairs),
+    dict_create(Http, json, Http_Pairs),
+
+    include([_-V]>>(nonvar(V)), [httpRequest-Http,
+                                 path-Path,
+                                 message-"Request started"
+                                ],
+            Dict_Pairs),
+    generate_operation_id(Local_Id, Operation_Id),
+    dict_create(Dict, json, Dict_Pairs),
+    json_log_info(Operation_Id,
+                  Dict).
+
+http_request_logger(request_finished(Local_Id, Code, _Status, _Cpu, Bytes)) :-
+    term_string(Bytes, Bytes_String),
+    generate_operation_id(Local_Id, Operation_Id),
+    json_log_info(Operation_Id,
+                  json{
+                      httpRequest: json{
+                                       status: Code,
+                                       responseSize: Bytes_String
+                                   },
+                      message: "Request completed"
+                  }).

--- a/src/core/util/json_log.pl
+++ b/src/core/util/json_log.pl
@@ -3,6 +3,8 @@
               json_log_error_formatted/2,
               json_log_warning/1,
               json_log_warning_formatted/2,
+              json_log_notice/1,
+              json_log_notice_formatted/2,
               json_log_info/1,
               json_log_info_formatted/2,
               json_log_debug/1,
@@ -141,6 +143,15 @@ json_log_warning(Loggable) :-
 json_log_warning_formatted(Format, Arguments) :-
     format(string(Message), Format, Arguments),
     json_log_warning(Message).
+
+json_log_notice(Operation_Id, Loggable) :-
+    json_log(Operation_Id, 'NOTICE', Loggable).
+json_log_notice(Loggable) :-
+    json_log('NOTICE', Loggable).
+
+json_log_notice_formatted(Format, Arguments) :-
+    format(string(Message), Format, Arguments),
+    json_log_notice(Message).
 
 json_log_info(Operation_Id, Loggable) :-
     json_log(Operation_Id, 'INFO', Loggable).

--- a/src/core/util/json_log.pl
+++ b/src/core/util/json_log.pl
@@ -248,12 +248,14 @@ http_request_logger(request_start(Local_Id, Request)) :-
            Http_Pairs),
     dict_create(Http, json, Http_Pairs),
 
+    generate_operation_id(Local_Id, Operation_Id),
+    format(string(Message), "Request ~w started", [Operation_Id]),
+
     include([_-V]>>(nonvar(V)), [httpRequest-Http,
                                  path-Path,
-                                 message-"Request started"
+                                 message-Message
                                 ],
             Dict_Pairs),
-    generate_operation_id(Local_Id, Operation_Id),
     dict_create(Dict, json, Dict_Pairs),
     json_log_info(first(Operation_Id),
                   Dict).
@@ -261,13 +263,14 @@ http_request_logger(request_start(Local_Id, Request)) :-
 http_request_logger(request_finished(Local_Id, Code, _Status, _Cpu, Bytes)) :-
     term_string(Bytes, Bytes_String),
     generate_operation_id(Local_Id, Operation_Id),
+    format(string(Message), "Request ~w completed", [Operation_Id]),
     json_log_info(last(Operation_Id),
                   json{
                       httpRequest: json{
                                        status: Code,
                                        responseSize: Bytes_String
                                    },
-                      message: "Request completed"
+                      message: Message
                   }).
 
 log_enabled_for_level(Severity) :-

--- a/src/core/util/json_log.pl
+++ b/src/core/util/json_log.pl
@@ -33,7 +33,7 @@ json_log_raw_text_error(E, Dict) :-
     term_string(Dict, Dict_String),
     term_string(E, E_String),
 
-    format(user_error, "Error while trying to write a log entry: ~w (~w)~n", [E_String, Dict_String]).
+    format(user_error, "[ERROR] Error while trying to write a log entry: ~w (~w)~n", [E_String, Dict_String]).
 
 
 json_log_raw_error(E, Dict) :-

--- a/src/core/util/json_log.pl
+++ b/src/core/util/json_log.pl
@@ -61,9 +61,10 @@ json_log_raw(Dict) :-
     config:log_format(text),
     !,
     (   get_dict(message, Dict, Message),
-        get_dict(severity, Dict, Severity)
+        get_dict(severity, Dict, Severity),
+        get_dict(timestamp, Dict, Timestamp)
     ->  with_output_to(user_error,
-                       format("[~w] ~w~n", [Severity, Message]))
+                       format("[~w] ~w ~w~n", [Severity, Timestamp, Message]))
     ;   catch((with_output_to(string(Result),
                               json_write_dict(current_output,
                                               Dict,

--- a/src/interactive.pl
+++ b/src/interactive.pl
@@ -44,8 +44,6 @@ prolog:message(server_missing_config(BasePath)) -->
 :- use_module(core(query/json_woql),[initialise_woql_contexts/0]).
 :- use_module(core(api), [bootstrap_files/0]).
 
-:- use_module(library(http/http_log)).
-
 :- set_test_options([run(manual)]). % ,concurrent(true)]).
 
 :- use_module(cli(main)).

--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -20,7 +20,6 @@
 :- use_module(core(account)).
 
 % http libraries
-:- use_module(library(http/http_log)).
 :- use_module(library(http/http_dispatch)).
 :- use_module(library(http/http_server_files)).
 :- use_module(library(http/html_write)).
@@ -168,7 +167,7 @@ message_handler(_Method, Request, _System_DB, _Auth) :-
         json_write(current_output, Message, [])
     ),
 
-    http_log('~N[Message] ~s~n',[Payload]),
+    json_log_info_formatted('~N[Message] ~s~n',[Payload]),
 
     write_cors_headers(Request),
 
@@ -1867,7 +1866,7 @@ auth_wrapper(Goal,Request) :-
                  www_form_encode(Auth, Domain),
                  call(Goal, [domain(Domain)], Request)),
           error(authentication_incorrect(Reason),_),
-          (   http_log("~NAuthentication Incorrect for reason: ~q~n", [Reason]),
+          (   json_log_error_formatted("~NAuthentication Incorrect for reason: ~q~n", [Reason]),
               reply_json(_{'@type' : 'api:ErrorResponse',
                            'api:status' : 'api:failure',
                            'api:error' : _{'@type' : 'api:IncorrectAuthenticationError'},
@@ -3483,7 +3482,7 @@ cors_handler(Method, Goal, Options, R) :-
                   error(authentication_incorrect(Reason),_),
 
                   (   write_cors_headers(Request),
-                      http_log("~NAuthentication Incorrect for reason: ~q~n", [Reason]),
+                      json_log_error_formatted("~NAuthentication Incorrect for reason: ~q~n", [Reason]),
                       reply_json(_{'@type' : 'api:ErrorResponse',
                                    'api:status' : 'api:failure',
                                    'api:error' : _{'@type' : 'api:IncorrectAuthenticationError'},
@@ -3562,7 +3561,7 @@ customise_exception(error(E)) :-
                  'api:message' : EM},
                [status(500)]).
 customise_exception(error(E, CTX)) :-
-    http_log('~N[Exception] ~q~n',[error(E,CTX)]),
+    json_log_error_formatted('~N[Exception] ~q~n',[error(E,CTX)]),
     (   CTX = context(prolog_stack(Stack),_)
     ->  with_output_to(
             string(Ctx_String),
@@ -3575,7 +3574,7 @@ customise_exception(error(E, CTX)) :-
 customise_exception(http_reply(Obj)) :-
     throw(http_reply(Obj)).
 customise_exception(E) :-
-    http_log('~N[Exception] ~q~n',[E]),
+    json_log_error_formatted('~N[Exception] ~q~n',[E]),
     throw(E).
 
 /*
@@ -3714,7 +3713,6 @@ try_get_param(Key,Request,Value) :-
 
     http_parameters(Request, [], [form_data(Data)]),
 
-    http_log("request: ~q~n", [Request]),
     (   memberchk(Key=Value,Data)
     <>  throw(error(no_parameter_key_in_query_parameters(Key,Data)))),
     !.

--- a/src/start.pl
+++ b/src/start.pl
@@ -44,8 +44,6 @@ prolog:message(server_missing_config(BasePath)) -->
 :- use_module(core(query/json_woql),[initialise_woql_contexts/0]).
 :- use_module(core(api), [bootstrap_files/0]).
 
-:- use_module(library(http/http_log)).
-
 :- set_test_options([run(manual)]).
 
 :- use_module(cli(main)).


### PR DESCRIPTION
This pull request will replace the existing log with a new type.

The new logger allows structured logging of json structures by severity, and will make an effort to associate each log entry with an ongoing request.

Through the environment variable `TERMINUSDB_LOG_LEVEL`, the desired log level can be set. this can be one of DEBUG, INFO, NOTICE, WARNING or ERROR. The default is INFO. Anything below the desired log level is omitted from the log.

Through the environment variable `TERMINUSDB_LOG_FORMAT`, the desired log format can be set. By default this is `text`, which will just print the log severity, a timestamp and the log message (provided those fields exist in the structured log record). By setting it to `json`, the full structured log record is printed instead.

This log format should be compatible with google cloud logging.

Currently, log records are made for the following cases:
- request start (info)
- request end (info)
- descriptor open (debug)
- descriptor commit (debug)
- uncaught errors (error)