### PR TITLE
Add tests for `prefixed`

### DIFF
--- a/src/core/api/api_document.pl
+++ b/src/core/api/api_document.pl
@@ -68,15 +68,15 @@ api_generate_document_uris_by_type_(schema, Transaction, Type, Skip, Count, Uri)
         Skip,
         Count).
 
-api_generate_documents_(instance, Transaction, Prefixed, Unfold, Skip, Count, Document) :-
+api_generate_documents_(instance, Transaction, Compress, Unfold, Skip, Count, Document) :-
     api_generate_document_uris_(instance, Transaction, Unfold, Skip, Count, Uri),
-    get_document(Transaction, Prefixed, Unfold, Uri, Document).
+    get_document(Transaction, Compress, Unfold, Uri, Document).
 
 api_generate_documents_(schema, Transaction, _Prefixed, Unfold, Skip, Count, Document) :-
     api_generate_document_uris_(schema, Transaction, Unfold, Skip, Count, Uri),
     get_schema_document(Transaction, Uri, Document).
 
-api_generate_documents(SystemDB, Auth, Path, Schema_Or_Instance, Prefixed, Unfold, Skip, Count, Document) :-
+api_generate_documents(SystemDB, Auth, Path, Schema_Or_Instance, Compress, Unfold, Skip, Count, Document) :-
     do_or_die(
         resolve_absolute_string_descriptor(Path, Descriptor),
         error(invalid_path(Path),_)),
