### PR TITLE
Introduce mock header

### DIFF
--- a/src/cli/main.pl
+++ b/src/cli/main.pl
@@ -561,7 +561,6 @@ command_subcommand(Command,Subcommand) :-
     opt_spec(Command,Subcommand,_,_,_).
 
 run(Argv) :-
-    check_env_vars,
     (   (   Argv = [Cmd|_],
             member(Cmd, [help, store, test])
         ;   open_descriptor(system_descriptor{}, _))

--- a/src/cli/main.pl
+++ b/src/cli/main.pl
@@ -561,6 +561,7 @@ command_subcommand(Command,Subcommand) :-
     opt_spec(Command,Subcommand,_,_,_).
 
 run(Argv) :-
+    check_env_vars,
     (   (   Argv = [Cmd|_],
             member(Cmd, [help, store, test])
         ;   open_descriptor(system_descriptor{}, _))

--- a/src/config/terminus_config.pl
+++ b/src/config/terminus_config.pl
@@ -23,7 +23,8 @@
               clear_log_level/0,
               log_format/1,
               set_log_format/1,
-              clear_log_format/0
+              clear_log_format/0,
+              check_env_vars/0
           ]).
 
 :- use_module(core(util)).
@@ -188,3 +189,14 @@ set_log_format(Log_Format) :-
 
 clear_log_format :-
     retractall(log_format_override(_)).
+
+check_insecure_user_header :-
+    getenv('TERMINUSDB_INSECURE_USER_HEADER', Value),
+    (   re_match("[A-Za-z0-9-]+", Value)
+    ->  true
+    ;   throw(error(invalid_insecure_user_header(Value)))).
+
+check_env_vars :-
+    (   getenv('TERMINUSDB_INSECURE_USER_HEADER_ENABLED', true)
+    ->  check_insecure_user_header
+    ;   true).

--- a/src/config/terminus_config.pl
+++ b/src/config/terminus_config.pl
@@ -5,6 +5,7 @@
               server_name/1,
               server_port/1,
               worker_amount/1,
+              user_forwarded_header/1,
               max_transaction_retries/1,
               index_template/1,
               default_database_path/1,
@@ -51,6 +52,13 @@ server_port(Value) :-
 
 worker_amount(Value) :-
     getenv_default_number('TERMINUSDB_SERVER_WORKERS', 8, Value).
+
+user_forwarded_header(Functor) :-
+    getenv('TERMINUSDB_INSECURE_MODE', _),
+    getenv('TERMINUSDB_FORWARDED_USER_HEADER', Value),
+    string_lower(Value, LowerString),
+    re_replace("-"/g, "_", LowerString, LowerStringNoDashes),
+    atom_string(Functor, LowerStringNoDashes).
 
 :- table max_transaction_retries/1 as shared.
 max_transaction_retries(Value) :-

--- a/src/config/terminus_config.pl
+++ b/src/config/terminus_config.pl
@@ -30,6 +30,8 @@
 :- use_module(core(util)).
 
 version('10.0.13').
+env_insecure_user_header('TERMINUSDB_INSECURE_USER_HEADER').
+env_insecure_user_header_enabled('TERMINUSDB_INSECURE_USER_HEADER_ENABLED').
 
 bootstrap_config_files :-
     initialize_system_ssl_certs.
@@ -55,8 +57,10 @@ worker_amount(Value) :-
     getenv_default_number('TERMINUSDB_SERVER_WORKERS', 8, Value).
 
 insecure_user_header(Header_Key) :-
-    getenv('TERMINUSDB_INSECURE_USER_HEADER_ENABLED', true),
-    getenv('TERMINUSDB_INSECURE_USER_HEADER', Value),
+    env_insecure_user_header_enabled(Env_Insecure_User_Header_Enabled),
+    getenv(Env_Insecure_User_Header_Enabled, true),
+    env_insecure_user_header(Env_Insecure_User_Header),
+    getenv(Env_Insecure_User_Header, Value),
     string_lower(Value, Lower_String),
     re_replace("-"/g, "_", Lower_String, Lower_String_No_Dashes),
     atom_string(Header_Key, Lower_String_No_Dashes).
@@ -191,12 +195,14 @@ clear_log_format :-
     retractall(log_format_override(_)).
 
 check_insecure_user_header :-
-    getenv('TERMINUSDB_INSECURE_USER_HEADER', Value),
+    env_insecure_user_header(Env_Insecure_User_Header),
+    getenv(Env_Insecure_User_Header, Value),
     (   re_match("[A-Za-z0-9-]+", Value)
     ->  true
     ;   throw(error(invalid_insecure_user_header(Value)))).
 
 check_env_vars :-
