### PR TITLE
benchmark: only run one job at a time

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   benchmark:
+    concurrency: benchmark
     runs-on: ubuntu-latest
     if: github.repository_owner == 'terminusdb'
     env:


### PR DESCRIPTION
If we want reliable benchmarks, multiple benchmarks shouldn't be run at the same time because this would lead to degraded performance on these benchmarks.
<!--
Thanks for taking the time to contribute!

Is this your first pull request? If you don't mind, please read this first.

<https://github.com/terminusdb/terminusdb/blob/main/docs/CONTRIBUTING.md>
-->
