### PR TITLE
Add plunit to every prolog file that makes use of it

### DIFF
--- a/src/core/api/api_bundle.pl
+++ b/src/core/api/api_bundle.pl
@@ -9,6 +9,8 @@
 :- use_module(core(api/api_remote)).
 :- use_module(core(api/db_push)).
 
+:- use_module(library(plunit)).
+
 bundle(System_DB, Auth, Path, Payload, Options) :-
 
     do_or_die(

--- a/src/core/api/api_db.pl
+++ b/src/core/api/api_db.pl
@@ -11,6 +11,7 @@
 :- use_module(core(transaction)).
 
 :- use_module(library(lists)).
+:- use_module(library(plunit)).
 
 get_all_databases(System_DB, Databases) :-
     create_context(System_DB, Context),

--- a/src/core/api/api_document.pl
+++ b/src/core/api/api_document.pl
@@ -20,6 +20,7 @@
 
 :- use_module(library(http/json)).
 :- use_module(library(lists)).
+:- use_module(library(plunit)).
 
 document_auth_action_type(Descriptor_Type, Graph_Type_String, ReadWrite_String, Action) :-
     atom_string(Graph_Type, Graph_Type_String),

--- a/src/core/api/api_error.pl
+++ b/src/core/api/api_error.pl
@@ -8,6 +8,8 @@
                      ]).
 
 :- use_module(library(http/json)).
