### PR TITLE
bootstrap: import plunit as library

### DIFF
--- a/src/bootstrap.pl
+++ b/src/bootstrap.pl
@@ -9,6 +9,7 @@
 :- reexport(core(util/syntax)).
 
 :- use_module(core(util)).
+:- use_module(library(plunit)).
 
 :- set_test_options([run(manual), load(always)]).
 


### PR DESCRIPTION
We use set_test_options which is a predicate defined in plunit. I do think we should avoid to rely on autoloading as much as possible.