### PR TITLE
Add insecure user header for authentication

### DIFF
--- a/src/cli/main.pl
+++ b/src/cli/main.pl
@@ -561,6 +561,8 @@ command_subcommand(Command,Subcommand) :-
     opt_spec(Command,Subcommand,_,_,_).
 
 run(Argv) :-
+    % Check env vars to report errors as soon as possible.
+    check_all_env_vars,
     (   (   Argv = [Cmd|_],
             member(Cmd, [help, store, test])
         ;   open_descriptor(system_descriptor{}, _))

--- a/src/core/api/api_init.pl
+++ b/src/core/api/api_init.pl
@@ -158,3 +158,106 @@ initialize_database_with_store(Key, Store, Force) :-
     initialize_woql_schema(Store, Force),
 
     initialize_system_instance(Store, System_Schema, Key, Force).
+
+% FIXME! These tests should go into `src/config/terminus_config.pl`, but I
+% couldn't run them when they were there.
+:- begin_tests(env_vars).
+
+test("TERMINUSDB_INSECURE_USER_HEADER_ENABLED is not set",
+     [ setup(config:clear_check_insecure_user_header_enabled),
+       cleanup(config:clear_check_insecure_user_header_enabled),
+       true(Enabled = false)
+     ]) :-
+    config:check_insecure_user_header_enabled(Enabled).
+
+test("TERMINUSDB_INSECURE_USER_HEADER_ENABLED=true",
+     [ setup((
+           config:clear_check_insecure_user_header_enabled,
+           setenv('TERMINUSDB_INSECURE_USER_HEADER_ENABLED', true)
+       )),
+       cleanup((
+           config:clear_check_insecure_user_header_enabled,
+           unsetenv('TERMINUSDB_INSECURE_USER_HEADER_ENABLED'))
+       ),
+       true(Enabled = true)
+     ]) :-
+    config:check_insecure_user_header_enabled(Enabled).
+
+test("TERMINUSDB_INSECURE_USER_HEADER_ENABLED has a bad value",
+     [ setup((
+           config:clear_check_insecure_user_header_enabled,
+           setenv('TERMINUSDB_INSECURE_USER_HEADER_ENABLED', 42)
+       )),
+       cleanup((
+           config:clear_check_insecure_user_header_enabled,
+           unsetenv('TERMINUSDB_INSECURE_USER_HEADER_ENABLED')
+       )),
+       throws(error(bad_env_var_value('TERMINUSDB_INSECURE_USER_HEADER_ENABLED', '42'), _))
+     ]) :-
+    config:check_insecure_user_header_enabled(_).
+
+test("TERMINUSDB_INSECURE_USER_HEADER is not set",
+     [ setup((
+           config:clear_check_insecure_user_header_enabled,
+           config:clear_insecure_user_header_key,
+           setenv('TERMINUSDB_INSECURE_USER_HEADER_ENABLED', true)
+       )),
+       cleanup((
+           config:clear_check_insecure_user_header_enabled,
+           config:clear_insecure_user_header_key,
+           unsetenv('TERMINUSDB_INSECURE_USER_HEADER_ENABLED')
+       )),
+       throws(error(missing_env_var('TERMINUSDB_INSECURE_USER_HEADER'), _))
+     ]) :-
+    insecure_user_header_key(_).
+
+test("TERMINUSDB_INSECURE_USER_HEADER is missing",
+     [ setup((
+           config:clear_check_insecure_user_header_enabled,
+           config:clear_insecure_user_header_key,
+           setenv('TERMINUSDB_INSECURE_USER_HEADER_ENABLED', true)
+       )),
+       cleanup((
+           config:clear_check_insecure_user_header_enabled,
+           config:clear_insecure_user_header_key,
+           unsetenv('TERMINUSDB_INSECURE_USER_HEADER_ENABLED')
+       )),
+       throws(error(missing_env_var('TERMINUSDB_INSECURE_USER_HEADER'), _))
+     ]) :-
+    insecure_user_header_key(_).
+
+test("TERMINUSDB_INSECURE_USER_HEADER has a bad value",
+     [ setup((
+           config:clear_check_insecure_user_header_enabled,
+           config:clear_insecure_user_header_key,
+           setenv('TERMINUSDB_INSECURE_USER_HEADER_ENABLED', true),
+           setenv('TERMINUSDB_INSECURE_USER_HEADER', '')
+       )),
+       cleanup((
+           config:clear_check_insecure_user_header_enabled,
+           config:clear_insecure_user_header_key,
+           unsetenv('TERMINUSDB_INSECURE_USER_HEADER_ENABLED'),
+           unsetenv('TERMINUSDB_INSECURE_USER_HEADER')
+       )),
+       throws(error(bad_env_var_value('TERMINUSDB_INSECURE_USER_HEADER', ''), _))
+     ]) :-
+    insecure_user_header_key(_).
+
+test("TERMINUSDB_INSECURE_USER_HEADER=TerminusDB-5",
+     [ setup((
+           config:clear_check_insecure_user_header_enabled,
+           config:clear_insecure_user_header_key,
+           setenv('TERMINUSDB_INSECURE_USER_HEADER_ENABLED', true),
+           setenv('TERMINUSDB_INSECURE_USER_HEADER', 'TerminusDB-5')
+       )),
+       cleanup((
+           config:clear_check_insecure_user_header_enabled,
+           config:clear_insecure_user_header_key,
+           unsetenv('TERMINUSDB_INSECURE_USER_HEADER_ENABLED'),
+           unsetenv('TERMINUSDB_INSECURE_USER_HEADER')
+       )),
+       true(Header_Key = terminusdb_5)
+     ]) :-
+    insecure_user_header_key(Header_Key).
+
+:- end_tests(env_vars).

--- a/src/core/util/test_utils.pl
+++ b/src/core/util/test_utils.pl
@@ -430,7 +430,11 @@ spawn_server_1(Path, URL, PID, Options) :-
         'TERMINUSDB_SERVER_JWKS_ENDPOINT'='https://cdn.terminusdb.com/jwks.json'
     ],
 
-    inherit_env_vars(Env_List_1,
+    (   memberchk(env_vars(Env_List_User), Options)
+    ->  append(Env_List_1, Env_List_User, Combined_Env_List)
+    ;   Combined_Env_List = Env_List_1),
+
+    inherit_env_vars(Combined_Env_List,
                      [
                          'HOME',
                          'SystemRoot', % Windows specific stuff...


### PR DESCRIPTION
* test_utils: add option for env vars on spawn

  Sometimes a test needs additional ENV vars even though it might not
  be necessary to set them globally for every test. Therefore I
  introduced the extra option called `env_vars`.

* Add authentication with insecure header for username

  Some systems can be setup in such a way to offload user
  authentication. For instance, you could set up TerminusDB in a
  protected environment and use oauth2-proxy to secure it.

  Therefore we now allow an insecure mode to be set in conjunction with
  a custom user header to authenticate.

* Implement env vars with dynamic predicates and robust checking for
  insecure header

* Check the env vars at initialization

* Closes #831