### PR TITLE
Id capture

### DIFF
--- a/src/core/api/api_document.pl
+++ b/src/core/api/api_document.pl
@@ -225,6 +225,7 @@ api_insert_documents(SystemDB, Auth, Path, Schema_Or_Instance, Author, Message, 
 
     stream_property(Stream, position(Pos)),
 
+    ensure_transaction_has_builder(instance, Transaction),
     with_transaction(Context,
                      (   set_stream_position(Stream, Pos),
                          Full_Replace = true

--- a/src/core/api/api_document.pl
+++ b/src/core/api/api_document.pl
@@ -359,14 +359,11 @@ api_replace_documents(SystemDB, Auth, Path, Schema_Or_Instance, Author, Message,
                                      ),
                                      Captures_Var),
                                  Ids),
-                         json_log_info_formatted("done replacing", []),
                          die_if(nonground_captures(Captures_Var, Nonground),
                                 error(not_all_captures_found(Nonground), _)),
-                         die_if(has_duplicates(Ids, Duplicates), error(same_ids_in_one_transaction(Duplicates), _)),
-                         json_log_info_formatted("awafsd", [])
+                         die_if(has_duplicates(Ids, Duplicates), error(same_ids_in_one_transaction(Duplicates), _))
                      ),
-                     _),
-    json_log_info_formatted("do we get here?", []).
+                     _).
 
 :- begin_tests(delete_document).
 :- use_module(core(util/test_utils)).

--- a/src/core/api/api_error.pl
+++ b/src/core/api/api_error.pl
@@ -1564,6 +1564,15 @@ api_document_error_jsonld(Type, error(key_fields_is_empty(Document),_),JSON) :-
                               'api:document' : Document },
              'api:message' : Msg
             }.