-    (   getenv('TERMINUSDB_INSECURE_USER_HEADER_ENABLED', true)
+    env_insecure_user_header_enabled(Env_Insecure_User_Header_Enabled),
+    (   getenv(Env_Insecure_User_Header_Enabled, true)
     ->  check_insecure_user_header
     ;   true).

--- a/src/config/terminus_config.pl
+++ b/src/config/terminus_config.pl
@@ -5,7 +5,7 @@
               server_name/1,
               server_port/1,
               worker_amount/1,
-              user_forwarded_header/1,
+              insecure_user_header/1,
               max_transaction_retries/1,
               index_template/1,
               default_database_path/1,
@@ -53,12 +53,12 @@ server_port(Value) :-
 worker_amount(Value) :-
     getenv_default_number('TERMINUSDB_SERVER_WORKERS', 8, Value).
 
-user_forwarded_header(Functor) :-
-    getenv('TERMINUSDB_INSECURE_MODE', _),
-    getenv('TERMINUSDB_FORWARDED_USER_HEADER', Value),
-    string_lower(Value, LowerString),
-    re_replace("-"/g, "_", LowerString, LowerStringNoDashes),
-    atom_string(Functor, LowerStringNoDashes).
+insecure_user_header(Header_Key) :-
+    getenv('TERMINUSDB_INSECURE_USER_HEADER_ENABLED', true),
+    getenv('TERMINUSDB_INSECURE_USER_HEADER', Value),
+    string_lower(Value, Lower_String),
+    re_replace("-"/g, "_", Lower_String, Lower_String_No_Dashes),
+    atom_string(Header_Key, Lower_String_No_Dashes).
 
 :- table max_transaction_retries/1 as shared.
 max_transaction_retries(Value) :-

--- a/src/core/util/test_utils.pl
+++ b/src/core/util/test_utils.pl
@@ -430,7 +430,11 @@ spawn_server_1(Path, URL, PID, Options) :-
         'TERMINUSDB_SERVER_JWKS_ENDPOINT'='https://cdn.terminusdb.com/jwks.json'
     ],
 
-    inherit_env_vars(Env_List_1,
+    (   memberchk(env_vars(Env_List_User), Options)
+    ->  append(Env_List_1, Env_List_User, Combined_Env_List)
+    ;   Combined_Env_List = Env_List_1),
+
+    inherit_env_vars(Combined_Env_List,
                      [
                          'HOME',
                          'SystemRoot', % Windows specific stuff...

--- a/src/server/main.pl
+++ b/src/server/main.pl
@@ -49,6 +49,7 @@ load_jwt_conditionally :-
 
 
 terminus_server(Argv,Wait) :-
+    check_env_vars,
     config:server(Server),
     config:server_port(Port),
     config:worker_amount(Workers),

--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -146,8 +146,8 @@ test(connection_authorised_user_http_basic, [
 
 test(connection_authorised_user_forwarded_header, [
          setup(setup_temp_server(State, Server, [env_vars([
-                                     'TERMINUSDB_INSECURE_MODE'=1,
-                                     'TERMINUSDB_FORWARDED_USER_HEADER'='X-Forwarded-User'
+                                     'TERMINUSDB_INSECURE_USER_HEADER_ENABLED'=true,
+                                     'TERMINUSDB_INSECURE_USER_HEADER'='X-Forwarded-User'
                                  ])])),
          cleanup(teardown_temp_server(State))
      ]) :-
@@ -160,8 +160,8 @@ test(connection_authorised_user_forwarded_header, [
 
 test(connection_unauthorised_user_forwarded_header, [
          setup(setup_temp_server(State, Server, [env_vars([
-                                     'TERMINUSDB_INSECURE_MODE'=1,
-                                     'TERMINUSDB_FORWARDED_USER_HEADER'='X-Forwarded-User'
+                                     'TERMINUSDB_INSECURE_USER_HEADER_ENABLED'=true,
+                                     'TERMINUSDB_INSECURE_USER_HEADER'='X-Forwarded-User'
                                  ])])),
          cleanup(teardown_temp_server(State))
      ]) :-
@@ -3675,23 +3675,23 @@ authenticate(System_Askable, Request, Auth) :-
                        user: Username
                    }).
 authenticate(System_Askable, Request, Auth) :-
-    user_forwarded_header(Functor),
-    Term =.. [Functor, Username],
+    insecure_user_header(Header_Key),
+    Term =.. [Header_Key, Username],
     memberchk(Term, Request),
     (   username_auth(System_Askable, Username, Auth)
     ->  true
-    ;   format(string(Message), "User and header '~w and ~w' failed to authenticate", [Functor, Username]),
+    ;   format(string(Message), "User '~w' failed to authenticate with header '~w'", [Username, Header_Key]),
         json_log_debug(_{
                            message: Message,
-                           authMethod: forwarded_user_header,
+                           authMethod: insecure_user_header,
                            authResult: failure,
                            user: Username
                        }),
-        throw(error(authentication_incorrect(forwarded_header_no_user_with_name(Username)),_))),
-    format(string(Message), "User '~w' authenticated through the header ~w", [Username, Functor]),
+        throw(error(authentication_incorrect(insecure_user_header_no_user_with_name(Username)),_))),
+    format(string(Message), "User '~w' authenticated with header '~w'", [Username, Header_Key]),
     json_log_debug(_{
                        message: Message,
-                       authMethod: forwarded_user_header,
+                       authMethod: insecure_user_header,
                        authResult: success,
                        user: Username
                    }).

--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -3691,7 +3691,7 @@ authenticate(System_Askable, Request, Auth) :-
     format(string(Message), "User '~w' authenticated through the header ~w", [Username, Functor]),
     json_log_debug(_{
                        message: Message,
-                       authMethod: jwt,
+                       authMethod: forwarded_user_header,
                        authResult: success,
                        user: Username
                    }).


### PR DESCRIPTION
Some systems can be setup in such a way to offload user authentication. For instance, you could set up TerminusDB in a protected environment and use oauth2-proxy to secure it.

Therefore we now allow an insecure mode to be set in conjunction with a custom user header to authenticate.

The ENV variables required for this functionality are:

TERMINUSDB_INSECURE_MODE which has to be set to a value and TERMINUSDB_FORWARDED_USER_HEADER with the name of the HTTP header which contains the username.
