### PR TITLE
Adding better back-off numbers

### DIFF
--- a/src/core/transaction/database.pl
+++ b/src/core/transaction/database.pl
@@ -108,8 +108,8 @@ already_committed(Transaction_Object) :-
 partial_commits(Query_Context) :-
     exists(already_committed, Query_Context.transaction_objects).
 
-slot_size(4).
-slot_coefficient(0.25).
+slot_size(2).
+slot_coefficient(0.5).
 slot_time(0.1).
 
 /*


### PR DESCRIPTION
We had numbers that were growing too quickly - for fewer than 10 iterations, we should remain in a very managable backoff with the expectation value of the first 5 rounds remaining less than one second.

Fixes #695 