### PR TITLE
Test stable and devel SWI-Prolog

### DIFF
--- a/.github/install-swi-prolog.sh
+++ b/.github/install-swi-prolog.sh
@@ -1,0 +1,48 @@
+!/usr/bin/env bash
+
+die() {
+  echo >&2 -e "${1-}"
+  exit 1
+}
+
+parse_param() {
+  local release="${1-}"
+  case "$release" in
+    stable | devel)
+      [ "$RUNNER_OS" = "Linux" ] || die "Unsupported: '$release' on '$RUNNER_OS'"
+      ;;
+    homebrew)
+      [ "$RUNNER_OS" = "macOS" ] || die "Unsupported: '$release' on '$RUNNER_OS'"
+      ;;
+    *)
+      die "Unexpected argument: '$release'"
+      ;;
+  esac
+}
+
+do_install() {
+  local release="${1-}"
+  case "$release" in
+    stable | devel)
+      # Install swipl from PPA: https://www.swi-prolog.org/build/PPA.html
+      sudo apt-add-repository "ppa:swi-prolog/$release"
+      sudo apt-get update
+      sudo apt-get install swi-prolog
+      [ "$(which swipl)" = "/usr/bin/swipl" ] || die "swipl command not found"
+      ;;
+    homebrew)
+      # Install swipl from Homebrew: https://www.swi-prolog.org/build/macos.html
+      brew install swi-prolog
+      [ "$(which swipl)" = "/usr/local/bin/swipl" ] || die "swipl command not found"
+      ;;
+    *)
+      die "Unexpected release: '$release'"
+      ;;
+  esac
+}
+
+parse_param "${1-}"
+do_install "${1-}"
+
+echo -n "Installed: "
+swipl --version

--- a/.github/workflows/non-docker.yml
+++ b/.github/workflows/non-docker.yml
@@ -8,19 +8,24 @@ on:
 
 jobs:
 
-  ubuntu:
-    runs-on: ubuntu-latest
+  build-and-test:
+
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            swipl_release: stable
+          - os: ubuntu-latest
+            swipl_release: devel
+          - os: macos-latest
+            swipl_release: homebrew
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install swi-prolog
-        run: |
-          # Installing swipl on Debian: https://www.swi-prolog.org/build/PPA.html
-          sudo apt-add-repository ppa:swi-prolog/stable
-          sudo apt-get update
-          sudo apt-get install swi-prolog
-          swipl --version
+      - run: ./.github/install-swi-prolog.sh ${{ matrix.swipl_release }}
 
       - name: Check out tus
         uses: actions/checkout@v2
@@ -37,34 +42,4 @@ jobs:
 
       - run: make
 
-      - run: ./terminusdb test
-
-  macos:
-    runs-on: macos-latest
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install swi-prolog
-        run: |
-          # Installing swipl on macOS: https://www.swi-prolog.org/build/macos.html
-          brew install swi-prolog
-          swipl --version
-
-      - name: Check out tus
-        uses: actions/checkout@v2
-        with:
-          repository: terminusdb/tus
-          path: tus
-          ref: v0.0.5
-
-      - name: Install tus
-        run: swipl -g "pack_install('file://$GITHUB_WORKSPACE/tus', [interactive(false)])"
-
-      - name: Install terminus_store_prolog
-        run: swipl -g "pack_install(terminus_store_prolog, [interactive(false), upgrade(true)])"
-
-      - run: make
-
-        # This can take a long time to run (12 - 20 minutes).
       - run: ./terminusdb test


### PR DESCRIPTION
* `non-docker.yml`: install script for SWI-Prolog on all systems
* Test both `stable` and `devel` releases on `ubuntu-latest`

<!--
Thanks for taking the time to contribute!

Is this your first pull request? If you don't mind, please read this first.

<https://github.com/terminusdb/terminusdb/blob/main/docs/CONTRIBUTING.md>
-->
