### PR TITLE
Import lists explicitly where member/2 is called

### DIFF
--- a/src/cli/main.pl
+++ b/src/cli/main.pl
@@ -19,6 +19,7 @@
 :- use_module(library(optparse)).
 :- use_module(core(util), [do_or_die/2, basic_authorization/3]).
 :- use_module(library(prolog_stack), [print_prolog_backtrace/2]).
+:- use_module(library(lists)).
 
 cli_toplevel :-
     current_prolog_flag(argv, Argv),

--- a/src/core/account/capabilities.pl
+++ b/src/core/account/capabilities.pl
@@ -41,6 +41,7 @@
 :- use_module(config(terminus_config),[]).
 
 :- use_module(library(crypto)).
+:- use_module(library(lists)).
 
 /**
  * username_user_id(+DB, +Username, -User_ID) is semidet.

--- a/src/core/api/api_db.pl
+++ b/src/core/api/api_db.pl
@@ -10,6 +10,8 @@
 :- use_module(core(query)).
 :- use_module(core(transaction)).
 
+:- use_module(library(lists)).
+
 get_all_databases(System_DB, Databases) :-
     create_context(System_DB, Context),
     findall(

--- a/src/core/api/api_document.pl
+++ b/src/core/api/api_document.pl
@@ -19,6 +19,7 @@
 :- use_module(core(account)).
 
 :- use_module(library(http/json)).
+:- use_module(library(lists)).
 
 document_auth_action_type(Descriptor_Type, Graph_Type_String, ReadWrite_String, Action) :-
     atom_string(Graph_Type, Graph_Type_String),

--- a/src/core/api/api_init.pl
+++ b/src/core/api/api_init.pl
@@ -13,6 +13,7 @@
 :- use_module(library(semweb/turtle)).
 :- use_module(library(terminus_store)).
 :- use_module(library(http/json)).
+:- use_module(library(lists)).
 
 /**
  * create_graph_from_turtle(DB:database, Graph_ID:graph_identifier, Turtle:string) is det.

--- a/src/core/api/api_optimize.pl
+++ b/src/core/api/api_optimize.pl
@@ -4,6 +4,7 @@
 :- use_module(core(transaction)).
 :- use_module(core(account)).
 :- use_module(library(terminus_store)).
+:- use_module(library(lists)).
 :- use_module(core(util/test_utils)).
 :- use_module(core(triple)).
 

--- a/src/core/api/db_create.pl
+++ b/src/core/api/db_create.pl
@@ -25,6 +25,8 @@
 :- use_module(library(terminus_store)).
 :- use_module(core(util/test_utils)).
 
+:- use_module(library(lists)).
+
 :- multifile prolog:message//1.
 prolog:message(error(database_exists(Name), _)) -->
                 [ 'The database ~w already exists'-[Name]].

--- a/src/core/api/db_pack.pl
+++ b/src/core/api/db_pack.pl
@@ -14,6 +14,8 @@
 :- use_module(core(triple)).
 :- use_module(core(account)).
 
+:- use_module(library(lists)).
+
 payload_repository_head_and_pack(Data, Head, Pack) :-
     ground(Head),
     ground(Pack),

--- a/src/core/document/instance.pl
+++ b/src/core/document/instance.pl
@@ -26,6 +26,7 @@
 
 :- use_module(library(http/json)).
 :- use_module(library(aggregate)).
+:- use_module(library(lists)).
 
 
 is_rdf_list_(_Instance, Type) :-

--- a/src/core/document/json.pl
+++ b/src/core/document/json.pl
@@ -57,6 +57,7 @@
 
 :- use_module(library(terminus_store)).
 :- use_module(library(http/json)).
+:- use_module(library(lists)).
 
 :- use_module(core(util)).
 :- use_module(core(query)).

--- a/src/core/document/query.pl
+++ b/src/core/document/query.pl
@@ -11,6 +11,7 @@
 :- use_module(library(apply_macros)).
 :- use_module(library(terminus_store)).
 :- use_module(library(http/json)).
+:- use_module(library(lists)).
 
 :- use_module(core(util)).
 :- use_module(core(query)).

--- a/src/core/document/schema.pl
+++ b/src/core/document/schema.pl
@@ -44,6 +44,8 @@
 :- use_module(core(triple/literals)).
 :- use_module(core(query), [has_at/1, compress_dict_uri/3]).
 
+:- use_module(library(lists)).
+
 % performance
 :- use_module(library(apply)).
 :- use_module(library(yall)).

--- a/src/core/document/validation.pl
+++ b/src/core/document/validation.pl
@@ -7,6 +7,8 @@
 :- use_module(core(query)).
 :- use_module(instance).
 :- use_module(schema).
+
+:- use_module(library(lists)).
 /*
  * needs_schema_validation(Validation_Object) is det.
  *

--- a/src/core/query/ask.pl
+++ b/src/core/query/ask.pl
@@ -34,6 +34,8 @@
 
 :- use_module(core(document), [database_prefixes/2]).
 
+:- use_module(library(lists)).
+
 prefix_preterm(Ctx, Woql_Var, Pre_Term) :-
     freeze(Woql_Var,
            (   is_dict(Woql_Var) % Document

--- a/src/core/query/json_woql.pl
+++ b/src/core/query/json_woql.pl
@@ -27,6 +27,8 @@
 :- use_module(library(yall)).
 :- use_module(library(apply_macros)).
 
+:- use_module(library(lists)).
+
 :- dynamic woql_context/1.
 initialise_woql_contexts :-
     terminus_schema_path(Path),

--- a/src/core/query/jsonld.pl
+++ b/src/core/query/jsonld.pl
@@ -31,6 +31,7 @@
 :- use_module(library(pcre)).
 :- use_module(library(pairs)).
 :- use_module(library(http/json)).
+:- use_module(library(lists)).
 
 % Currently a bug in groundedness checking.
 %:- use_module(library(mavis)).

--- a/src/core/query/metadata.pl
+++ b/src/core/query/metadata.pl
@@ -6,6 +6,8 @@
           ]).
 
 :- use_module(library(terminus_store)).
+
+:- use_module(library(lists)).
 :- use_module(core(transaction)).
 :- use_module(core(util)).
 

--- a/src/core/query/path.pl
+++ b/src/core/query/path.pl
@@ -7,6 +7,8 @@
 :- use_module(core(util)).
 :- use_module(core(triple)).
 
+:- use_module(library(lists)).
+
 hop(type_filter{ types : Types}, X, P, Y, Transaction_Object) :-
     memberchk(instance,Types),
     not_literal(X),

--- a/src/core/query/query_response.pl
+++ b/src/core/query/query_response.pl
@@ -12,6 +12,8 @@
 :- use_module(core(transaction)).
 :- use_module(core(triple/literals)).
 
+:- use_module(library(lists)).
+
 /** <module> Query Response
  *
  * Code to generate bindings for query response in JSON-LD

--- a/src/core/transaction/descriptor.pl
+++ b/src/core/transaction/descriptor.pl
@@ -158,6 +158,7 @@
 :- use_module(core(query)).
 
 :- use_module(library(terminus_store)).
+:- use_module(library(lists)).
 
 is_descriptor_name(system_descriptor).
 is_descriptor_name(label_descriptor).

--- a/src/core/transaction/ref_entity.pl
+++ b/src/core/transaction/ref_entity.pl
@@ -41,6 +41,7 @@
               attach_layer_to_commit/4
           ]).
 :- use_module(library(terminus_store)).
+:- use_module(library(lists)).
 
 :- use_module(core(util)).
 :- use_module(core(query)).

--- a/src/core/transaction/validate.pl
+++ b/src/core/transaction/validate.pl
@@ -33,6 +33,7 @@
               ]).
 
 :- use_module(library(semweb/turtle)).
+:- use_module(library(lists)).
 
 :- use_module(library(terminus_store)).
 

--- a/src/core/triple/temp_graph.pl
+++ b/src/core/triple/temp_graph.pl
@@ -15,6 +15,7 @@
 :- use_module(core(transaction)).
 
 :- use_module(library(semweb/turtle)).
+:- use_module(library(lists)).
 
 /*
  * extend_database_with_temp_graph(+Graph_Name, +Path, +Options, -Program,

--- a/src/core/triple/triplestore.pl
+++ b/src/core/triple/triplestore.pl
@@ -36,6 +36,7 @@
 :- use_module(library(apply)).
 :- use_module(library(yall)).
 :- use_module(library(apply_macros)).
+:- use_module(library(lists)).
 
 :- reexport(library(terminus_store),
             except([create_named_graph/3,

--- a/src/core/triple/turtle_utils.pl
+++ b/src/core/triple/turtle_utils.pl
@@ -20,6 +20,8 @@
 :- use_module(library(semweb/turtle)).
 :- use_module(core(document)).
 
+:- use_module(library(lists)).
+
 :- multifile user:portray/1.
 user:portray(turtle_utils:open_string(_, Stream)) :-
     format("~q", [turtle_utils:open_string("... string elided...", Stream)]).

--- a/src/core/triple/upgrade_db.pl
+++ b/src/core/triple/upgrade_db.pl
@@ -47,6 +47,7 @@
 :- use_module(core(util)).
 
 :- use_module(library(pcre)).
+:- use_module(library(lists)).
 
 
 /**

--- a/src/core/util/file_utils.pl
+++ b/src/core/util/file_utils.pl
@@ -16,6 +16,7 @@
 :- use_module(library(apply)).
 :- use_module(library(yall)).
 :- use_module(library(apply_macros)).
+:- use_module(library(lists)).
 
 /** <module> File Utils
  *

--- a/src/core/util/test_utils.pl
+++ b/src/core/util/test_utils.pl
@@ -85,6 +85,8 @@
 
 :- use_module(library(process)).
 
+:- use_module(library(lists)).
+
 :- meta_predicate test_format(:, +, +).
 
 %!  test_format(+Goal:callable, +Format:text, +Args:list) is det

--- a/src/core/util/types.pl
+++ b/src/core/util/types.pl
@@ -61,6 +61,7 @@ This file deliberately has no dependencies - please do not introduce them.
 :- use_module(library(yall)).
 :- use_module(library(apply)).
 :- use_module(library(apply_macros)).
+:- use_module(library(lists)).
 
 /**
  * is_literal(+X) is semidet.

--- a/src/core/util/utils.pl
+++ b/src/core/util/utils.pl
@@ -83,6 +83,7 @@
 :- use_module(library(apply_macros)).
 :- use_module(library(http/json)).
 :- use_module(library(solution_sequences)).
+:- use_module(library(lists)).
 
 /*
  * Forget the next phrase.
@@ -923,7 +924,6 @@ input_to_integer(Atom, Integer) :-
     ->  catch(atom_number(Atom, Integer), _, fail),
         integer(Integer)).
 
-:- use_module(library(lists)).
 duplicates([], []) :- !.
 duplicates(List, Duplicates) :-
     msort(List, Sorted),

--- a/src/core/util/xsd_parser.pl
+++ b/src/core/util/xsd_parser.pl
@@ -67,6 +67,8 @@
 
 :- use_module(core(triple/iana)). % dubious - seems to be the only place where iana is used, so shouldn't iana be part of this module?
 
+:- use_module(library(lists)).
+
 /******************
  *  Punctuation   *
  ******************/

--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -22,6 +22,9 @@
 % prolog stack print
 :- use_module(library(prolog_stack), [print_prolog_backtrace/2]).
 
+% various prolog helper libraries
+:- use_module(library(lists)).
+
 % http libraries
 :- use_module(library(http/http_dispatch)).
 :- use_module(library(http/http_server_files)).


### PR DESCRIPTION
The member/2 predicate is used extensively throughout the code but the module where it comes from is almost never loaded.

This commit fixes that by importing it in every file where member/2 is used.