+:- use_module(library(plunit)).
+
 :- use_module(core(query)).
 
 /**

--- a/src/core/api/api_init.pl
+++ b/src/core/api/api_init.pl
@@ -14,6 +14,7 @@
 :- use_module(library(terminus_store)).
 :- use_module(library(http/json)).
 :- use_module(library(lists)).
+:- use_module(library(plunit)).
 
 /**
  * create_graph_from_turtle(DB:database, Graph_ID:graph_identifier, Turtle:string) is det.

--- a/src/core/api/api_optimize.pl
+++ b/src/core/api/api_optimize.pl
@@ -5,6 +5,7 @@
 :- use_module(core(account)).
 :- use_module(library(terminus_store)).
 :- use_module(library(lists)).
+:- use_module(library(plunit)).
 :- use_module(core(util/test_utils)).
 :- use_module(core(triple)).
 

--- a/src/core/api/api_prefixes.pl
+++ b/src/core/api/api_prefixes.pl
@@ -7,6 +7,8 @@
 :- use_module(library(terminus_store)).
 :- use_module(core(document)).
 
+:- use_module(library(plunit)).
+
 get_prefixes(Path, System_DB, Auth, JSON) :-
 
     do_or_die(

--- a/src/core/api/api_remote.pl
+++ b/src/core/api/api_remote.pl
@@ -11,6 +11,8 @@
 :- use_module(core(query)).
 :- use_module(core(account)).
 
+:- use_module(library(plunit)).
+
 add_remote(SystemDB, Auth, Path, Remote_Name, Remote_Location) :-
     atomic_list_concat([Path, '/_meta'], Repo_Path),
 

--- a/src/core/api/api_reset.pl
+++ b/src/core/api/api_reset.pl
@@ -6,6 +6,8 @@
 :- use_module(library(terminus_store)).
 :- use_module(core(util/test_utils)).
 
+:- use_module(library(plunit)).
+
 api_reset(System_DB, Auth, Path, Ref) :-
 
     do_or_die(

--- a/src/core/api/api_squash.pl
+++ b/src/core/api/api_squash.pl
@@ -6,6 +6,8 @@
 :- use_module(library(terminus_store)).
 :- use_module(core(util/test_utils)).
 
+:- use_module(library(plunit)).
+
 % Take a path, squash and return a reference to the
 % Commit.
 %

--- a/src/core/api/api_user_organizations.pl
+++ b/src/core/api/api_user_organizations.pl
@@ -7,6 +7,8 @@
 :- use_module(core(query)).
 :- use_module(core(document)).
 
+:- use_module(library(plunit)).
+
 user_organizations(System_DB, Auth, Result) :-
     findall(
         _{ '@type' : 'Organization',

--- a/src/core/api/db_branch.pl
+++ b/src/core/api/db_branch.pl
@@ -8,6 +8,7 @@
 
 :- use_module(library(terminus_store)).
 :- use_module(core(transaction/validate), [commit_validation_object/2]).
+:- use_module(library(plunit)).
 
 create_schema(Repository_Context, New_Branch_Name, Branch_Uri, Schema, Prefixes) :-
     query_context_transaction_objects(Repository_Context, [Repository_Transaction]),

--- a/src/core/api/db_create.pl
+++ b/src/core/api/db_create.pl
@@ -26,6 +26,7 @@
 :- use_module(core(util/test_utils)).
 
 :- use_module(library(lists)).
+:- use_module(library(plunit)).
 
 :- multifile prolog:message//1.
 prolog:message(error(database_exists(Name), _)) -->

--- a/src/core/api/db_fetch.pl
+++ b/src/core/api/db_fetch.pl
@@ -11,6 +11,7 @@
 :- use_module(db_pack).
 :- use_module(library(ssl)).
 :- use_module(library(http/http_client)).
+:- use_module(library(plunit)).
 
 :- meta_predicate remote_fetch(+, +, +, 3, -, -).
 remote_fetch(System_DB, Auth, Path, Fetch_Predicate, New_Head_Layer_Id, Head_Has_Updated) :-

--- a/src/core/api/db_pack.pl
+++ b/src/core/api/db_pack.pl
@@ -15,6 +15,7 @@
 :- use_module(core(account)).
 
 :- use_module(library(lists)).
+:- use_module(library(plunit)).
 
 payload_repository_head_and_pack(Data, Head, Pack) :-
     ground(Head),

--- a/src/core/api/db_push.pl
+++ b/src/core/api/db_push.pl
@@ -15,6 +15,7 @@
 :- use_module(core(document)).
 
 :- use_module(library(tus)).
+:- use_module(library(plunit)).
 
 % error conditions:
 % - branch to push does not exist

--- a/src/core/api/db_rebase.pl
+++ b/src/core/api/db_rebase.pl
@@ -3,6 +3,7 @@
               cycle_context/4
           ]).
 :- use_module(library(terminus_store)).
+:- use_module(library(plunit)).
 
 :- use_module(core(util)).
 :- use_module(core(account)).

--- a/src/core/api/graph_dump.pl
+++ b/src/core/api/graph_dump.pl
@@ -5,6 +5,8 @@
 :- use_module(core(account)).
 :- use_module(core(triple/turtle_utils)).
 
+:- use_module(library(plunit)).
+
 graph_dump(System_DB, Auth, Path, Format, String) :-
     do_or_die(
         resolve_absolute_string_descriptor_and_graph(Path, Descriptor, Graph),

--- a/src/core/query/json_woql.pl
+++ b/src/core/query/json_woql.pl
@@ -28,6 +28,7 @@
 :- use_module(library(apply_macros)).
 
 :- use_module(library(lists)).
+:- use_module(library(plunit)).
 
 :- dynamic woql_context/1.
 initialise_woql_contexts :-

--- a/src/core/query/jsonld.pl
+++ b/src/core/query/jsonld.pl
@@ -32,6 +32,7 @@
 :- use_module(library(pairs)).
 :- use_module(library(http/json)).
 :- use_module(library(lists)).
+:- use_module(library(plunit)).
 
 % Currently a bug in groundedness checking.
 %:- use_module(library(mavis)).

--- a/src/core/query/metadata.pl
+++ b/src/core/query/metadata.pl
@@ -8,6 +8,7 @@
 :- use_module(library(terminus_store)).
 
 :- use_module(library(lists)).
+:- use_module(library(plunit)).
 :- use_module(core(transaction)).
 :- use_module(core(util)).
 

--- a/src/core/query/path.pl
+++ b/src/core/query/path.pl
@@ -8,6 +8,7 @@
 :- use_module(core(triple)).
 
 :- use_module(library(lists)).
+:- use_module(library(plunit)).
 
 hop(type_filter{ types : Types}, X, P, Y, Transaction_Object) :-
     memberchk(instance,Types),

--- a/src/core/transaction/database.pl
+++ b/src/core/transaction/database.pl
@@ -21,6 +21,7 @@
 :- use_module(core(triple), [xrdf_added/4, xrdf_deleted/4]).
 
 :- use_module(library(prolog_stack)).
+:- use_module(library(plunit)).
 :- use_module(library(apply)).
 :- use_module(library(apply_macros)).
 :- use_module(library(terminus_store)).

--- a/src/core/transaction/descriptor.pl
+++ b/src/core/transaction/descriptor.pl
@@ -159,6 +159,7 @@
 
 :- use_module(library(terminus_store)).
 :- use_module(library(lists)).
+:- use_module(library(plunit)).
 
 is_descriptor_name(system_descriptor).
 is_descriptor_name(label_descriptor).

--- a/src/core/transaction/layer_entity.pl
+++ b/src/core/transaction/layer_entity.pl
@@ -7,6 +7,8 @@
 :- use_module(core(query)).
 :- use_module(core(document)).
 
+:- use_module(library(plunit)).
+
 has_layer(Askable, Layer_Id) :-
     ask(Askable,
         t(_, layer:identifier, Layer_Id^^xsd:string)).

--- a/src/core/transaction/ref_entity.pl
+++ b/src/core/transaction/ref_entity.pl
@@ -42,6 +42,7 @@
           ]).
 :- use_module(library(terminus_store)).
 :- use_module(library(lists)).
+:- use_module(library(plunit)).
 
 :- use_module(core(util)).
 :- use_module(core(query)).

--- a/src/core/transaction/repo_entity.pl
+++ b/src/core/transaction/repo_entity.pl
@@ -24,6 +24,8 @@
 
 :- use_module(layer_entity).
 
+:- use_module(library(plunit)).
+
 has_repository(Askable, Repo_Name) :-
     ask(Askable,
         t(_, name, Repo_Name^^xsd:string)).

--- a/src/core/transaction/validate.pl
+++ b/src/core/transaction/validate.pl
@@ -34,6 +34,7 @@
 
 :- use_module(library(semweb/turtle)).
 :- use_module(library(lists)).
+:- use_module(library(plunit)).
 
 :- use_module(library(terminus_store)).
 

--- a/src/core/triple/database_utils.pl
+++ b/src/core/triple/database_utils.pl
@@ -27,6 +27,7 @@
 :- use_module(core(transaction/database)).
 
 :- use_module(library(pcre)).
+:- use_module(library(plunit)).
 
 /**
  * system_graph_layer(-Graph,-Layer) is det.

--- a/src/core/triple/literals.pl
+++ b/src/core/triple/literals.pl
@@ -34,6 +34,7 @@
 :- use_module(core(triple/casting), [typecast/4]).
 :- use_module(core(triple/base_type), [basetype_subsumption_of/2]).
 
+:- use_module(library(plunit)).
 /*
  * date_time_string(-Date_Time,+String) is det.
  * date_time_string(+Date_Time,-String) is det.

--- a/src/core/util/speculative_parse.pl
+++ b/src/core/util/speculative_parse.pl
@@ -35,6 +35,7 @@
 :- use_module(xsd_parser).
 :- use_module(utils).
 :- use_module(library(dcg/basics), [whites//0, blanks//0]).
+:- use_module(library(plunit)).
 
 /*
  * guess_date(+Val,-Date) is nondet.

--- a/src/core/util/test_utils.pl
+++ b/src/core/util/test_utils.pl
@@ -84,6 +84,7 @@
 :- use_module(library(apply_macros)).
 
 :- use_module(library(process)).
+:- use_module(library(plunit)).
 
 :- use_module(library(lists)).
 

--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -25,6 +25,9 @@
 % various prolog helper libraries
 :- use_module(library(lists)).
 
+% unit tests
+:- use_module(library(plunit)).
+
 % http libraries
 :- use_module(library(http/http_dispatch)).
 :- use_module(library(http/http_server_files)).


### PR DESCRIPTION
All the test capabilities are defined in the module plunit, but the module is rarely imported. This can lead to issues when autoloading is disabled.