### PR TITLE
Fix print_all_documents test utility

### DIFF
--- a/src/core/document/json.pl
+++ b/src/core/document/json.pl
@@ -1876,6 +1876,16 @@ get_schema_document_uri(_DB, '@context').
 get_schema_document_uri(DB, Uri) :-
     is_simple_class(DB, Uri).
 
+get_schema_document(Query_Context, Id, Document) :-
+    is_query_context(Query_Context),
+    !,
+    query_default_collection(Query_Context, TO),
+    get_schema_document(TO, Id, Document).
+get_schema_document(Desc, Id, Document) :-
+    is_descriptor(Desc),
+    !,
+    open_descriptor(Desc, Transaction),
+    get_schema_document(Transaction, Id, Document).
 get_schema_document(DB, '@context', Document) :-
     !,
     database_context_object(DB, Context_Object),

--- a/src/core/util/test_utils.pl
+++ b/src/core/util/test_utils.pl
@@ -329,11 +329,17 @@ print_all_triples(Askable, Selector) :-
 print_all_documents(Askable) :-
     print_all_documents(Askable, instance).
 
+get_selector_document(instance, Askable, Id, Document) :-
+    get_document(Askable, Id, Document).
+get_selector_document(schema, Askable, Id, Document) :-
+    get_schema_document(Askable, Id, Document).
+
 print_all_documents(Askable, Selector) :-
     nl,
     forall(
-        api_document:api_generate_documents_(Selector, Askable, true, false, 0, unlimited, Document),
-        json_write_dict(current_output, Document, [])),
+        api_document:api_generate_document_ids(Selector, Askable, true, 0, unlimited, Id),
+        (   get_selector_document(Selector, Askable, Id, Document),
+            json_write_dict(current_output, Document, []))),
     nl.
 
 cleanup_user_database(User, Database) :-


### PR DESCRIPTION
It was calling a predicate that no longer exists. Now it calls only predicates that do exist.