### PR TITLE
Rename Nightly to Non-Docker

### DIFF
--- a/.github/workflows/non-docker.yml
+++ b/.github/workflows/non-docker.yml
@@ -1,11 +1,9 @@
-# Build and run tests every night of the working week.
-#
-# These mainly exist to test installing TerminusDB on different systems.
-name: Nightly
+# Build and run tests every night on non-Docker systems.
+name: Non-Docker
 
 on:
   schedule:
-    - cron:  '45 1 * * MON-FRI'
+    - cron:  '45 1 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
* It's a less confusing name, since “nightly” could also mean the nightly release of Rust, for example.
* Run every night instead of every weeknight. It doesn't hurt.