### PR TITLE
Refactor document API: separate parts

### DIFF
--- a/src/core/api.pl
+++ b/src/core/api.pl
@@ -110,10 +110,11 @@
               unbundle/4,
 
               % api_document.pl
-              api_generate_documents/9,
-              api_generate_documents_by_type/10,
-              api_generate_documents_by_query/11,
-              api_get_document/8,
+              api_get_document_read_transaction/5,
+              api_generate_document_ids/6,
+              api_generate_document_ids_by_type/6,
+              api_generate_document_ids_by_query/7,
+              api_get_document/6,
               api_insert_documents/9,
               api_delete_documents/7,
               api_delete_document/7,

--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -786,18 +786,26 @@ document_handler(get, Path, Request, System_DB, Auth) :-
             ;   JSON_Options = []),
 
             cors_json_stream_start(Stream_Started),
+            api_get_document_read_transaction(System_DB, Auth, Path, Graph_Type, Transaction),
 
             (   nonvar(Query) % dictionaries do not need tags to be bound
-            ->  forall(api_generate_documents_by_query(System_DB, Auth, Path, Graph_Type, Compress_Ids, Unfold, Type, Query, Skip, Count, Document),
-                       cors_json_stream_write_dict(Request, As_List, Stream_Started, Document, JSON_Options))
+            ->  forall(
+                    api_generate_document_ids_by_query(Graph_Type, Transaction, Type, Query, Skip, Count, Id),
+                    (   api_get_document(Graph_Type, Transaction, Compress_Ids, Unfold, Id, Document),
+                        cors_json_stream_write_dict(Request, As_List, Stream_Started, Document, JSON_Options)))
             ;   ground(Id)
-            ->  api_get_document(System_DB, Auth, Path, Graph_Type, Compress_Ids, Unfold, Id, Document),
+            ->  api_get_document(Graph_Type, Transaction, Compress_Ids, Unfold, Id, Document),
                 cors_json_stream_write_dict(Request, As_List, Stream_Started, Document, JSON_Options)
             ;   ground(Type)
-            ->  forall(api_generate_documents_by_type(System_DB, Auth, Path, Graph_Type, Compress_Ids, Unfold, Type, Skip, Count, Document),
-                       cors_json_stream_write_dict(Request, As_List, Stream_Started, Document, JSON_Options))
-            ;   forall(api_generate_documents(System_DB, Auth, Path, Graph_Type, Compress_Ids, Unfold, Skip, Count, Document),
-                       cors_json_stream_write_dict(Request, As_List, Stream_Started, Document, JSON_Options))),
+            ->  forall(
+                    api_generate_document_ids_by_type(Graph_Type, Transaction, Type, Skip, Count, Id),
+                    (   api_get_document(Graph_Type, Transaction, Compress_Ids, Unfold, Id, Document),
+                        cors_json_stream_write_dict(Request, As_List, Stream_Started, Document, JSON_Options)))
+            ;   forall(
+                    api_generate_document_ids(Graph_Type, Transaction, Unfold, Skip, Count, Id),
+                    (   api_get_document(Graph_Type, Transaction, Compress_Ids, Unfold, Id, Document),
+                        cors_json_stream_write_dict(Request, As_List, Stream_Started, Document, JSON_Options)))
+            ),
 
             cors_json_stream_end(Request, As_List, Stream_Started)
         )).


### PR DESCRIPTION
For queries:
1. Create transaction
2. Generate IDs
3. Get document

This allows future work to extend the transaction creation without getting mingled in the generation of multiple document IDs.