### PR TITLE
Fix makefile targets to support incremental build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,8 @@ MAINTAINER="TerminusDB Team <team@terminusdb.com>"
 SWIPL=LANG=C.UTF-8 $(SWIPL_DIR)swipl
 RONN_FILE=docs/terminusdb.1.ronn
 ROFF_FILE=docs/terminusdb.1
+TARGET=terminusdb
 
-# Get the absolute path of the Makefile to use for the target (handling spaces
-# in the path), so that we can use the path to run the target to build the docs.
-# Source: https://stackoverflow.com/a/61429483
-SPACE :=
-SPACE +=
-TARGET_DIR := $(subst $(lastword $(notdir $(MAKEFILE_LIST))),,$(subst $(SPACE),\$(SPACE),$(shell realpath '$(strip $(MAKEFILE_LIST))')))
-TARGET=$(TARGET_DIR)terminusdb
 RUST_FILES = src/rust/Cargo.toml src/rust/Cargo.lock $(shell find src/rust/src/ -type f -name '*.rs')
 
 ifeq ($(shell uname), Darwin)
@@ -86,7 +80,7 @@ $(RUST_TARGET): $(RUST_FILES)
 
 # Create input for `ronn` from a template and the `terminusdb` help text.
 $(RONN_FILE): docs/terminusdb.1.ronn.template $(TARGET)
-	HELP="$$($(TARGET) help -m)" envsubst < $< > $@
+	HELP="$$(./$(TARGET) help -m)" envsubst < $< > $@
 
 # Create a man page from using `ronn`.
 $(ROFF_FILE): $(RONN_FILE)

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ ROFF_FILE=docs/terminusdb.1
 TARGET=terminusdb
 
 RUST_FILES = src/rust/Cargo.toml src/rust/Cargo.lock $(shell find src/rust/src/ -type f -name '*.rs')
+PROLOG_FILES = $(shell find ./ -not -path './rust/*' \( -name '*.pl' -o -name '*.ttl' -o -name '*.json' \))
 
 ifeq ($(shell uname), Darwin)
 	RUST_LIB_NAME := librust.dylib
@@ -67,7 +68,7 @@ docs-clean:
 
 ################################################################################
 
-$(TARGET): $(RUST_TARGET)
+$(TARGET): $(RUST_TARGET) $(PROLOG_FILES)
 	# Build the target and fail for errors and warnings. Ignore warnings
 	# having "qsave(strip_failed(..." that occur on macOS.
 	$(SWIPL) -t 'main,halt.' -O -q -f src/bootstrap.pl 2>&1 | \


### PR DESCRIPTION
Some more Makefile changes
- I changed the doc build to use a relative path rather than an absolute path. As far as I can tell, using ./terminusdb works just as well as using the absolute path to terminusdb, and it saves us from having to do the magic to find the absolute path. This also means that make is once again able to detect that terminusdb has been built, which it couldn't do anymore due to mild path mangling in the absolute path target.
- I added all prolog, json, and ttl files in our source dir as a dependency to the terminusdb target. This means that running make will only rebuild terminusdb when one of these files has changed since the last build.