### PR TITLE
Explicit prolog_stack module import for printing backtrace

### DIFF
--- a/src/cli/main.pl
+++ b/src/cli/main.pl
@@ -18,6 +18,7 @@
 :- use_module(core(transaction), [open_descriptor/2]).
 :- use_module(library(optparse)).
 :- use_module(core(util), [do_or_die/2, basic_authorization/3]).
+:- use_module(library(prolog_stack), [print_prolog_backtrace/2]).
 
 cli_toplevel :-
     current_prolog_flag(argv, Argv),

--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -19,6 +19,9 @@
 :- use_module(core(api)).
 :- use_module(core(account)).
 
+% prolog stack print
+:- use_module(library(prolog_stack), [print_prolog_backtrace/2]).
+
 % http libraries
 :- use_module(library(http/http_dispatch)).
 :- use_module(library(http/http_server_files)).


### PR DESCRIPTION
We don't want to rely too much on autoloading! 

```% rg print_prolog_backtrace

src/server/routes.pl
3510:            print_prolog_backtrace(current_output,Stack))

src/cli/main.pl
34:            print_prolog_backtrace(user_error, Stack)

```

But they don't import the prolog_stack module.