### PR TITLE
modify welcome banner to be locale and servername independent

### DIFF
--- a/src/config/terminus_config.pl
+++ b/src/config/terminus_config.pl
@@ -134,9 +134,8 @@ file_upload_storage_path(Path) :-
 
 server(Server) :-
     server_protocol(Protocol),
-    server_name(Name),
     server_port(Port),
-    atomic_list_concat([Protocol,'://',Name,':',Port],Server).
+    atomic_list_concat([Protocol,'://localhost',':',Port],Server).
 
 server_worker_options([]).
 

--- a/src/server/main.pl
+++ b/src/server/main.pl
@@ -107,7 +107,7 @@ loading_page -->
 welcome_banner(Server,Argv) :-
     % Test utils currently reads this so watch out if you change it!
     get_time(Now),
-    format_time(string(StrTime), '%A, %b %d, %H:%M:%S %Z', Now),
+    format_time(string(StrTime), '%A, %b %d, %H:%M:%S %Z', Now, posix),
     format(user_error,'~N% TerminusDB server started at ~w (utime ~w) args ~w~n',
            [StrTime, Now, Argv]),
     format(user_error,'% Welcome to TerminusDB\'s terminusdb-server!~n',[]),


### PR DESCRIPTION
The welcome banner was using server name to build an example url, even though the server name could be wholly unsuitable for that, and is really just meant for identifying purposes in logs. The example url is now hardcoded to localhost.

Furthermore, date printing was locale-dependent, changing the weekday depending on language, which is weird in an otherwise english sentence. It should be locale-independent now.