### PR TITLE
ci: add benchmarking with external machine

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,6 +15,8 @@ jobs:
   benchmark:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'terminusdb'
+    env:
+      SSH_AUTH_SOCK: /tmp/ssh_agent.sock
 
     steps:
       - name: Checkout
@@ -27,8 +29,6 @@ jobs:
           path: terminusdb-http-perf
 
       - name: Add SSH Key
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
         run: |
           mkdir -p ${HOME}/.ssh
           ssh-keyscan "${{ secrets.SSH_HOST }}" >> ${HOME}/.ssh/known_hosts
@@ -39,8 +39,6 @@ jobs:
 
 
       - name: Run benchmark
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
         run: |
           ssh "${{ secrets.SSH_USER }}"@"${{ secrets.SSH_HOST }}" "benchmark $GITHUB_SHA" > data-points.json
 


### PR DESCRIPTION
Instead of running it entirely within Github Actions, we are now running this on a VM somewhere to provide somewhat stable results instead.

I run it on every push to main. Not every pull request is merged so it will mess up our statistics if we run this on every pull request. We should modify it in the future though, so that you know the difference between pull request performance and main before we merge.