+api_document_error_jsonld(Type, error(not_all_captures_found(Refs),_),JSON) :-
+    document_error_type(Type, JSON_Type),
+    format(string(Msg), "Ids were referenced but never captured.", []),
+    JSON = _{'@type' : JSON_Type,
+             'api:status' : "api:failure",
+             'api:error' : _{ '@type' : 'api:NotAllCapturesFound',
+                              'api:captures' : Refs },
+             'api:message' : Msg
+            }.
 
 /**
  * generic_exception_jsonld(Error,JSON) is det.

--- a/src/core/api/api_error.pl
+++ b/src/core/api/api_error.pl
@@ -1005,7 +1005,6 @@ api_error_jsonld(get_documents, Error, JSON) :-
 api_error_jsonld(insert_documents, Error, JSON) :-
     api_document_error_jsonld(insert_documents, Error, JSON).
 api_error_jsonld(replace_documents, Error, JSON) :-
-    json_log_error_formatted("~q", [Error]),
     api_document_error_jsonld(replace_documents, Error, JSON).
 api_error_jsonld(delete_documents, Error, JSON) :-
     api_document_error_jsonld(delete_documents, Error, JSON).

--- a/src/core/api/api_error.pl
+++ b/src/core/api/api_error.pl
@@ -7,6 +7,7 @@
                       generic_exception_jsonld/2
                      ]).
 
+:- use_module(core(util)).
 :- use_module(library(http/json)).
 :- use_module(core(query)).
 
@@ -1004,6 +1005,7 @@ api_error_jsonld(get_documents, Error, JSON) :-
 api_error_jsonld(insert_documents, Error, JSON) :-
     api_document_error_jsonld(insert_documents, Error, JSON).
 api_error_jsonld(replace_documents, Error, JSON) :-
+    json_log_error_formatted("~q", [Error]),
     api_document_error_jsonld(replace_documents, Error, JSON).
 api_error_jsonld(delete_documents, Error, JSON) :-
     api_document_error_jsonld(delete_documents, Error, JSON).

--- a/src/core/document.pl
+++ b/src/core/document.pl
@@ -9,7 +9,6 @@
               idgen_lexical/3,
 
               json_elaborate/3,
-              json_triple/3,
               json_schema_triple/3,
               json_schema_elaborate/3,
               context_triple/2,
@@ -33,6 +32,7 @@
               get_schema_document_uri_by_type/3,
               delete_document/2,
               insert_document/3,
+              insert_document/6,
               replace_document/2,
               replace_document/3,
               replace_document/4,

--- a/src/core/document.pl
+++ b/src/core/document.pl
@@ -36,6 +36,7 @@
               replace_document/2,
               replace_document/3,
               replace_document/4,
+              replace_document/7,
               nuke_documents/1,
               insert_schema_document/2,
               delete_schema_document/2,

--- a/src/core/document/json.pl
+++ b/src/core/document/json.pl
@@ -2022,6 +2022,7 @@ write_json_stream_to_builder(JSON_Stream, Builder, schema) :-
 write_json_stream_to_builder(JSON_Stream, Builder, instance(DB)) :-
     database_prefixes(DB,Context),
     empty_assoc(Captures_In),
+    ensure_transaction_has_builder(instance, DB),
     write_json_instance_stream_to_builder(JSON_Stream, Builder, DB, Context, Captures_In, Captures_Out),
     do_or_die(ground(Captures_Out),
               error(not_all_captures_ground(Captures_Out),_)).
@@ -2030,7 +2031,6 @@ write_json_instance_stream_to_builder(JSON_Stream, Builder, DB, Context, Capture
     !,
     json_elaborate(DB,Dict,Context,Captures_In,Elaborated,Dependencies,New_Captures_In),
 
-    ensure_transaction_has_builder(instance, DB),
     when(ground(Dependencies),
          forall(
              json_triple_(Elaborated,Context,t(S,P,O)),

--- a/src/core/document/json.pl
+++ b/src/core/document/json.pl
@@ -9545,4 +9545,39 @@ test(deep_reference,
     Ernie_Id == (Ernie_Cross_2.'@id'),
     Elmo_Id == (Elmo_Cross_1.'@id'),
     Elmo_Id == (Elmo_Cross_2.'@id').
+
+test(double_capture,
+     [setup((setup_temp_store(State),
+              test_document_label_descriptor(Desc),
+              write_schema(cross_reference_set_schema,Desc)
+            )),
+      cleanup(teardown_temp_store(State)),
+      throws(error(capture_already_bound("Capture"),_))
+     ]) :-
+    open_descriptor(Desc, DB),
+
+    database_prefixes(DB,Context),
+    empty_assoc(In),
+    json_elaborate(DB,
+                   _{'@type': "Person",
+                     '@capture': "Capture",
+                     name: "Bert",
+                     friends: []},
+                   Context,
+                   In,
+                   _Bert_Elaborated,
+                   _Dependencies_1,
+                   Out_1),
+
+    json_elaborate(DB,
+                   _{'@type': "Person",
+                     '@capture': "Capture",
+                     name: "Ernie",
+                     friends: []},
+                   Context,
+                   Out_1,
+                   _Ernie_Elaborated,
+                   _Dependencies_2,
+                   _Out_2).
+
 :- end_tests(id_capture).

--- a/src/core/document/json.pl
+++ b/src/core/document/json.pl
@@ -9552,7 +9552,7 @@ test(double_capture,
               write_schema(cross_reference_set_schema,Desc)
             )),
       cleanup(teardown_temp_store(State)),
-      throws(error(capture_already_bound("Capture"),_))
+      error(capture_already_bound("Capture"))
      ]) :-
     open_descriptor(Desc, DB),
 

--- a/src/core/transaction.pl
+++ b/src/core/transaction.pl
@@ -27,6 +27,7 @@
               read_write_object_to_name/2,
               transactions_to_map/2,
               collection_descriptor_graph_filter_graph_descriptor/3,
+              ensure_transaction_has_builder/2,
 
               % validate.pl
               transaction_objects_to_validation_objects/2,

--- a/src/core/transaction/database.pl
+++ b/src/core/transaction/database.pl
@@ -249,8 +249,6 @@ with_transaction_(_,
  */
 run_transactions(Transactions, All_Witnesses, Meta_Data) :-
     transaction_objects_to_validation_objects(Transactions, Validations),
-    forall(member(V,Validations),
-           print_all_triples(V)),
     validate_validation_objects(Validations, All_Witnesses, Witnesses),
     /*
     with_output_to(

--- a/src/core/transaction/database.pl
+++ b/src/core/transaction/database.pl
@@ -249,6 +249,8 @@ with_transaction_(_,
  */
 run_transactions(Transactions, All_Witnesses, Meta_Data) :-
     transaction_objects_to_validation_objects(Transactions, Validations),
