### PR TITLE
non-docker: Run all jobs even when some jobs fail

### DIFF
--- a/.github/workflows/non-docker.yml
+++ b/.github/workflows/non-docker.yml
@@ -11,6 +11,8 @@ jobs:
   build-and-test:
 
     strategy:
+      # Run all jobs even when some jobs fail.
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest


### PR DESCRIPTION
In [this run](https://github.com/terminusdb/terminusdb/actions/runs/1392785673), the `(ubuntu-latest, devel)` job was canceled because the `(macos-latest, homebrew)` job failed. This PR changes it so that all jobs are run even though some may fail.