### PR TITLE
Error if @key value is not dict

### DIFF
--- a/src/core/api/api_document.pl
+++ b/src/core/api/api_document.pl
@@ -160,6 +160,7 @@ known_document_error(document_key_type_unknown(_)).
 known_document_error(document_key_type_missing(_)).
 known_document_error(subdocument_key_missing).
 known_document_error(key_missing_required_field(_)).
+known_document_error(document_key_not_object(_)).
 
 :- meta_predicate call_catch_document_mutation(+, :).
 call_catch_document_mutation(Document, Goal) :-

--- a/src/core/api/api_error.pl
+++ b/src/core/api/api_error.pl
@@ -1350,6 +1350,16 @@ api_document_error_jsonld(Type, error(subdocument_key_missing(Document),_),JSON)
                               'api:document' : Document },
              'api:message' : Msg
             }.
+api_document_error_jsonld(Type, error(document_key_not_object(Key_Value, Document),_),JSON) :-
+    document_error_type(Type, JSON_Type),
+    format(string(Msg), "Document @key value is not an object: ~q", [Key_Value]),
+    JSON = _{'@type' : JSON_Type,
+             'api:status' : "api:failure",
+             'api:error' : _{ '@type' : 'api:DocumentKeyNotObject',
+                              'api:key_value' : Key_Value,
+                              'api:document' : Document },
+             'api:message' : Msg
+            }.
 api_document_error_jsonld(Type, error(key_missing_required_field(Field,Document),_),JSON) :-
     document_error_type(Type, JSON_Type),
     format(string(Msg), "The required field ~q is missing from the submitted document", [Field]),

--- a/src/core/document/json.pl
+++ b/src/core/document/json.pl
@@ -1022,6 +1022,8 @@ json_schema_predicate_value('@cardinality',V,_,_,P,json{'@type' : Type,
 json_schema_predicate_value('@key',V,Context,Path,P,Value) :-
     !,
     global_prefix_expand(sys:key, P),
+    do_or_die(is_dict(V),
+              error(document_key_not_object(V), _)),
     json_schema_elaborate_key(V,Context,Elab),
     key_id(V,Context,Path,ID),
     put_dict(_{'@id' : ID}, Elab, Value).


### PR DESCRIPTION
Fixes #587.

Here's the new error:

```json
{
    "@type": "api:InsertDocumentErrorResponse",
    "api:error": {
        "@type": "api:DocumentKeyNotObject",
        "api:document": {
            "@id": "X",
            "@key": false,
            "@type": "Class"
        },
        "api:key_value": false
    },
    "api:message": "Document @key value is not an object: false",
    "api:status": "api:failure"
}
```

I've got an integration test:

```js
const r = http.post(`/api/document/${http.user}/dbname?graph_type=schema&author=a&message=m`, {
  json: { '@id': 'X', '@type': 'Class', '@key': false },
})
t.status(r).toEqual(400)
t.hasValidJson(r)
t.json(r, '@type').toEqual('api:InsertDocumentErrorResponse')
t.json(r, 'api:status').toEqual('api:failure')
t.json(r, 'api:error.@type').toEqual('api:DocumentKeyNotObject')
t.json(r, 'api:error.api:key_value').toEqual(false)
t.json(r, 'api:error.api:document.@id').toEqual('X')
t.json(r, 'api:error.api:document.@key').toEqual(false)
t.json(r, 'api:error.api:document.@type').toEqual('Class')
```