### PR TITLE
routes: fix stuck connection on empty post data

### DIFF
--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -3956,6 +3956,7 @@ add_payload_to_request(Request,[payload(Document)|Request]) :-
     !.
 add_payload_to_request(Request,[payload(Document)|Request]) :-
     memberchk(content_type(_Some_Other_Type), Request),
+    check_content_length(Request),
     !,
     http_read_data(Request, Document, []).
 add_payload_to_request(Request,Request).


### PR DESCRIPTION
If there is no content, http_read_data will get stuck until the connection times out. Therefore I check whether there is some content first.

Fixes #864