### PR TITLE
Better error for duplicate field

### DIFF
--- a/src/core/api/api_error.pl
+++ b/src/core/api/api_error.pl
@@ -1419,6 +1419,11 @@ generic_exception_jsonld(syntax_error(M),JSON) :-
     JSON = _{'api:status' : 'api:failure',
              'system:witnesses' : [_{'@type' : 'vio:ViolationWithDatatypeObject',
                                      'vio:literal' : OM}]}.
+generic_exception_jsonld(duplicate_key(Key), JSON) :-
+    format(string(Msg), "Duplicate field in request: ~q", [Key]),
+    JSON = _{'@type' : 'api:DuplicateField',
+             'api:status' : 'api:failure',
+             'api:message' : Msg}.
 generic_exception_jsonld(woql_syntax_error(JSON,Path,Element),JSON) :-
     json_woql_path_element_error_message(JSON,Path,Element,Message),
     reverse(Path,Director),


### PR DESCRIPTION
Fixes #603

Integration test:

```js
describe('duplicate field (#603)', (t) => {
  const r = http.post('/api/db/u/d', {
    text: '{"comment":"c","comment":"c","label":"l"}',
    headers: { 'Content-Type': 'application/json' },
  })
  t.status(r).toEqual(400)
  t.json(r, '@type').toEqual('api:DuplicateField')
  t.json(r, 'api:status').toEqual('api:failure')
})
```