### PR TITLE
tests: Use .then() with verify functions

### DIFF
--- a/tests/lib/branch.js
+++ b/tests/lib/branch.js
@@ -4,6 +4,7 @@ function verifyFailure (r) {
   expect(r.status).to.equal(400)
   expect(r.body['api:status']).to.equal('api:failure')
   expect(r.body['@type']).to.equal('api:BranchErrorResponse')
+  return r
 }
 
 module.exports = {

--- a/tests/lib/db.js
+++ b/tests/lib/db.js
@@ -36,30 +36,35 @@ function verifyCreateSuccess (r) {
   expect(r.status).to.equal(200)
   expect(r.body['api:status']).to.equal('api:success')
   expect(r.body['@type']).to.equal('api:DbCreateResponse')
+  return r
 }
 
 function verifyCreateFailure (r) {
   expect(r.status).to.equal(400)
   expect(r.body['@type']).to.equal('api:DbCreateErrorResponse')
   expect(r.body['api:status']).to.equal('api:failure')
+  return r
 }
 
 function verifyDeleteSuccess (r) {
   expect(r.status).to.equal(200)
   expect(r.body['api:status']).to.equal('api:success')
   expect(r.body['@type']).to.equal('api:DbDeleteResponse')
+  return r
 }
 
 function verifyDeleteFailure (r) {
   expect(r.status).to.equal(400)
   expect(r.body['api:status']).to.equal('api:failure')
   expect(r.body['@type']).to.equal('api:DbDeleteErrorResponse')
+  return r
 }
 
 function verifyDeleteNotFound (r) {
   expect(r.status).to.equal(404)
   expect(r.body['api:status']).to.equal('api:not_found')
   expect(r.body['@type']).to.equal('api:DbDeleteErrorResponse')
+  return r
 }
 
 module.exports = {

--- a/tests/lib/document.js
+++ b/tests/lib/document.js
@@ -111,18 +111,21 @@ function verifyInsertSuccess (r) {
     expect(r.body.length).to.equal(1)
     verifyId(r.request._data['@id'], r.body[0])
   }
+  return r
 }
 
 function verifyInsertFailure (r) {
   expect(r.status).to.equal(400)
   expect(r.body['api:status']).to.equal('api:failure')
   expect(r.body['@type']).to.equal('api:InsertDocumentErrorResponse')
+  return r
 }
 
 function verifyReplaceFailure (r) {
   expect(r.status).to.equal(400)
   expect(r.body['api:status']).to.equal('api:failure')
   expect(r.body['@type']).to.equal('api:ReplaceDocumentErrorResponse')
+  return r
 }
 
 module.exports = {

--- a/tests/test/branch-auth.js
+++ b/tests/test/branch-auth.js
@@ -14,7 +14,7 @@ describe('branch', function () {
     const r = await agent
       .post(path)
       .send({ origin: originDescriptor })
-    branch.verifyFailure(r)
+      .then(branch.verifyFailure)
     expect(r.body['api:error']['@type']).to.equal('api:BadOriginAbsoluteDescriptor')
     expect(r.body['api:error']['api:absolute_descriptor']).to.equal(originDescriptor)
   })
@@ -25,7 +25,7 @@ describe('branch', function () {
     const r = await agent
       .post(path)
       .send({ origin: `${orgName}/${originDbName}` })
-    branch.verifyFailure(r)
+      .then(branch.verifyFailure)
     expect(r.body['api:error']['@type']).to.equal('api:UnknownOriginDatabase')
     expect(r.body['api:error']['api:organization_name']).to.equal(orgName)
     expect(r.body['api:error']['api:database_name']).to.equal(originDbName)

--- a/tests/test/branch-noauth.js
+++ b/tests/test/branch-noauth.js
@@ -12,7 +12,7 @@ describe('branch-noauth', function () {
     const r = await agent
       .post('/api/branch/unknowndesc')
       .send({})
-    branch.verifyFailure(r)
+      .then(branch.verifyFailure)
     expect(r.body['api:error']['@type']).to.equal('api:BadTargetAbsoluteDescriptor')
     expect(r.body['api:error']['api:absolute_descriptor']).to.equal('unknowndesc')
   })

--- a/tests/test/db-auth.js
+++ b/tests/test/db-auth.js
@@ -15,8 +15,9 @@ describe('db', function () {
     await db.delUnverified(agent, path)
 
     // Delete the same database.
-    const r = await db.del(agent, path)
-    db.verifyDeleteNotFound(r)
+    const r = await db
+      .del(agent, path)
+      .then(db.verifyDeleteNotFound)
     expect(r.body['api:error']['@type']).to.equal('api:UnknownDatabase')
     expect(r.body['api:error']['api:organization_name']).to.equal(orgName)
     expect(r.body['api:error']['api:database_name']).to.equal(dbName)

--- a/tests/test/db-noauth.js
+++ b/tests/test/db-noauth.js
@@ -47,14 +47,16 @@ describe('db-noauth', function () {
     )
 
     {
-      const r = await db.create(agent, path)
-      db.verifyCreateFailure(r)
+      const r = await db
+        .create(agent, path)
+        .then(db.verifyCreateFailure)
       expect(r.body['api:error']['@type']).to.equal('api:UnknownOrganization')
       expect(r.body['api:error']['api:organization_name']).to.equal(orgName)
     }
     {
-      const r = await db.del(agent, path)
-      db.verifyDeleteFailure(r)
+      const r = await db
+        .del(agent, path)
+        .then(db.verifyDeleteFailure)
       expect(r.body['api:error']['@type']).to.equal('api:UnknownOrganization')
       expect(r.body['api:error']['api:organization_name']).to.equal(orgName)
     }

--- a/tests/test/document-auth.js
+++ b/tests/test/document-auth.js
@@ -26,8 +26,9 @@ describe('document', function () {
 
     it('disallows Class with empty @id string (#647)', async function () {
       const schema = { '@id': '', '@type': 'Class' }
-      const r = await document.insert(agent, docPath, { schema: schema })
-      document.verifyInsertFailure(r)
+      const r = await document
+        .insert(agent, docPath, { schema: schema })
+        .then(document.verifyInsertFailure)
       expect(r.body['api:error']['@type']).to.equal('api:EmptyKey')
       expect(r.body['api:error']['api:document']).to.deep.equal(schema)
     })
@@ -71,16 +72,18 @@ describe('document', function () {
       const schema = { '@type': 'Class', '@subdocument': [] }
       {
         schema['@id'] = util.randomString()
-        const r = await document.insert(agent, docPath, { schema: schema })
-        document.verifyInsertFailure(r)
+        const r = await document
+          .insert(agent, docPath, { schema: schema })
+          .then(document.verifyInsertFailure)
         expect(r.body['api:error']['@type']).to.equal('api:SubdocumentKeyMissing')
         expect(r.body['api:error']['api:document']['@id']).to.equal(schema['@id'])
       }
       {
         schema['@id'] = util.randomString()
         schema['@key'] = { useless_key: 'useless_value' }
-        const r = await document.insert(agent, docPath, { schema: schema })
-        document.verifyInsertFailure(r)
+        const r = await document
+          .insert(agent, docPath, { schema: schema })
+          .then(document.verifyInsertFailure)
         expect(r.body['api:error']['@type']).to.equal('api:DocumentKeyTypeMissing')
         expect(r.body['api:error']['api:document']['@id']).to.equal(schema['@id'])
         expect(JSON.parse(r.body['api:error']['api:key'])).to.deep.equal(schema['@key'])
@@ -88,8 +91,9 @@ describe('document', function () {
       {
         schema['@id'] = util.randomString()
         schema['@key'] = { '@type': 'Unknown' }
-        const r = await document.insert(agent, docPath, { schema: schema })
-        document.verifyInsertFailure(r)
+        const r = await document
+          .insert(agent, docPath, { schema: schema })
+          .then(document.verifyInsertFailure)
         expect(r.body['api:error']['@type']).to.equal('api:DocumentKeyTypeUnknown')
         expect(r.body['api:error']['api:document']['@id']).to.equal(schema['@id'])
         expect(r.body['api:error']['api:key_type']).to.equal(schema['@key']['@type'])
@@ -98,9 +102,9 @@ describe('document', function () {
 
     it('fails when @key value is not an object (#587)', async function () {
       const schema = { '@id': util.randomString(), '@type': 'Class', '@key': false }
-      const r = await document.insert(agent, docPath, { schema: schema })
-
-      document.verifyInsertFailure(r)
+      const r = await document
+        .insert(agent, docPath, { schema: schema })
+        .then(document.verifyInsertFailure)
       expect(r.body['api:error']['@type']).to.equal('api:DocumentKeyNotObject')
       expect(r.body['api:error']['api:key_value']).to.equal(false)
       expect(r.body['api:error']['api:document']['@id']).to.equal(schema['@id'])
@@ -154,7 +158,7 @@ describe('document', function () {
               ref: badValue,
             },
           })
-        document.verifyInsertFailure(r)
+          .then(document.verifyInsertFailure)
         expect(r.body['api:error']['@type']).to.equal('api:MissingTypeField')
         expect(r.body['api:error']['api:document']).to.deep.equal(badValue)
       }
@@ -167,7 +171,7 @@ describe('document', function () {
               ref: badValue,
             },
           })
-        document.verifyReplaceFailure(r)
+          .then(document.verifyReplaceFailure)
         expect(r.body['api:error']['@type']).to.equal('api:MissingTypeField')
         expect(r.body['api:error']['api:document']).to.deep.equal(badValue)
       }
@@ -182,10 +186,11 @@ describe('document', function () {
         })
         .then(document.verifyInsertSuccess)
       const badValue = ['a', 'b']
-      const r = await document.insert(agent, docPath, {
-        instance: { '@type': type, s: badValue },
-      })
-      document.verifyInsertFailure(r)
+      const r = await document
+        .insert(agent, docPath, {
+          instance: { '@type': type, s: badValue },
+        })
+        .then(document.verifyInsertFailure)
       expect(r.body['api:error']['@type']).to.equal('api:UnexpectedArrayValue')
       expect(r.body['api:error']['api:value']).to.deep.equal(badValue)
       expect(r.body['api:error']['api:expected_type']).to.equal(expectedType)
@@ -204,7 +209,7 @@ describe('document', function () {
           .insert(agent, docPath, {
             instance: { '@type': type, s: value },
           })
-        document.verifyInsertFailure(r)
+          .then(document.verifyInsertFailure)
         expect(r.body['api:error']['@type']).to.equal('api:UnexpectedBooleanValue')
         expect(r.body['api:error']['api:value']).to.equal(value)
         expect(r.body['api:error']['api:expected_type']).to.equal(expectedType)
@@ -234,6 +239,7 @@ describe('document', function () {
         .get(agent, docPath, {
           id: id,
         })
+        .then(document.verifyGetSuccess)
       expect(r.body['@id']).to.equal(id)
       expect(r.body['@type']).to.equal(type)
       expect(r.body.bfalse).to.equal(false)


### PR DESCRIPTION
Return the response with verify functions to allow a more natural way of verifying the response.