@@ -86,16 +86,16 @@ api_generate_documents(SystemDB, Auth, Path, Schema_Or_Instance, Prefixed, Unfol
     do_or_die(open_descriptor(Descriptor, Transaction),
               error(unresolvable_collection(Descriptor), _)),
 
-    api_generate_documents_(Schema_Or_Instance, Transaction, Prefixed, Unfold, Skip, Count, Document).
+    api_generate_documents_(Schema_Or_Instance, Transaction, Compress, Unfold, Skip, Count, Document).
 
 api_generate_documents_by_type_(schema, Transaction, Type, _Prefixed, _Unfold, Skip, Count, Document) :-
     api_generate_document_uris_by_type_(schema, Transaction, Type, Skip, Count, Uri),
     get_schema_document(Transaction, Uri, Document).
-api_generate_documents_by_type_(instance, Transaction, Type, Prefixed, Unfold, Skip, Count, Document) :-
+api_generate_documents_by_type_(instance, Transaction, Type, Compress, Unfold, Skip, Count, Document) :-
     api_generate_document_uris_by_type_(instance, Transaction, Type, Skip, Count, Uri),
-    get_document(Transaction, Prefixed, Unfold, Uri, Document).
+    get_document(Transaction, Compress, Unfold, Uri, Document).
 
-api_generate_documents_by_type(SystemDB, Auth, Path, Graph_Type, Prefixed, Unfold, Type, Skip, Count, Document) :-
+api_generate_documents_by_type(SystemDB, Auth, Path, Graph_Type, Compress, Unfold, Type, Skip, Count, Document) :-
     do_or_die(
         resolve_absolute_string_descriptor(Path, Descriptor),
         error(invalid_path(Path),_)),
@@ -105,9 +105,9 @@ api_generate_documents_by_type(SystemDB, Auth, Path, Graph_Type, Prefixed, Unfol
     do_or_die(open_descriptor(Descriptor, Transaction),
               error(unresolvable_collection(Descriptor), _)),
 
-    api_generate_documents_by_type_(Graph_Type, Transaction, Type, Prefixed, Unfold, Skip, Count, Document).
+    api_generate_documents_by_type_(Graph_Type, Transaction, Type, Compress, Unfold, Skip, Count, Document).
 
-api_generate_documents_by_query(SystemDB, Auth, Path, Graph_Type, Prefixed, Unfold, Type, Query, Skip, Count, Document) :-
+api_generate_documents_by_query(SystemDB, Auth, Path, Graph_Type, Compress, Unfold, Type, Query, Skip, Count, Document) :-
     do_or_die(
         resolve_absolute_string_descriptor(Path, Descriptor),
         error(invalid_path(Path),_)),
@@ -124,17 +124,17 @@ api_generate_documents_by_query(SystemDB, Auth, Path, Graph_Type, Prefixed, Unfo
         match_query_document_uri(Transaction, Type, Query, Uri),
         Skip,
         Count),
-    get_document(Transaction, Prefixed, Unfold, Uri, Document).
+    get_document(Transaction, Compress, Unfold, Uri, Document).
 
-api_get_document_(instance, Transaction, Prefixed, Unfold, Id, Document) :-
-    do_or_die(get_document(Transaction, Prefixed, Unfold, Id, Document),
+api_get_document_(instance, Transaction, Compress, Unfold, Id, Document) :-
+    do_or_die(get_document(Transaction, Compress, Unfold, Id, Document),
               error(document_not_found(Id), _)).
 
 api_get_document_(schema, Transaction, _Prefixed, _Unfold, Id, Document) :-
     do_or_die(get_schema_document(Transaction, Id, Document),
               error(document_not_found(Id), _)).
 
-api_get_document(SystemDB, Auth, Path, Schema_Or_Instance, Prefixed, Unfold, Id, Document) :-
+api_get_document(SystemDB, Auth, Path, Schema_Or_Instance, Compress, Unfold, Id, Document) :-
     do_or_die(
         resolve_absolute_string_descriptor(Path, Descriptor),
         error(invalid_path(Path),_)),
@@ -143,7 +143,7 @@ api_get_document(SystemDB, Auth, Path, Schema_Or_Instance, Prefixed, Unfold, Id,
 
     do_or_die(open_descriptor(Descriptor, Transaction),
               error(unresolvable_collection(Descriptor), _)),
-    api_get_document_(Schema_Or_Instance, Transaction, Prefixed, Unfold, Id, Document).
+    api_get_document_(Schema_Or_Instance, Transaction, Compress, Unfold, Id, Document).
 
 embed_document_in_error(Error, Document, New_Error) :-
     Error =.. Error_List,

--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -779,7 +779,7 @@ document_handler(get, Path, Request, System_DB, Auth) :-
             param_value_search_or_json_optional(Search, JSON, count, nonnegative_integer, unlimited, Count),
             param_value_search_or_json_optional(Search, JSON, minimized, boolean, true, Minimized),
             param_value_search_or_json_optional(Search, JSON, as_list, boolean, false, As_List),
-            param_value_search_or_json_optional(Search, JSON, prefixed, boolean, true, Prefixed),
+            param_value_search_or_json_optional(Search, JSON, prefixed, boolean, true, Compress),
             param_value_search_or_json_optional(Search, JSON, unfold, boolean, true, Unfold),
             param_value_search_or_json_optional(Search, JSON, id, atom, _, Id),
             param_value_search_or_json_optional(Search, JSON, type, atom, _, Type),
@@ -792,15 +792,15 @@ document_handler(get, Path, Request, System_DB, Auth) :-
 
             Header_Written = written(_),
             (   nonvar(Query) % dictionaries do not need tags to be bound
-            ->  forall(api_generate_documents_by_query(System_DB, Auth, Path, Graph_Type, Prefixed, Unfold, Type, Query, Skip, Count, Document),
+            ->  forall(api_generate_documents_by_query(System_DB, Auth, Path, Graph_Type, Compress, Unfold, Type, Query, Skip, Count, Document),
                        json_write_with_header(Request, Document, Header_Written, As_List, JSON_Options))
             ;   ground(Id)
-            ->  api_get_document(System_DB, Auth, Path, Graph_Type, Prefixed, Unfold, Id, Document),
+            ->  api_get_document(System_DB, Auth, Path, Graph_Type, Compress, Unfold, Id, Document),
                 json_write_with_header(Request, Document, Header_Written, As_List, JSON_Options)
             ;   ground(Type)
-            ->  forall(api_generate_documents_by_type(System_DB, Auth, Path, Graph_Type, Prefixed, Unfold, Type, Skip, Count, Document),
+            ->  forall(api_generate_documents_by_type(System_DB, Auth, Path, Graph_Type, Compress, Unfold, Type, Skip, Count, Document),
                        json_write_with_header(Request, Document, Header_Written, As_List, JSON_Options))
-            ;   forall(api_generate_documents(System_DB, Auth, Path, Graph_Type, Prefixed, Unfold, Skip, Count, Document),
+            ;   forall(api_generate_documents(System_DB, Auth, Path, Graph_Type, Compress, Unfold, Skip, Count, Document),
                        json_write_with_header(Request, Document, Header_Written, As_List, JSON_Options))),
 
             % ensure the header has been written by now.

--- a/tests/lib/document.js
+++ b/tests/lib/document.js
@@ -12,6 +12,7 @@ function commonGetParams (params) {
   result.id = params.string('id')
   result.count = params.integer('count')
   result.skip = params.integer('skip')
+  result.prefixed = params.boolean('prefixed')
   params.assertEmpty()
   return result
 }

--- a/tests/lib/util.js
+++ b/tests/lib/util.js
@@ -2,6 +2,10 @@
 
 const crypto = require('crypto')
 
+function deepClone (object) {
+  return JSON.parse(JSON.stringify(object))
+}
+
 function isBoolean (val) {
   return typeof val === 'boolean'
 }
@@ -27,6 +31,7 @@ function randomString () {
 }
 
 module.exports = {
+  deepClone,
   isBoolean,
   isInteger,
   isNonNegativeInteger,


### PR DESCRIPTION
* Add tests for the `prefixed` parameter for `graph_type=instance`
* Rename `Prefix` to `Compress` in `api_document.pl`

`prefixed` does not currently work with `graph_type=schema`. That issue is tracked in #801.