+    forall(member(V,Validations),
+           print_all_triples(V)),
     validate_validation_objects(Validations, All_Witnesses, Witnesses),
     /*
     with_output_to(

--- a/src/core/transaction/descriptor.pl
+++ b/src/core/transaction/descriptor.pl
@@ -20,7 +20,8 @@
               collection_descriptor_graph_filter_graph_descriptor/3,
               collection_descriptor_prefixes/2,
               collection_descriptor_default_write_graph/2,
-              descriptor_to_loggable/2
+              descriptor_to_loggable/2,
+              ensure_transaction_has_builder/2
           ]).
 
 /** <module> Descriptor Manipulation
@@ -375,6 +376,13 @@ read_write_obj_builder(Read_Write_Obj, Layer_Builder) :-
 read_write_obj_builder(Read_Write_Obj, Layer_Builder) :-
     open_write(Read_Write_Obj.read, Layer_Builder),
     nb_set_dict(write,Read_Write_Obj,Layer_Builder).
+
+ensure_transaction_has_builder(schema, Transaction) :-
+    [RWO] = (Transaction.schema_objects),
+    read_write_obj_builder(RWO, _).
+ensure_transaction_has_builder(instance, Transaction) :-
+    [RWO] = (Transaction.instance_objects),
+    read_write_obj_builder(RWO, _).
 /*
 read_write_obj_builder(Read_Write_Obj, Layer_Builder) :-
     (   get_dict(commit_type, (Read_Write_Obj.descriptor), 'http://terminusdb.com/schema/ref#InitialCommit')

--- a/src/core/triple/triplestore.pl
+++ b/src/core/triple/triplestore.pl
@@ -231,6 +231,8 @@ import_graph(_File, _DB_ID, _Graph_ID) :-
  * Insert triple into transaction layer, record changed as 1 or 0
  */
 insert(G,X,Y,Z,Changed) :-
+    do_or_die(ground(Z),
+              error(instantiation_error, _)),
     ground_object_storage(Z,S),
     read_write_obj_builder(G, Builder),
     (   nb_add_triple(Builder, X, Y, S)

--- a/src/core/util.pl
+++ b/src/core/util.pl
@@ -126,11 +126,13 @@
               time_to_internal_time/2,
               datetime_to_internal_datetime/2,
               json_read_dict_stream/2,
+              json_stream_read_single_dict/2,
               skip_generate_nsols/3,
               input_to_integer/2,
               duplicates/2,
               has_duplicates/2,
               index_list/2,
+              nb_thread_var/2,
 
               % speculative_parse.pl
               %guess_date/2,

--- a/src/core/util/utils.pl
+++ b/src/core/util/utils.pl
@@ -64,11 +64,13 @@
               time_to_internal_time/2,
               datetime_to_internal_datetime/2,
               json_read_dict_stream/2,
+              json_stream_read_single_dict/2,
               skip_generate_nsols/3,
               input_to_integer/2,
               duplicates/2,
               has_duplicates/2,
-              index_list/2
+              index_list/2,
+              nb_thread_var/2
           ]).
 
 /** <module> Utils
@@ -898,6 +900,12 @@ time_to_internal_time(time(HH,MM,SS,Offset),time(HN,MN,SN)) :-
 
 json_read_dict_stream(Stream,Term) :-
     repeat,
+    (   json_stream_read_single_dict(Stream,Term)
+    *-> true
+    ;   !,
+        fail).
+
+json_stream_read_single_dict(Stream,Term) :-
     json_read_dict(Stream, Term, [default_tag(json),end_of_file(eof)]),
     (   Term = eof
     ->  !,
@@ -953,3 +961,8 @@ index_list(List,Indexes) :-
         numlist(0, N, Indexes)
     ;   Indexes = []
     ).
+
+:- meta_predicate nb_thread_var(2,+).
+nb_thread_var(Callable, State) :-
+    call(Callable, State, Out),
+    nb_setarg(1,State, Out).


### PR DESCRIPTION
This pull request introduces id captures, a feature of the document interface where, when one does an insert or replace operation, they can capture ids, and refer to them elsewhere in the same insert/update stream.

This supports both backwards references (where you first capture an id, then refer to it later), and forward references (where you first refer to an id, then capture it later).