### PR TITLE
Add data versions for document and woql endpoints

### DIFF
--- a/src/cli/main.pl
+++ b/src/cli/main.pl
@@ -641,7 +641,7 @@ run_command(query,[Database,Query],Opts) :-
         (   woql_context(Prefixes),
             context_extend_prefixes(Context,Prefixes,Context0),
             read_query_term_from_atom(Query,AST),
-            query_response:run_context_ast_jsonld_response(Context0, AST, Response),
+            query_response:run_context_ast_jsonld_response(Context0, AST, no_data_version, _, Response),
             get_dict(prefixes, Context0, Context_Prefixes),
             default_prefixes(Defaults),
             put_dict(Defaults, Context_Prefixes, Final_Prefixes),

--- a/src/core/api.pl
+++ b/src/core/api.pl
@@ -61,7 +61,7 @@
               api_filled_frame/5,
 
               % api_woql.pl
-              woql_query_json/8,
+              woql_query_json/10,
 
               % api_squash.pl
               api_squash/6,
@@ -111,16 +111,15 @@
               unbundle/4,
 
               % api_document.pl
-              api_get_document_read_transaction/5,
-              api_generate_document_ids/6,
-              api_generate_document_ids_by_type/6,
-              api_generate_document_ids_by_query/7,
-              api_get_document/6,
-              api_insert_documents/9,
-              api_delete_documents/7,
-              api_delete_document/7,
-              api_replace_documents/9,
-              api_nuke_documents/6,
+              api_get_documents/11,
+              api_get_documents_by_type/12,
+              api_get_documents_by_query/13,
+              api_get_document_by_id/10,
+              api_insert_documents/11,
+              api_delete_documents/9,
+              api_delete_document/9,
+              api_replace_documents/11,
+              api_nuke_documents/8,
 
               % api_user_organizations.pl
               user_organizations/3,

--- a/src/core/api/api_document.pl
+++ b/src/core/api/api_document.pl
@@ -1,14 +1,13 @@
 :- module(api_document, [
-              api_get_document_read_transaction/5,
-              api_generate_document_ids/6,
-              api_generate_document_ids_by_type/6,
-              api_generate_document_ids_by_query/7,
-              api_get_document/6,
-              api_insert_documents/9,
-              api_delete_documents/7,
-              api_delete_document/7,
-              api_replace_documents/9,
-              api_nuke_documents/6
+              api_get_documents/11,
+              api_get_documents_by_type/12,
+              api_get_documents_by_query/13,
+              api_get_document_by_id/10,
+              api_insert_documents/11,
+              api_delete_documents/9,
+              api_delete_document/9,
+              api_replace_documents/11,
+              api_nuke_documents/8
           ]).
 
 :- use_module(core(util)).
@@ -39,35 +38,33 @@ document_auth_action_type_(branch_descriptor, schema, write, '@schema':'Action/s
 document_auth_action_type_(commit_descriptor, instance, read, '@schema':'Action/instance_read_access').
 document_auth_action_type_(commit_descriptor, schema, read, '@schema':'Action/schema_read_access').
 
-assert_document_auth(SystemDB, Auth, Descriptor, Graph_Type, ReadWrite) :-
+resolve_descriptor_auth(ReadWrite, SystemDB, Auth, Path, Graph_Type, Descriptor) :-
+    do_or_die(
+        resolve_absolute_string_descriptor(Path, Descriptor),
+        error(invalid_path(Path), _)),
     Descriptor_Type{} :< Descriptor,
     do_or_die(document_auth_action_type(Descriptor_Type, Graph_Type, ReadWrite, Action),
               error(document_access_impossible(Descriptor, Graph_Type, ReadWrite), _)),
-
     check_descriptor_auth(SystemDB, Descriptor, Action, Auth).
 
-api_get_document_read_transaction(SystemDB, Auth, Path, Schema_Or_Instance, Transaction) :-
-    do_or_die(
-        resolve_absolute_string_descriptor(Path, Descriptor),
-        error(invalid_path(Path),_)),
-
-    assert_document_auth(SystemDB, Auth, Descriptor, Schema_Or_Instance, read),
-
+before_read(Descriptor, Requested_Data_Version, Actual_Data_Version, Transaction) :-
     do_or_die(
         open_descriptor(Descriptor, Transaction),
-        error(unresolvable_collection(Descriptor), _)).
+        error(unresolvable_collection(Descriptor), _)),
 
-api_get_document_write_transaction(SystemDB, Auth, Path, Schema_Or_Instance, Author, Message, Context, Transaction) :-
+    transaction_data_version(Transaction, Actual_Data_Version),
+    compare_data_versions(Requested_Data_Version, Actual_Data_Version).
+
+before_write(Descriptor, Author, Message, Requested_Data_Version, Context, Transaction) :-
     do_or_die(
-        resolve_absolute_string_descriptor(Path, Descriptor),
-        error(invalid_path(Path),_)),
+        create_context(Descriptor, commit_info{author: Author, message: Message}, Context),
+        error(unresolvable_collection(Descriptor), _)),
+    do_or_die(
+        query_default_collection(Context, Transaction),
+        error(query_default_collection_failed_unexpectedly(Context), _)),
 
-    assert_document_auth(SystemDB, Auth, Descriptor, Schema_Or_Instance, write),
-
-    do_or_die(create_context(Descriptor, commit_info{author: Author, message: Message}, Context),
-              error(unresolvable_collection(Descriptor), _)),
-    do_or_die(query_default_collection(Context, Transaction),
-              error(query_default_collection_failed_unexpectedly(Context), _)).
+    transaction_data_version(Transaction, Actual_Data_Version),
+    compare_data_versions(Requested_Data_Version, Actual_Data_Version).
 
 api_generate_document_ids(instance, Transaction, Unfold, Skip, Count, Id) :-
     (   Unfold = true
@@ -83,6 +80,14 @@ api_generate_document_ids(schema, Transaction, _Unfold, Skip, Count, Id) :-
         Skip,
         Count).
 
+api_get_documents(SystemDB, Auth, Path, Graph_Type, Compress_Ids, Unfold, Skip, Count, Requested_Data_Version, Actual_Data_Version, Goal) :-
+    resolve_descriptor_auth(read, SystemDB, Auth, Path, Graph_Type, Descriptor),
+    before_read(Descriptor, Requested_Data_Version, Actual_Data_Version, Transaction),
+    Goal = {Graph_Type, Transaction, Skip, Count, Compress_Ids, Unfold}/[Document]>>(
+        api_document:api_generate_document_ids(Graph_Type, Transaction, Unfold, Skip, Count, Id),
+        api_document:api_get_document(Graph_Type, Transaction, Compress_Ids, Unfold, Id, Document)
+    ).
+
 api_generate_document_ids_by_type(instance, Transaction, Type, Skip, Count, Id) :-
     skip_generate_nsols(
         get_document_uri_by_type(Transaction, Type, Id),
@@ -94,6 +99,14 @@ api_generate_document_ids_by_type(schema, Transaction, Type, Skip, Count, Id) :-
         Skip,
         Count).
 
+api_get_documents_by_type(SystemDB, Auth, Path, Graph_Type, Compress_Ids, Unfold, Type, Skip, Count, Requested_Data_Version, Actual_Data_Version, Goal) :-
+    resolve_descriptor_auth(read, SystemDB, Auth, Path, Graph_Type, Descriptor),
+    before_read(Descriptor, Requested_Data_Version, Actual_Data_Version, Transaction),
+    Goal = {Graph_Type, Transaction, Type, Skip, Count, Compress_Ids, Unfold}/[Document]>>(
+        api_document:api_generate_document_ids_by_type(Graph_Type, Transaction, Type, Skip, Count, Id),
+        api_document:api_get_document(Graph_Type, Transaction, Compress_Ids, Unfold, Id, Document)
+    ).
+
 api_generate_document_ids_by_query(instance, Transaction, Type, Query, Skip, Count, Id) :-
     skip_generate_nsols(
         match_query_document_uri(Transaction, Type, Query, Id),
@@ -102,13 +115,25 @@ api_generate_document_ids_by_query(instance, Transaction, Type, Query, Skip, Cou
 api_generate_document_ids_by_query(schema, _Transaction, _Type, _Query, _Skip, _Count, _Id) :-
     throw(error(query_is_only_supported_for_instance_graphs, _)).
 
+api_get_documents_by_query(SystemDB, Auth, Path, Graph_Type, Compress_Ids, Unfold, Type, Query, Skip, Count, Requested_Data_Version, Actual_Data_Version, Goal) :-
+    resolve_descriptor_auth(read, SystemDB, Auth, Path, Graph_Type, Descriptor),
+    before_read(Descriptor, Requested_Data_Version, Actual_Data_Version, Transaction),
+    Goal = {Graph_Type, Transaction, Type, Query, Skip, Count, Compress_Ids, Unfold}/[Document]>>(
+        api_document:api_generate_document_ids_by_query(Graph_Type, Transaction, Type, Query, Skip, Count, Id),
+        api_document:api_get_document(Graph_Type, Transaction, Compress_Ids, Unfold, Id, Document)
+    ).
+
 api_get_document(instance, Transaction, Compress_Ids, Unfold, Id, Document) :-
     do_or_die(get_document(Transaction, Compress_Ids, Unfold, Id, Document),
               error(document_not_found(Id), _)).
-
 api_get_document(schema, Transaction, _Prefixed, _Unfold, Id, Document) :-
     do_or_die(get_schema_document(Transaction, Id, Document),
               error(document_not_found(Id), _)).
+
+api_get_document_by_id(SystemDB, Auth, Path, Graph_Type, Compress_Ids, Unfold, Requested_Data_Version, Actual_Data_Version, Id, Document) :-
+    resolve_descriptor_auth(read, SystemDB, Auth, Path, Graph_Type, Descriptor),
+    before_read(Descriptor, Requested_Data_Version, Actual_Data_Version, Transaction),
+    api_get_document(Graph_Type, Transaction, Compress_Ids, Unfold, Id, Document).
 
 embed_document_in_error(Error, Document, New_Error) :-
     Error =.. Error_List,
@@ -167,27 +192,29 @@ replace_existing_graph(instance, Transaction, Stream) :-
            nb_thread_var({Transaction,Document}/[State,Captures_Out]>>(api_insert_document_(instance, Transaction, Document, State, _, Captures_Out)),
                          state(Captures))).
 
-api_insert_documents(SystemDB, Auth, Path, Schema_Or_Instance, Author, Message, Full_Replace, Stream, Ids) :-
-    api_get_document_write_transaction(SystemDB, Auth, Path, Schema_Or_Instance, Author, Message, Context, Transaction),
+api_insert_documents(SystemDB, Auth, Path, Graph_Type, Author, Message, Full_Replace, Stream, Requested_Data_Version, New_Data_Version, Ids) :-
+    resolve_descriptor_auth(write, SystemDB, Auth, Path, Graph_Type, Descriptor),
+    before_write(Descriptor, Author, Message, Requested_Data_Version, Context, Transaction),
     stream_property(Stream, position(Pos)),
     with_transaction(Context,
                      (   set_stream_position(Stream, Pos),
                          Full_Replace = true
-                     ->  replace_existing_graph(Schema_Or_Instance, Transaction, Stream),
+                     ->  replace_existing_graph(Graph_Type, Transaction, Stream),
                          Ids = []
                      ;   empty_assoc(Captures),
                          Captures_Var = state(Captures),
-                         ensure_transaction_has_builder(Schema_Or_Instance, Transaction),
+                         ensure_transaction_has_builder(Graph_Type, Transaction),
                          findall(Id,
                                  (   json_read_dict_list_stream(Stream, Document),
-                                     nb_thread_var({Schema_Or_Instance,Transaction,Document,Id}/[State,Captures_Out]>>(api_insert_document_(Schema_Or_Instance, Transaction, Document, State, Id, Captures_Out)),
+                                     nb_thread_var({Graph_Type,Transaction,Document,Id}/[State,Captures_Out]>>(api_insert_document_(Graph_Type, Transaction, Document, State, Id, Captures_Out)),
                                                    Captures_Var)),
                                  Ids),
 
                          die_if(nonground_captures(Captures_Var, Nonground),
                                 error(not_all_captures_found(Nonground), _)),
                          die_if(has_duplicates(Ids, Duplicates), error(same_ids_in_one_transaction(Duplicates), _))),
-                     _).
+                     Meta_Data),
+    meta_data_version(Transaction, Meta_Data, New_Data_Version).
 
 nonground_captures(state(Captures), Nonground) :-
     findall(Ref,
@@ -201,8 +228,9 @@ api_delete_document_(schema, Transaction, Id) :-
 api_delete_document_(instance, Transaction, Id) :-
     delete_document(Transaction, Id).
 
-api_delete_documents(SystemDB, Auth, Path, Schema_Or_Instance, Author, Message, Stream) :-
-    api_get_document_write_transaction(SystemDB, Auth, Path, Schema_Or_Instance, Author, Message, Context, Transaction),
+api_delete_documents(SystemDB, Auth, Path, Graph_Type, Author, Message, Stream, Requested_Data_Version, New_Data_Version) :-
+    resolve_descriptor_auth(write, SystemDB, Auth, Path, Graph_Type, Descriptor),
+    before_write(Descriptor, Author, Message, Requested_Data_Version, Context, Transaction),
     stream_property(Stream, position(Pos)),
     with_transaction(Context,
                      (   set_stream_position(Stream, Pos),
@@ -212,46 +240,52 @@ api_delete_documents(SystemDB, Auth, Path, Schema_Or_Instance, Author, Message, 
                                  ->  member(ID_Unchecked, JSON)
                                  ;   ID_Unchecked = JSON),
                                  param_check_json(string, id, ID_Unchecked, ID)),
-                             api_delete_document_(Schema_Or_Instance, Transaction, ID))),
-                     _).
+                             api_delete_document_(Graph_Type, Transaction, ID))),
+                     Meta_Data),
+    meta_data_version(Transaction, Meta_Data, New_Data_Version).
 
-api_delete_document(SystemDB, Auth, Path, Schema_Or_Instance, Author, Message, ID) :-
-    api_get_document_write_transaction(SystemDB, Auth, Path, Schema_Or_Instance, Author, Message, Context, Transaction),
+api_delete_document(SystemDB, Auth, Path, Graph_Type, Author, Message, ID, Requested_Data_Version, New_Data_Version) :-
+    resolve_descriptor_auth(write, SystemDB, Auth, Path, Graph_Type, Descriptor),
+    before_write(Descriptor, Author, Message, Requested_Data_Version, Context, Transaction),
     with_transaction(Context,
-                     api_delete_document_(Schema_Or_Instance, Transaction, ID),
-                     _).
+                     api_delete_document_(Graph_Type, Transaction, ID),
+                     Meta_Data),
+    meta_data_version(Transaction, Meta_Data, New_Data_Version).
 
 api_nuke_documents_(schema, Transaction) :-
     nuke_schema_documents(Transaction).
 api_nuke_documents_(instance, Transaction) :-
     nuke_documents(Transaction).
 
-api_nuke_documents(SystemDB, Auth, Path, Schema_Or_Instance, Author, Message) :-
-    api_get_document_write_transaction(SystemDB, Auth, Path, Schema_Or_Instance, Author, Message, Context, Transaction),
+api_nuke_documents(SystemDB, Auth, Path, Graph_Type, Author, Message, Requested_Data_Version, New_Data_Version) :-
+    resolve_descriptor_auth(write, SystemDB, Auth, Path, Graph_Type, Descriptor),
+    before_write(Descriptor, Author, Message, Requested_Data_Version, Context, Transaction),
     with_transaction(Context,
-                     api_nuke_documents_(Schema_Or_Instance, Transaction),
-                    _).
+                     api_nuke_documents_(Graph_Type, Transaction),
+                     Meta_Data),
+    meta_data_version(Transaction, Meta_Data, New_Data_Version).
 
 api_replace_document_(instance, Transaction, Document, Create, state(Captures_In), Id, Captures_Out):-
     replace_document(Transaction, Document, Create, Captures_In, Id, _Dependencies, Captures_Out).
 api_replace_document_(schema, Transaction, Document, Create, state(Captures_In), Id, Captures_In):-
     replace_schema_document(Transaction, Document, Create, Id).
 
-api_replace_documents(SystemDB, Auth, Path, Schema_Or_Instance, Author, Message, Stream, Create, Ids) :-
-    api_get_document_write_transaction(SystemDB, Auth, Path, Schema_Or_Instance, Author, Message, Context, Transaction),
+api_replace_documents(SystemDB, Auth, Path, Graph_Type, Author, Message, Stream, Create, Requested_Data_Version, New_Data_Version, Ids) :-
+    resolve_descriptor_auth(write, SystemDB, Auth, Path, Graph_Type, Descriptor),
+    before_write(Descriptor, Author, Message, Requested_Data_Version, Context, Transaction),
     stream_property(Stream, position(Pos)),
     with_transaction(Context,
                      (   set_stream_position(Stream, Pos),
                          empty_assoc(Captures),
                          Captures_Var = state(Captures),
-                         ensure_transaction_has_builder(Schema_Or_Instance, Transaction),
+                         ensure_transaction_has_builder(Graph_Type, Transaction),
                          findall(Id,
                                  nb_thread_var(
-                                     {Schema_Or_Instance, Transaction,Stream,Id}/[State,Captures_Out]>>
+                                     {Graph_Type, Transaction,Stream,Id}/[State,Captures_Out]>>
                                      (   json_read_dict_list_stream(Stream,Document),
                                          call_catch_document_mutation(
                                              Document,
-                                             api_replace_document_(Schema_Or_Instance,
+                                             api_replace_document_(Graph_Type,
                                                                    Transaction,
                                                                    Document,
                                                                    Create,
@@ -265,7 +299,8 @@ api_replace_documents(SystemDB, Auth, Path, Schema_Or_Instance, Author, Message,
                                 error(not_all_captures_found(Nonground), _)),
                          die_if(has_duplicates(Ids, Duplicates), error(same_ids_in_one_transaction(Duplicates), _))
                      ),
-                     _).
+                     Meta_Data),
+    meta_data_version(Transaction, Meta_Data, New_Data_Version).
 
 :- begin_tests(delete_document).
 :- use_module(core(util/test_utils)).
@@ -283,7 +318,7 @@ insert_some_cities(System, Path) :-
   "@id" : "City/Utrecht",
   "name" : "Utrecht" }',
                 Stream),
-    api_insert_documents(System, 'User/admin', Path, instance, "author", "message", false, Stream, _Out_Ids).
+    api_insert_documents(System, 'User/admin', Path, instance, "author", "message", false, Stream, no_data_version, _New_Data_Version, _Ids).
 
 test(delete_objects_with_stream,
      [setup((setup_temp_store(State),
@@ -294,7 +329,7 @@ test(delete_objects_with_stream,
     insert_some_cities(System, 'admin/foo'),
 
     open_string('"City/Dublin" "City/Pretoria"', Stream),
-    api_delete_documents(system_descriptor{}, 'User/admin', 'admin/foo', instance, "author", "message", Stream),
+    api_delete_documents(System, 'User/admin', 'admin/foo', instance, "author", "message", Stream, no_data_version, _New_Data_Version),
 
     resolve_absolute_string_descriptor("admin/foo", Descriptor),
     create_context(Descriptor, Context),
@@ -314,7 +349,7 @@ test(delete_objects_with_string,
     insert_some_cities(System, 'admin/foo'),
 
     open_string('["City/Dublin", "City/Pretoria"]', Stream),
-    api_delete_documents(system_descriptor{}, 'User/admin', 'admin/foo', instance, "author", "message", Stream),
+    api_delete_documents(System, 'User/admin', 'admin/foo', instance, "author", "message", Stream, no_data_version, _New_Data_Version),
 
     resolve_absolute_string_descriptor("admin/foo", Descriptor),
     create_context(Descriptor, Context),
@@ -334,7 +369,7 @@ test(delete_objects_with_mixed_string_stream,
     insert_some_cities(System, 'admin/foo'),
 
     open_string('"City/Dublin"\n["City/Pretoria"]', Stream),
-    api_delete_documents(system_descriptor{}, 'User/admin', 'admin/foo', instance, "author", "message", Stream),
+    api_delete_documents(System, 'User/admin', 'admin/foo', instance, "author", "message", Stream, no_data_version, _New_Data_Version),
 
     resolve_absolute_string_descriptor("admin/foo", Descriptor),
     create_context(Descriptor, Context),
@@ -363,7 +398,7 @@ insert_some_cities(System, Path) :-
   "@id" : "City/Utrecht",
   "name" : "Utrecht" }',
                 Stream),
-    api_insert_documents(System, 'User/admin', Path, instance, "author", "message", false, Stream, _Out_Ids).
+    api_insert_documents(System, 'User/admin', Path, instance, "author", "message", false, Stream, no_data_version, _New_Data_Version, _Ids).
 
 test(replace_objects_with_stream,
      [setup((setup_temp_store(State),
@@ -380,7 +415,7 @@ test(replace_objects_with_stream,
 { "@type": "City",
   "@id" : "City/Pretoria",
   "name" : "Tshwane" }', Stream),
-    api_replace_documents(system_descriptor{}, 'User/admin', 'admin/foo', instance, "author", "message", Stream, false, Ids),
+    api_replace_documents(System, 'User/admin', 'admin/foo', instance, "author", "message", Stream, false, no_data_version, _New_Data_Version, Ids),
 
     Ids = ['http://example.com/data/world/City/Dublin','http://example.com/data/world/City/Pretoria'].
 
@@ -486,15 +521,7 @@ test(basic_capture, [
     open_descriptor(system_descriptor{}, SystemDB),
     super_user_authority(Auth),
 
-    api_insert_documents(SystemDB,
-                         Auth,
-                         "admin/testdb",
-                         instance,
-                         "testauthor",
-                         "testmessage",
-                         false,
-                         Stream,
-                         _Ids),
+    api_insert_documents(SystemDB, Auth, "admin/testdb", instance, "author", "message", false, Stream, no_data_version, _New_Data_Version, _Ids),
 
     open_descriptor(Desc, T),
     get_document(T, 'Person/Bert', Bert),
@@ -536,15 +563,7 @@ test(capture_missing, [
     open_descriptor(system_descriptor{}, SystemDB),
     super_user_authority(Auth),
 
-    api_insert_documents(SystemDB,
-                         Auth,
-                         "admin/testdb",
-                         instance,
-                         "testauthor",
-                         "testmessage",
-                         false,
-                         Stream,
-                         _Ids).
+    api_insert_documents(SystemDB, Auth, "admin/testdb", instance, "author", "message", false, Stream, no_data_version, _New_Data_Version, _Ids).
 
 test(double_capture, [
          setup((setup_temp_store(State),
@@ -585,15 +604,8 @@ test(double_capture, [
     open_descriptor(system_descriptor{}, SystemDB),
     super_user_authority(Auth),
 
-    api_insert_documents(SystemDB,
-                         Auth,
-                         "admin/testdb",
-                         instance,
-                         "testauthor",
-                         "testmessage",
-                         false,
-                         Stream,
-                         _Ids).
+    api_insert_documents(SystemDB, Auth, "admin/testdb", instance, "author", "message", false, Stream, no_data_version, _New_Data_Version, _Ids).
+
 test(basic_capture_list, [
          setup((setup_temp_store(State),
                 create_db_with_empty_schema("admin", "testdb"),
@@ -631,15 +643,7 @@ test(basic_capture_list, [
     open_descriptor(system_descriptor{}, SystemDB),
     super_user_authority(Auth),
 
-    api_insert_documents(SystemDB,
-                         Auth,
-                         "admin/testdb",
-                         instance,
-                         "testauthor",
-                         "testmessage",
-                         false,
-                         Stream,
-                         _Ids),
+    api_insert_documents(SystemDB, Auth, "admin/testdb", instance, "author", "message", false, Stream, no_data_version, _New_Data_Version, _Ids),
 
     open_descriptor(Desc, T),
     get_document(T, 'Person/Bert', Bert),
@@ -668,7 +672,6 @@ test(basic_capture_replace, [
                          '@class': "Person"}})
     ),
 
-
     open_string('
 { "@type": "Person",
   "name" : "Bert",
@@ -683,15 +686,7 @@ test(basic_capture_replace, [
     open_descriptor(system_descriptor{}, SystemDB),
     super_user_authority(Auth),
 
-    api_insert_documents(SystemDB,
-                         Auth,
-                         "admin/testdb",
-                         instance,
-                         "testauthor",
-                         "testmessage",
-                         false,
-                         Stream_1,
-                         _Ids_1),
+    api_insert_documents(SystemDB, Auth, "admin/testdb", instance, "author", "message", false, Stream_1, no_data_version, _New_Data_Version_1, _Ids_1),
 
     open_string('
 { "@type": "Person",
@@ -706,16 +701,7 @@ test(basic_capture_replace, [
 }',
                 Stream_2),
 
-
-    api_replace_documents(SystemDB,
-                          Auth,
-                          "admin/testdb",
-                          instance,
-                          "testauthor",
-                          "testmessage",
-                          Stream_2,
-                          false,
-                          _Ids_2),
+    api_replace_documents(SystemDB, Auth, "admin/testdb", instance, "author", "message", Stream_2, false, no_data_version, _New_Data_Version_2, _Ids_2),
 
     open_descriptor(Desc, T),
     get_document(T, 'Person/Bert', Bert),
@@ -759,15 +745,7 @@ test(basic_capture_list_replace, [
     open_descriptor(system_descriptor{}, SystemDB),
     super_user_authority(Auth),
 
-    api_insert_documents(SystemDB,
-                         Auth,
-                         "admin/testdb",
-                         instance,
-                         "testauthor",
-                         "testmessage",
-                         false,
-                         Stream_1,
-                         _Ids_1),
+    api_insert_documents(SystemDB, Auth, "admin/testdb", instance, "author", "message", false, Stream_1, no_data_version, _New_Data_Version_1, _Ids_1),
 
     open_string('
 [{ "@type": "Person",
@@ -782,16 +760,7 @@ test(basic_capture_list_replace, [
 }]',
                 Stream_2),
 
-
-    api_replace_documents(SystemDB,
-                          Auth,
-                          "admin/testdb",
-                          instance,
-                          "testauthor",
-                          "testmessage",
-                          Stream_2,
-                          false,
-                          _Ids_2),
+    api_replace_documents(SystemDB, Auth, "admin/testdb", instance, "author", "message", Stream_2, false, no_data_version, _New_Data_Version_2, _Ids_2),
 
     open_descriptor(Desc, T),
     get_document(T, 'Person/Bert', Bert),
@@ -838,15 +807,7 @@ test(insert_subdocument_as_document, [
     open_descriptor(system_descriptor{}, SystemDB),
     super_user_authority(Auth),
 
-    api_insert_documents(SystemDB,
-                         Auth,
-                         "admin/testdb",
-                         instance,
-                         "testauthor",
-                         "testmessage",
-                         false,
-                         Stream,
-                         _Ids).
+    api_insert_documents(SystemDB, Auth, "admin/testdb", instance, "author", "message", false, Stream, no_data_version, _New_Data_Version, _Ids).
 
 test(replace_nonexisting_subdocument_as_document, [
          setup((setup_temp_store(State),
@@ -877,15 +838,7 @@ test(replace_nonexisting_subdocument_as_document, [
     open_descriptor(system_descriptor{}, SystemDB),
     super_user_authority(Auth),
 
-    api_replace_documents(SystemDB,
-                         Auth,
-                         "admin/testdb",
-                         instance,
-                         "testauthor",
-                         "testmessage",
-                         Stream,
-                         true,
-                         _Ids).
+    api_replace_documents(SystemDB, Auth, "admin/testdb", instance, "author", "message", Stream, true, no_data_version, _New_Data_Version, _Ids).
 
 test(replace_existing_subdocument_as_document, [
          setup((setup_temp_store(State),
@@ -933,15 +886,7 @@ test(replace_existing_subdocument_as_document, [
     open_descriptor(system_descriptor{}, SystemDB),
     super_user_authority(Auth),
 
-    api_insert_documents(SystemDB,
-                         Auth,
-                         "admin/testdb",
-                         instance,
-                         "testauthor",
-                         "testmessage",
-                         false,
-                         Stream_1,
-                         [Outer_Id]),
+    api_insert_documents(SystemDB, Auth, "admin/testdb", instance, "author", "message", false, Stream_1, no_data_version, _New_Data_Version_1, [Outer_Id]),
 
     get_document(Desc, Outer_Id, Outer_Document),
     Id = (Outer_Document.thing.'@id'),
@@ -951,15 +896,7 @@ test(replace_existing_subdocument_as_document, [
            [Id]),
     open_string(Replace_String, Stream_2),
 
-    api_replace_documents(SystemDB,
-                         Auth,
-                         "admin/testdb",
-                         instance,
-                         "testauthor",
-                         "testmessage",
-                         Stream_2,
-                         false,
-                         _Ids),
+    api_replace_documents(SystemDB, Auth, "admin/testdb", instance, "author", "message", Stream_2, false, no_data_version, _New_Data_Version_2, _Ids_2),
 
     get_document(Desc, Id, Inner_Document),
     print_term(Inner_Document),nl.

--- a/src/core/api/api_error.pl
+++ b/src/core/api/api_error.pl
@@ -1029,6 +1029,7 @@ api_error_jsonld(diff,error(explicitly_copied_key_has_changed(Key),_), JSON) :-
                               'api:key' : Key},
              'api:message' : Msg
             }.
+
 api_error_jsonld(get_documents, Error, JSON) :-
     api_document_error_jsonld(get_documents, Error, JSON).
 api_error_jsonld(insert_documents, Error, JSON) :-
@@ -1037,6 +1038,34 @@ api_error_jsonld(replace_documents, Error, JSON) :-
     api_document_error_jsonld(replace_documents, Error, JSON).
 api_error_jsonld(delete_documents, Error, JSON) :-
     api_document_error_jsonld(delete_documents, Error, JSON).
+
+%% Errors that are common to all error types
+api_error_jsonld(Type, error(bad_data_version(Data_Version),_),JSON) :-
+    error_type(Type, Type_Msg),
+    format(string(Data_Version_String), "~w", [Data_Version]),
+    format(string(Msg), "Bad data version: ~s", [Data_Version_String]),
+    JSON = _{'@type' : Type_Msg,
+             'api:status' : "api:failure",
+             'api:error' : _{ '@type' : 'api:BadDataVersion',
+                              'api:data_version' : Data_Version_String },
+             'api:message' : Msg
+            }.
+api_error_jsonld(Type, error(data_version_mismatch(Requested_Data_Version, Actual_Data_Version), _), JSON) :-
+    error_type(Type, Type_Msg),
+    format(string(Msg), "Requested data version in header does not match actual data version.", []),
+    JSON = _{'@type' : Type_Msg,
+             'api:status' : "api:failure",
+             'api:message' : Msg,
+             'api:error' : _{ '@type' : "api:DataVersionMismatch",
+                              'api:requested_data_version' : Requested_Data_Version,
+                              'api:actual_data_version' : Actual_Data_Version }
+            }.
+
+error_type(woql, 'api:WoqlErrorResponse').
+error_type(get_documents, 'api:GetDocumentErrorResponse').
+error_type(insert_documents, 'api:InsertDocumentErrorResponse').
+error_type(replace_documents, 'api:ReplaceDocumentErrorResponse').
+error_type(delete_documents, 'api:DeleteDocumentErrorResponse').
 
 % Graph <Type>
 api_error_jsonld(graph,error(invalid_absolute_graph_descriptor(Path),_), Type, JSON) :-
@@ -1084,7 +1113,6 @@ api_error_jsonld(graph,error(graph_already_exists(Descriptor,Graph_Name), _), Ty
                               'api:graph_name' : Graph_Name,
                               'api:absolute_descriptor' : Path}
             }.
-
 
 document_error_type(get_documents, 'api:GetDocumentErrorResponse').
 document_error_type(insert_documents, 'api:InsertDocumentErrorResponse').

--- a/src/core/api/api_woql.pl
+++ b/src/core/api/api_woql.pl
@@ -1,10 +1,10 @@
-:- module(api_woql, [woql_query_json/8]).
+:- module(api_woql, [woql_query_json/10]).
 :- use_module(core(util)).
 :- use_module(core(query)).
 :- use_module(core(transaction)).
 :- use_module(core(account)).
 
-woql_query_json(System_DB, Auth, Path_Option, Query, Commit_Info, Files, All_Witnesses, JSON) :-
+woql_query_json(System_DB, Auth, Path_Option, Query, Commit_Info, Files, All_Witnesses, Requested_Data_Version, New_Data_Version, JSON) :-
 
     % No descriptor to work with until the query sets one up
     (   some(Path) = Path_Option
@@ -26,5 +26,4 @@ woql_query_json(System_DB, Auth, Path_Option, Query, Commit_Info, Files, All_Wit
     ),
 
     json_woql(Query, AST),
-    run_context_ast_jsonld_response(Context,AST,JSON).
-
+    run_context_ast_jsonld_response(Context, AST, Requested_Data_Version, New_Data_Version, JSON).

--- a/src/core/document/json.pl
+++ b/src/core/document/json.pl
@@ -2225,12 +2225,16 @@ insert_document(Transaction, Document, Captures_In, ID, Dependencies, Captures_O
     !,
     json_elaborate(Transaction, Document, Captures_In, Elaborated, Dependencies, Captures_Out),
     % Are we trying to insert a subdocument?
-    get_dict('@type', Elaborated, Type),
+    do_or_die(
+        get_dict('@type', Elaborated, Type),
+        error(missing_field('@type', Elaborated), _)),
     die_if(is_subdocument(Transaction, Type),
            error(inserted_subdocument_as_document, _)),
 
     % After elaboration, the Elaborated document will have an '@id'
-    get_dict('@id', Elaborated, ID),
+    do_or_die(
+        get_dict('@id', Elaborated, ID),
+        error(missing_field('@id', Elaborated), _)),
 
     ensure_transaction_has_builder(instance, Transaction),
     when(ground(Dependencies),

--- a/src/core/query.pl
+++ b/src/core/query.pl
@@ -50,7 +50,7 @@
               json_value_cast_type/3,
 
               % query_response.pl
-              run_context_ast_jsonld_response/3,
+              run_context_ast_jsonld_response/5,
               pretty_print_query_response/3,
 
               % resolve_query_resource.pl

--- a/src/core/query/path.pl
+++ b/src/core/query/path.pl
@@ -207,12 +207,12 @@ test(n_m, [
 
     resolve_absolute_string_descriptor("admin/test", Descriptor),
     create_context(Descriptor,Commit_Info, Context),
-    query_response:run_context_ast_jsonld_response(Context, AST, _),
+    query_response:run_context_ast_jsonld_response(Context, AST, no_data_version, _, _),
 
     AST2 = path(a, times((p(b);p(d);p(f);p(h)),1,3), v(x), v(p)),
 
     create_context(Descriptor,Commit_Info, Context2),
-    query_response:run_context_ast_jsonld_response(Context2, AST2, Result),
+    query_response:run_context_ast_jsonld_response(Context2, AST2, no_data_version, _, Result),
     get_dict(bindings,Result,Bindings),
     length(Bindings, 3).
 
@@ -232,12 +232,12 @@ test(n_m_loop, [
 
     resolve_absolute_string_descriptor("admin/test", Descriptor),
     create_context(Descriptor,Commit_Info, Context),
-    query_response:run_context_ast_jsonld_response(Context, AST, _),
+    query_response:run_context_ast_jsonld_response(Context, AST, no_data_version, _, _),
 
     AST2 = path(a, times((p(b);p(d);p(f);p(h)),1,5), v(x), v(p)),
 
     create_context(Descriptor,Commit_Info, Context2),
-    query_response:run_context_ast_jsonld_response(Context2, AST2, Result),
+    query_response:run_context_ast_jsonld_response(Context2, AST2, no_data_version, _, Result),
     get_dict(bindings,Result,Bindings),
 
     % test that we aren't going in circles

--- a/src/core/query/query_response.pl
+++ b/src/core/query/query_response.pl
@@ -1,5 +1,5 @@
 :- module(query_response,[
-              run_context_ast_jsonld_response/3,
+              run_context_ast_jsonld_response/5,
               pretty_print_query_response/3
           ]).
 
@@ -19,8 +19,13 @@
  *
  * Code to generate bindings for query response in JSON-LD
  */
-run_context_ast_jsonld_response(Context, AST, JSON) :-
+run_context_ast_jsonld_response(Context, AST, Requested_Data_Version, New_Data_Version, Binding_JSON) :-
     compile_query(AST,Prog,Context,Output_Context),
+    do_or_die(
+        query_default_collection(Output_Context, Transaction),
+        error(query_default_collection_failed_unexpectedly(Output_Context), _)),
+    transaction_data_version(Transaction, Actual_Data_Version),
+    compare_data_versions(Requested_Data_Version, Actual_Data_Version),
     with_transaction(
         Output_Context,
         query_response:(
@@ -34,12 +39,17 @@ run_context_ast_jsonld_response(Context, AST, JSON) :-
         ),
         Meta_Data
     ),
+    meta_data_version(Transaction, Meta_Data, New_Data_Version),
     context_variable_names(Output_Context, Names),
     Binding_JSON = _{'@type' : 'api:WoqlResponse',
                      'api:status' : 'api:success',
                      'api:variable_names' : Names,
-                     'bindings' : Binding_Set},
-    put_dict(Meta_Data, Binding_JSON, JSON).
+                     'bindings' : Binding_Set,
+                     % These are whitelisted metadata fields for serialization.
+                     % Other fields (e.g. data_versions) cannot be serialized.
+                     inserts : Meta_Data.inserts,
+                     deletes : Meta_Data.deletes,
+                     transaction_retry_count : Meta_Data.transaction_retry_count }.
 
 context_variable_names(Context, Header) :-
     get_dict(bindings, Context, Bindings),

--- a/src/core/query/woql_compile.pl
+++ b/src/core/query/woql_compile.pl
@@ -1946,7 +1946,7 @@ filter_transaction(type_name_filter{ type : schema}, Transaction, New_Transactio
 :- use_module(ask,[ask/2,create_context/2, create_context/3, context_extend_prefixes/3]).
 % NOTE: This circularity is very irritating...
 % We are merely hoping that query_response is loaded before we run this test.
-%:- use_module(query_response, [run_context_ast_jsonld_response/3]).
+%:- use_module(query_response, [run_context_ast_jsonld_response/5]).
 :- use_module(library(ordsets)).
 :- use_module(core(util/test_utils)).
 :- use_module(core(api)).
@@ -1973,7 +1973,7 @@ query_test_response(Descriptor, Query, Response) :-
     create_context(Descriptor,commit_info{ author : "automated test framework",
                                            message : "testing"}, Context),
     json_woql(Query, AST),
-    query_response:run_context_ast_jsonld_response(Context, AST, Response).
+    query_response:run_context_ast_jsonld_response(Context, AST, no_data_version, _, Response).
 
 test(subsumption, [setup(setup_temp_store(State)),
                    cleanup(teardown_temp_store(State))
@@ -2546,7 +2546,7 @@ test(length_of_var, [
 
     create_context(system_descriptor{},Commit_Info, Context),
 
-    query_response:run_context_ast_jsonld_response(Context, AST, Result),
+    query_response:run_context_ast_jsonld_response(Context, AST, no_data_version, _, Result),
     [First] = (Result.bindings),
     (First.'N'.'@value') = 3.
 
@@ -3388,7 +3388,7 @@ test(ast_when_test, [
 
     AST = when(t(a,b,v('X')),
                insert(e, f, v('X'))),
-    query_response:run_context_ast_jsonld_response(Context2, AST, _JSON),
+    query_response:run_context_ast_jsonld_response(Context2, AST, no_data_version, _, _JSON),
 
     findall(t(X,P,Y),
             ask(Descriptor, t(X, P, Y)),
@@ -3421,7 +3421,7 @@ test(ast_when_update, [
                 (   delete(a, v('P'), v('X')),
                     insert(a, v('P'), g)))),
 
-    query_response:run_context_ast_jsonld_response(Context2, AST, _JSON),
+    query_response:run_context_ast_jsonld_response(Context2, AST, no_data_version, _, _JSON),
 
     findall(t(X,P,Y),
             ask(Descriptor, t(X, P, Y)),
@@ -3607,7 +3607,7 @@ test(date_marshall, [
     create_context(Descriptor,commit_info{ author : "automated test framework",
                                            message : "testing"}, Context),
 
-    query_response:run_context_ast_jsonld_response(Context, AST, Response),
+    query_response:run_context_ast_jsonld_response(Context, AST, no_data_version, _, Response),
 
     [_{'Start date':
        _{'@type':'xsd:dateTime',
@@ -3626,7 +3626,7 @@ test(into_absolute_descriptor, [
     create_context(Descriptor,commit_info{ author : "automated test framework",
                                            message : "testing"}, Context),
 
-    query_response:run_context_ast_jsonld_response(Context, AST, Response),
+    query_response:run_context_ast_jsonld_response(Context, AST, no_data_version, _, Response),
     Response.inserts = 1.
 
 test(one_witness, [
@@ -3641,7 +3641,7 @@ test(one_witness, [
     create_context(Descriptor,commit_info{ author : "automated test framework",
                                            message : "testing"}, Context),
 
-    query_response:run_context_ast_jsonld_response(Context, AST, _Response).
+    query_response:run_context_ast_jsonld_response(Context, AST, no_data_version, _, _Response).
 
 test(using_insert_default_graph, [
          setup((setup_temp_store(State),
@@ -3661,7 +3661,7 @@ test(using_insert_default_graph, [
     resolve_absolute_string_descriptor("admin/test", Descriptor),
     create_context(Descriptor,Commit_Info, Context),
 
-    query_response:run_context_ast_jsonld_response(Context, AST, _Response),
+    query_response:run_context_ast_jsonld_response(Context, AST, no_data_version, _, _Response),
 
     resolve_absolute_string_descriptor("admin/test/local/branch/new",
                                        New_Descriptor),
@@ -3681,14 +3681,14 @@ test(count_test, [
     resolve_absolute_string_descriptor("admin/test", Descriptor),
     create_context(Descriptor,Commit_Info, Context),
 
-    query_response:run_context_ast_jsonld_response(Context, AST, _Response),
+    query_response:run_context_ast_jsonld_response(Context, AST, no_data_version, _, _Response),
 
     resolve_absolute_string_descriptor("admin/test", New_Descriptor),
 
     New_AST = count(t(v('X'),v('Y'),v('Z')), v('Count')),
     create_context(New_Descriptor,Commit_Info,New_Context),
 
-    query_response:run_context_ast_jsonld_response(New_Context, New_AST, New_Response),
+    query_response:run_context_ast_jsonld_response(New_Context, New_AST, no_data_version, _, New_Response),
     [Binding] = (New_Response.bindings),
     2 = (Binding.'Count'.'@value').
 
@@ -3705,7 +3705,7 @@ test(unbound_test, [
     resolve_absolute_string_descriptor("admin/test", Descriptor),
     create_context(Descriptor,Commit_Info, Context),
 
-    query_response:run_context_ast_jsonld_response(Context, AST, _Response).
+    query_response:run_context_ast_jsonld_response(Context, AST, no_data_version, _, _Response).
 
 test(distinct, [
          setup((setup_temp_store(State),
@@ -3722,7 +3722,7 @@ test(distinct, [
     resolve_absolute_string_descriptor("admin/test", Descriptor),
     create_context(Descriptor,Commit_Info, Context),
 
-    query_response:run_context_ast_jsonld_response(Context, AST, Response),
+    query_response:run_context_ast_jsonld_response(Context, AST, no_data_version, _, Response),
     Bindings = (Response.bindings),
     findall(X-Y,
             (   member(B,Bindings),
@@ -3747,7 +3747,7 @@ test(immediately, [
     resolve_absolute_string_descriptor("admin/test", Descriptor),
     create_context(Descriptor,Commit_Info, Context),
 
-    query_response:run_context_ast_jsonld_response(Context, AST, _),
+    query_response:run_context_ast_jsonld_response(Context, AST, no_data_version, _, _),
 
     once(ask(Descriptor,
              t(a,b,c))).
@@ -3766,7 +3766,7 @@ test(immediately_doesnt_go, [
     resolve_absolute_string_descriptor("admin/test", Descriptor),
     create_context(Descriptor,Commit_Info, Context),
 
-    query_response:run_context_ast_jsonld_response(Context, AST, _),
+    query_response:run_context_ast_jsonld_response(Context, AST, no_data_version, _, _),
 
     \+ once(ask(Descriptor,
                 t(a,b,c))).
@@ -3787,7 +3787,7 @@ test(negative_path_pattern, [
     resolve_absolute_string_descriptor("admin/test", Descriptor),
     create_context(Descriptor,Commit_Info, Context),
 
-    query_response:run_context_ast_jsonld_response(Context, AST, _),
+    query_response:run_context_ast_jsonld_response(Context, AST, no_data_version, _, _),
 
     once(ask(Descriptor,
              path(a, plus((p(b),n(b))), f, _Path))).
@@ -3808,7 +3808,7 @@ test(any_path_pattern, [
     resolve_absolute_string_descriptor("admin/test", Descriptor),
     create_context(Descriptor,Commit_Info, Context),
 
-    query_response:run_context_ast_jsonld_response(Context, AST, _),
+    query_response:run_context_ast_jsonld_response(Context, AST, no_data_version, _, _),
     once(ask(Descriptor,
              path(a, plus((p,n)), f, _Path))).
 
@@ -3826,7 +3826,7 @@ test(any_two_path_pattern, [
     resolve_absolute_string_descriptor("admin/test", Descriptor),
     create_context(Descriptor,Commit_Info, Context),
 
-    query_response:run_context_ast_jsonld_response(Context, AST, _),
+    query_response:run_context_ast_jsonld_response(Context, AST, no_data_version, _, _),
     findall(
         Path,
         ask(Descriptor,
@@ -3853,7 +3853,7 @@ test(list_path_pattern, [
     resolve_absolute_string_descriptor("admin/test", Descriptor),
     create_context(Descriptor,Commit_Info, Context),
 
-    query_response:run_context_ast_jsonld_response(Context, AST, _),
+    query_response:run_context_ast_jsonld_response(Context, AST, no_data_version, _, _),
     findall(
         Path0,
         ask(Descriptor,
@@ -3939,7 +3939,7 @@ test(added_deleted_triple, [
     resolve_absolute_string_descriptor("admin/test", Descriptor),
     create_context(Descriptor,Commit_Info, Context),
 
-    query_response:run_context_ast_jsonld_response(Context, AST, _),
+    query_response:run_context_ast_jsonld_response(Context, AST, no_data_version, _, _),
 
 
     AST2 = (insert(h,i,j),
@@ -3947,7 +3947,7 @@ test(added_deleted_triple, [
 
     create_context(Descriptor,Commit_Info, Context2),
 
-    query_response:run_context_ast_jsonld_response(Context2, AST2, _),
+    query_response:run_context_ast_jsonld_response(Context2, AST2, no_data_version, _, _),
 
     once(ask(Descriptor,
              (   addition(h,i,j),
@@ -3971,14 +3971,14 @@ test(added_deleted_quad, [
     resolve_absolute_string_descriptor("admin/test", Descriptor),
     create_context(Descriptor,Commit_Info, Context),
 
-    query_response:run_context_ast_jsonld_response(Context, AST, _),
+    query_response:run_context_ast_jsonld_response(Context, AST, no_data_version, _, _),
 
     AST2 = (insert(h,i,j),
             delete(a,b,c)),
 
     create_context(Descriptor,Commit_Info, Context2),
 
-    query_response:run_context_ast_jsonld_response(Context2, AST2, _),
+    query_response:run_context_ast_jsonld_response(Context2, AST2, no_data_version, _, _),
 
     once(ask(Descriptor,
              (   addition(h,i,j, instance),
@@ -4001,7 +4001,7 @@ test(guard_interspersed_insertions, [
     resolve_absolute_string_descriptor("admin/test", Descriptor),
     create_context(Descriptor,Commit_Info, Context),
 
-    query_response:run_context_ast_jsonld_response(Context, AST, _),
+    query_response:run_context_ast_jsonld_response(Context, AST, no_data_version, _, _),
 
     \+ ask(Descriptor,
            (   t(a,b,c))).
@@ -4019,7 +4019,7 @@ test(guard_safe_intersperesed_insertions, [
     resolve_absolute_string_descriptor("admin/test", Descriptor),
     create_context(Descriptor,Commit_Info, Context),
 
-    query_response:run_context_ast_jsonld_response(Context, AST, _),
+    query_response:run_context_ast_jsonld_response(Context, AST, no_data_version, _, _),
 
 
     AST2 = (insert(e,f,g),
@@ -4028,7 +4028,7 @@ test(guard_safe_intersperesed_insertions, [
 
     create_context(Descriptor,Commit_Info, Context2),
 
-    query_response:run_context_ast_jsonld_response(Context2, AST2, _),
+    query_response:run_context_ast_jsonld_response(Context2, AST2, no_data_version, _, _),
 
     once(ask(Descriptor,
              (   t(a,b,c),
@@ -4048,7 +4048,7 @@ test(guard_safe_insertions, [
     resolve_absolute_string_descriptor("admin/test", Descriptor),
     create_context(Descriptor,Commit_Info, Context),
 
-    query_response:run_context_ast_jsonld_response(Context, AST, _),
+    query_response:run_context_ast_jsonld_response(Context, AST, no_data_version, _, _),
 
     create_context(Descriptor,Commit_Info, Context2),
 
@@ -4056,7 +4056,7 @@ test(guard_safe_insertions, [
         t(a,b,c),
         insert(e,f,g)),
 
-    query_response:run_context_ast_jsonld_response(Context2, AST2, _),
+    query_response:run_context_ast_jsonld_response(Context2, AST2, no_data_version, _, _),
 
     once(ask(Descriptor,
              (   t(a,b,c),
@@ -4075,7 +4075,7 @@ test(guard_disjunctive_insertions, [
     resolve_absolute_string_descriptor("admin/test", Descriptor),
     create_context(Descriptor,Commit_Info, Context),
 
-    query_response:run_context_ast_jsonld_response(Context, AST, _),
+    query_response:run_context_ast_jsonld_response(Context, AST, no_data_version, _, _),
 
     create_context(Descriptor,Commit_Info, Context2),
 
@@ -4084,7 +4084,7 @@ test(guard_disjunctive_insertions, [
            ;   not(t(a,b,c)),
                insert(x,y,z)),
 
-    query_response:run_context_ast_jsonld_response(Context2, AST2, _),
+    query_response:run_context_ast_jsonld_response(Context2, AST2, no_data_version, _, _),
 
     once(ask(Descriptor,
              t(e,f,g))),
@@ -4105,7 +4105,7 @@ test(guard_deep_insertions, [
     resolve_absolute_string_descriptor("admin/test", Descriptor),
     create_context(Descriptor,Commit_Info, Context),
 
-    query_response:run_context_ast_jsonld_response(Context, AST, _),
+    query_response:run_context_ast_jsonld_response(Context, AST, no_data_version, _, _),
 
     create_context(Descriptor,Commit_Info, Context2),
 
@@ -4116,7 +4116,7 @@ test(guard_deep_insertions, [
                ),
                insert(l,m,n)),
 
-    query_response:run_context_ast_jsonld_response(Context2, AST2, _),
+    query_response:run_context_ast_jsonld_response(Context2, AST2, no_data_version, _, _),
 
     once(ask(Descriptor,
              (   t(e,f,g),
@@ -4142,7 +4142,7 @@ test(using_multiple_prefixes, [
     resolve_absolute_string_descriptor("admin/schemaless_db", Descriptor),
     create_context(Descriptor,Commit_Info, Context),
 
-    query_response:run_context_ast_jsonld_response(Context, AST, _).
+    query_response:run_context_ast_jsonld_response(Context, AST, no_data_version, _, _).
 
 test(bad_class_vio, [
          setup((setup_temp_store(State),
@@ -4166,7 +4166,7 @@ test(bad_class_vio, [
     resolve_absolute_string_descriptor("admin/schema_db", Descriptor),
     create_context(Descriptor,Commit_Info, Context),
 
-    query_response:run_context_ast_jsonld_response(Context, AST, _Result).
+    query_response:run_context_ast_jsonld_response(Context, AST, no_data_version, _, _Result).
 
 
 test(typeof, [
@@ -4463,7 +4463,7 @@ test(commit_graph, [
                           t(v(target_commit),timestamp,v(timestamp))))),
 
     create_context(Descriptor, commit_info{ author : "test", message: "message3"}, Context3),
-    query_response:run_context_ast_jsonld_response(Context3, AST, Response),
+    query_response:run_context_ast_jsonld_response(Context3, AST, no_data_version, _, Response),
     [Commit1,Commit2] = (Response.bindings),
     (Commit1.message.'@value') = "message2",
     (Commit2.message.'@value') = "message1".
@@ -4588,7 +4588,7 @@ test(jobs_group_by, [
                         length(v('JobRoleInterestGroup'),v('TheCount'))))),
     create_context(Descriptor, commit_info{ author : "test", message: "message2"},
                    Context2),
-    query_response:run_context_ast_jsonld_response(Context2, AST, Response),
+    query_response:run_context_ast_jsonld_response(Context2, AST, no_data_version, _, Response),
     [_{'JobInterest':json{'@type':'xsd:string','@value':"Something"},
        'JobRoleInterestGroup':[json{'@type':'xsd:string','@value':"foo"},
                                json{'@type':'xsd:string','@value':"bar"}],
@@ -4682,6 +4682,8 @@ test(less_than, [
                     Commit_Info,
                     [],
                     false,
+                    no_data_version,
+                    _,
                     JSON),
     [_] = (JSON.bindings).
 
@@ -4733,6 +4735,8 @@ test(using_resource_works, [
                     Commit_Info,
                     [],
                     false,
+                    no_data_version,
+                    _,
                     _JSON).
 
 test(quad_compilation, [
@@ -4820,7 +4824,7 @@ test(document_path, [
     ),
 
     create_context(Descriptor, Commit_Info, C3),
-    query_response:run_context_ast_jsonld_response(C3, AST, Response),
+    query_response:run_context_ast_jsonld_response(C3, AST, no_data_version, _, Response),
     (Response.bindings) =
     [_{'Links':[_{source:'Node/a',target:'Node/b'},
                 _{source:'Node/a',target:'Node/c'},
@@ -4843,7 +4847,7 @@ test(test_matching, [
     AST = (_{ a : 1, b : v('X')} = _{ a : v('Y'), b : 2}),
 
     create_context(Descriptor, Commit_Info, C1),
-    query_response:run_context_ast_jsonld_response(C1, AST, Response),
+    query_response:run_context_ast_jsonld_response(C1, AST, no_data_version, _, Response),
     (Response.bindings) = [ _{'X':2, 'Y':1} ].
 
 test(json_dict_vars, [
@@ -4970,7 +4974,7 @@ test(insert_read_document, [
     resolve_absolute_string_descriptor('admin/test', Descriptor),
     create_context(Descriptor, commit_info{ author : "test", message: "message"}, Context2),
     Read_AST = get_document(ID,v('Doc')),
-    query_response:run_context_ast_jsonld_response(Context2, Read_AST, Response),
+    query_response:run_context_ast_jsonld_response(Context2, Read_AST, no_data_version, _, Response),
     [Res2] = (Response.bindings),
     _{'@id':_,
       '@type':'City',

--- a/src/core/transaction.pl
+++ b/src/core/transaction.pl
@@ -32,7 +32,7 @@
               % validate.pl
               transaction_objects_to_validation_objects/2,
               validation_objects_to_transaction_objects/2,
-              commit_validation_objects/1,
+              commit_validation_objects/2,
               commit_validation_object/2,
               commit_commit_validation_object/4,
               validate_validation_objects/2,

--- a/src/core/transaction/database.pl
+++ b/src/core/transaction/database.pl
@@ -269,8 +269,10 @@ run_transactions(Transactions, All_Witnesses, Meta_Data) :-
     (   Witnesses = []
     ->  true
     ;   throw(error(schema_check_failure(Witnesses),_))),
-    commit_validation_objects(Validations),
-    collect_validations_metadata(Validations, Meta_Data).
+    commit_validation_objects(Validations, Committed),
+    collect_validations_metadata(Validations, Validation_Meta_Data),
+    collect_commit_metadata(Committed, Commit_Meta_Data),
+    put_dict(Validation_Meta_Data, Commit_Meta_Data, Meta_Data).
 
 
 /* Note: This should not exist */
@@ -337,6 +339,15 @@ collect_validations_metadata(Validations, Meta_Data) :-
               deletes : 0
           },
           Meta_Data).
+
+collect_commit_metadata(Validations, Meta_Data) :-
+    convlist({Validations}/[Validation, Descriptor-Data_Version]>>(
+                transaction_data_version(Validation, Validations, Data_Version),
+                get_dict(descriptor, Validation, Descriptor)
+             ),
+             Validations,
+             Pairs),
+    Meta_Data = meta_data{data_versions : Pairs}.
 
 /*
  * query_context_transaction_objects(+Query_Object,Transaction_Objects) is det.

--- a/src/core/transaction/database.pl
+++ b/src/core/transaction/database.pl
@@ -342,7 +342,7 @@ collect_validations_metadata(Validations, Meta_Data) :-
 
 collect_commit_metadata(Validations, Meta_Data) :-
     convlist({Validations}/[Validation, Descriptor-Data_Version]>>(
-                transaction_data_version(Validation, Validations, Data_Version),
+                validation_data_version(Validation, Validations, Data_Version),
                 get_dict(descriptor, Validation, Descriptor)
              ),
              Validations,

--- a/src/core/util.pl
+++ b/src/core/util.pl
@@ -239,7 +239,7 @@
               read_data_version_header/2,
               write_data_version_header/1,
               transaction_data_version/2,
-              transaction_data_version/3,
+              validation_data_version/3,
               meta_data_version/3
           ]).
 

--- a/src/core/util.pl
+++ b/src/core/util.pl
@@ -232,7 +232,15 @@
               param_value_search_or_json_optional/6,
               param_value_search_author/2,
               param_value_search_message/2,
-              param_value_search_graph_type/2
+              param_value_search_graph_type/2,
+
+              % data_version.pl
+              compare_data_versions/2,
+              read_data_version_header/2,
+              write_data_version_header/1,
+              transaction_data_version/2,
+              transaction_data_version/3,
+              meta_data_version/3
           ]).
 
 % note: test_utils is intentionally omitted
@@ -248,3 +256,4 @@
 %:- use_module(util/plunit_patch).
 :- use_module(util/param).
 :- use_module(util/json_log).
+:- use_module(util/data_version).

--- a/src/core/util/data_version.pl
+++ b/src/core/util/data_version.pl
@@ -92,10 +92,9 @@ write_data_version_header(Data_Version) :-
     throw(error(unexpected_argument_instantiation(write_data_version_header, Data_Version), _)).
 
 /**
- * transaction_data_version(+Transaction, -Data_Version) is semidet.
+ * transaction_data_version(+Transaction, -Data_Version) is det.
  *
- * Return the data version of a transaction object. Fail if Transaction does not
- * have a data version.
+ * Return the data version of a transaction object.
  */
 transaction_data_version(Transaction, Data_Version) :-
     utils:do_or_die(
@@ -108,7 +107,11 @@ transaction_data_version(Transaction, Data_Version) :-
     ->  Repo_Object = Parent
     ;   Repo_Object = Transaction
     ),
-    extract_data_version(Descriptor, Repo_Object, Data_Version).
+    % We only check a transaction where we expect to find a data version. So,
+    % extract_data_version should never fail.
+    utils:do_or_die(
+        data_version:extract_data_version(Descriptor, Repo_Object, Data_Version),
+        error(data_version_not_found(Transaction), _)).
 
 /**
  * validation_data_version(+Validation, +Validations, -Data_Version) is semidet.

--- a/src/core/util/data_version.pl
+++ b/src/core/util/data_version.pl
@@ -133,6 +133,8 @@ transaction_data_version(Object, Objects, Data_Version) :-
         % Search Objects for the matching repository object.
         member(Repo_Object, Objects),
         get_dict(descriptor, Repo_Object, Repo_Descriptor),
+        % Remove choice points when we find a match.
+        !,
         transaction_data_version_(Descriptor, Repo_Object, Data_Version)
     ).
 

--- a/src/core/util/data_version.pl
+++ b/src/core/util/data_version.pl
@@ -1,0 +1,180 @@
+:- module(data_version, [
+              compare_data_versions/2,
+              read_data_version_header/2,
+              write_data_version_header/1,
+              transaction_data_version/2,
+              transaction_data_version/3,
+              meta_data_version/3
+          ]).
+
+:- use_module(library(plunit)).
+
+/**
+ * compare_data_versions(+Requested_Data_Version, +Actual_Data_Version) is det.
+ *
+ * Compare data versions. Throw an exception if they are different.
+ */
+compare_data_versions(no_data_version, _Actual_Data_Version) :-
+    !.
+compare_data_versions(data_version(Label, Value), data_version(Label, Value)) :-
+    !.
+compare_data_versions(data_version(Requested_Label, Requested_Value), data_version(Actual_Label, Actual_Value)) :-
+    !,
+    atomic_list_concat([Requested_Label, ':', Requested_Value], Requested_Data_Version),
+    atomic_list_concat([Actual_Label, ':', Actual_Value], Actual_Data_Version),
+    throw(error(data_version_mismatch(Requested_Data_Version, Actual_Data_Version), _)).
+compare_data_versions(Requested_Data_Version, _Actual_Data_Version) :-
+    throw(error(unexpected_argument_instantiation(compare_data_versions, Requested_Data_Version), _)).
+
+/**
+ * read_data_version_header(+Request, -Data_Version) is det.
+ *
+ * Compare data versions. Throw an exception if they are different.
+ */
+read_data_version_header(Request, Data_Version) :-
+    utils:die_if(
+        nonvar(Data_Version),
+        error(unexpected_argument_instantiation(read_data_version_header, Data_Version), _)),
+    memberchk(terminusdb_data_version(Header), Request),
+    !,
+    utils:do_or_die(
+        data_version:read_data_version_header_(Header, Data_Version),
+        error(bad_data_version(Header), _)).
+read_data_version_header(_Request, no_data_version).
+
+read_data_version_header_(Header, data_version(Label, Value)) :-
+    once(sub_atom(Header, Label_Length, 1, Value_Length, ':')),
+    % The lengths should be > 0, but we know they will be larger.
+    Label_Length > 3,
+    Value_Length > 3,
+    once(sub_atom(Header, 0, Label_Length, _After_Label, Label)),
+    Before_Value is Label_Length + 1,
+    once(sub_atom(Header, Before_Value, Value_Length, 0, Value)),
+    % Check for extraneous colons.
+    \+ sub_atom(Value, _, _, _, ':').
+
+:- begin_tests(read_data_version_header_tests).
+
+test("empty header", [fail]) :-
+    read_data_version_header_('', _).
+
+test("empty label and value", [fail]) :-
+    read_data_version_header_(':', _).
+
+test("empty label", [fail]) :-
+    read_data_version_header_(':value', _).
+
+test("empty value", [fail]) :-
+    read_data_version_header_('label:', _).
+
+test("extraneous colons", [fail]) :-
+    read_data_version_header_('label:value1:value2', _).
+
+test("short label", [fail]) :-
+    read_data_version_header_('labe:value', _).
+
+test("short value", [fail]) :-
+    read_data_version_header_('label:valu', _).
+
+test("pass") :-
+    read_data_version_header_('label:value', data_version(label, value)).
+
+:- end_tests(read_data_version_header_tests).
+
+write_data_version_header(data_version(Data_Version_Label, Data_Version_Value)) :-
+    atom(Data_Version_Label),
+    atom(Data_Version_Value),
+    !,
+    format("TerminusDB-Data-Version: ~s:~s~n", [Data_Version_Label, Data_Version_Value]).
+write_data_version_header(no_data_version) :-
+    !.
+write_data_version_header(Data_Version) :-
+    throw(error(unexpected_argument_instantiation(write_data_version_header, Data_Version), _)).
+
+/**
+ * transaction_data_version(+Object, -Data_Version) is semidet.
+ *
+ * Look for the data version of a transaction/validation object. Fail if Object
+ * does not have a data version.
+ */
+transaction_data_version(Object, Data_Version) :-
+    utils:do_or_die(
+        (   is_dict(Object),
+            (   transaction_object{} :< Object
+            ;   validation_object{} :< Object
+            )),
+        error(unexpected_argument_instantiation('transaction_data_version/2', Object), _)),
+    % Check if Object has a parent repository object and set that.
+    (   get_dict(parent, Object, Parent)
+    ->  Repo_Object = Parent
+    ;   Repo_Object = Object
+    ),
+    transaction_data_version_(Object.descriptor, Repo_Object, Data_Version).
+
+/**
+ * transaction_data_version(+Object, +Objects, -Data_Version) is semidet.
+ *
+ * Look for the data version of a transaction/validation object using Objects to
+ * look for Object's repository transaction/validation object. Fail if Object
+ * does not have a data version.
+ */
+transaction_data_version(Object, Objects, Data_Version) :-
+    utils:do_or_die(
+        (   is_dict(Object),
+            is_list(Objects),
+            (   transaction_object{} :< Object
+            ;   validation_object{} :< Object
+            )),
+        error(unexpected_argument_instantiation('transaction_data_version/3', objects(Object, Objects)), _)),
+    Descriptor = Object.descriptor,
+    (   transaction_data_version_(Descriptor, Object, Data_Version)
+    ->  true
+    ;   get_dict(repository_descriptor, Descriptor, Repo_Descriptor),
+        % Search Objects for the matching repository object.
+        member(Repo_Object, Objects),
+        get_dict(descriptor, Repo_Object, Repo_Descriptor),
+        transaction_data_version_(Descriptor, Repo_Object, Data_Version)
+    ).
+
+transaction_data_version_(Descriptor, Repo_Object, data_version(branch, Commit_Id)) :-
+    branch_descriptor{} :< Descriptor,
+    !,
+    % The /api/document/<org>/<db> endpoint uses a branch head commit ID as a
+    % data version. Since the schema and instance updates affect the same
+    % branch, we need only one commit ID for both.
+    transaction:branch_head_commit(Repo_Object, Descriptor.branch_name, Commit_Uri),
+    transaction:commit_id_uri(Repo_Object, Commit_Id_String, Commit_Uri),
+    atom_string(Commit_Id, Commit_Id_String).
+transaction_data_version_(Descriptor, Object, data_version(system, Value)) :-
+    system_descriptor{} :< Descriptor,
+    !,
+    % The /api/document/_system endpoint can be used to update the schema graph
+    % or the instance graph, and each lives in a separate layer. Rather than
+    % expect the client to track the graph, we use the layer IDs of both.
+    [Schema_Object] = Object.schema_objects,
+    [Instance_Object] = Object.instance_objects,
+    terminus_store:layer_to_id(Schema_Object.read, Schema_Layer_Id),
+    terminus_store:layer_to_id(Instance_Object.read, Instance_Layer_Id),
+    atomic_list_concat([Schema_Layer_Id, '/', Instance_Layer_Id], Value).
+transaction_data_version_(Descriptor, Object, data_version(Label, Layer_Id)) :-
+    (   repository_descriptor{} :< Descriptor, Label = repo
+    ;   database_descriptor{} :< Descriptor, Label = meta
+    ),
+    !,
+    % Both the _meta and _commit endpoints use only the instance graph layer ID
+    % for a data version. The schema_objects in each contains the ontology
+    % graph. While it is possible to change the ontology graph, we do not report
+    % that change in the data version.
+    [Instance_Object] = Object.instance_objects,
+    terminus_store:layer_to_id(Instance_Object.read, Layer_Id_String),
+    atom_string(Layer_Id, Layer_Id_String).
+
+/**
+ * meta_data_version(+Object_With_Descriptor, +Meta_Data, -Data_Version) is det.
+ *
+ * Look up the data version for a descriptor in the transaction metadata.
+ */
+meta_data_version(Object_With_Descriptor, Meta_Data, Data_Version) :-
+    utils:do_or_die(
+        memberchk(Object_With_Descriptor.descriptor-Data_Version, Meta_Data.data_versions),
+        error(unexpected_argument_instantiation(meta_data_version, args(Object_With_Descriptor, Meta_Data)), _)).

--- a/src/core/util/test_utils.pl
+++ b/src/core/util/test_utils.pl
@@ -333,16 +333,11 @@ print_all_triples(Askable, Selector) :-
 print_all_documents(Askable) :-
     print_all_documents(Askable, instance).
 
-get_selector_document(instance, Askable, Id, Document) :-
-    get_document(Askable, Id, Document).
-get_selector_document(schema, Askable, Id, Document) :-
-    get_schema_document(Askable, Id, Document).
-
 print_all_documents(Askable, Selector) :-
     nl,
     forall(
-        api_document:api_generate_document_ids(Selector, Askable, true, 0, unlimited, Id),
-        (   get_selector_document(Selector, Askable, Id, Document),
+        api_document:api_generate_document_ids(Selector, Askable, false, 0, unlimited, Id),
+        (   api_document:api_get_document(Selector, Askable, true, false, Id, Document),
             json_write_dict(current_output, Document, []))),
     nl.
 

--- a/tests/lib/endpoint.js
+++ b/tests/lib/endpoint.js
@@ -35,6 +35,36 @@ function document (params) {
   }
 }
 
+function documentCommits (params) {
+  params = new Params(params)
+  const orgName = params.stringRequired('orgName')
+  const dbName = params.stringRequired('dbName')
+  const remoteName = params.string('remoteName', 'local')
+  return {
+    path: `/api/document/${orgName}/${dbName}/${remoteName}/_commits`,
+    orgName: orgName,
+    dbName: dbName,
+    remoteName: remoteName,
+  }
+}
+
+function documentMeta (params) {
+  params = new Params(params)
+  const orgName = params.stringRequired('orgName')
+  const dbName = params.stringRequired('dbName')
+  return {
+    path: `/api/document/${orgName}/${dbName}/_meta`,
+    orgName: orgName,
+    dbName: dbName,
+  }
+}
+
+function documentSystem () {
+  return {
+    path: '/api/document/_system',
+  }
+}
+
 function remote (params) {
   params = new Params(params)
   const orgName = params.stringRequired('orgName')
@@ -60,11 +90,26 @@ function patch (params) {
   }
 }
 
+function woqlResource (params) {
+  params = new Params(params)
+  const orgName = params.stringRequired('orgName')
+  const dbName = params.stringRequired('dbName')
+  return {
+    path: `/api/woql/${orgName}/${dbName}`,
+    orgName: orgName,
+    dbName: dbName,
+  }
+}
+
 module.exports = {
   branch,
   db,
-  document,
-  remote,
   diff,
+  document,
+  documentCommits,
+  documentMeta,
+  documentSystem,
   patch,
+  remote,
+  woqlResource,
 }

--- a/tests/lib/index.js
+++ b/tests/lib/index.js
@@ -1,8 +1,9 @@
 exports.Agent = require('./agent.js').Agent
+exports.Params = require('./params.js').Params
 exports.branch = require('./branch.js')
 exports.db = require('./db.js')
 exports.document = require('./document.js')
 exports.endpoint = require('./endpoint.js')
 exports.organization = require('./organization.js')
-exports.Params = require('./params.js').Params
 exports.util = require('./util.js')
+exports.woql = require('./woql.js')

--- a/tests/lib/params.js
+++ b/tests/lib/params.js
@@ -9,7 +9,9 @@ const util = require('./util.js')
 class Params {
   // Wrap an object with `Params`.
   constructor (params) {
-    this.params = params || {}
+    // Clone with Object.assign() so that we can later use assertEmpty() without
+    // actually changing the params passed in.
+    this.params = Object.assign({}, params || {})
   }
 
   // Assert that there are no more parameters.

--- a/tests/lib/woql.js
+++ b/tests/lib/woql.js
@@ -1,0 +1,33 @@
+const { expect } = require('chai')
+
+const { Params } = require('./params.js')
+
+function post (agent, path, params) {
+  params = new Params(params)
+  const body = {}
+  body.query = params.object('query')
+  body.commit_info = params.object('commit_info')
+  params.assertEmpty()
+
+  return agent
+    .post(path)
+    .send(body)
+}
+
+function verifyGetSuccess (r) {
+  expect(r.status).to.equal(200)
+  return r
+}
+
+function verifyGetFailure (r) {
+  expect(r.status).to.equal(400)
+  expect(r.body['api:status']).to.equal('api:failure')
+  expect(r.body['@type']).to.equal('api:WoqlErrorResponse')
+  return r
+}
+
+module.exports = {
+  post,
+  verifyGetSuccess,
+  verifyGetFailure,
+}

--- a/tests/test/data-version.js
+++ b/tests/test/data-version.js
@@ -1,0 +1,255 @@
+const { expect } = require('chai')
+const { Agent, db, document, endpoint, util, woql } = require('../lib')
+
+const randomType0 = util.randomString()
+const randomType1 = util.randomString()
+const randomType2 = util.randomString()
+
+function dataVersionHeader (r) {
+  return r.header['terminusdb-data-version']
+}
+
+function lastDataVersionHeader (rs) {
+  return dataVersionHeader(rs[rs.length - 1])
+}
+
+function expectHeaders (label, rs) {
+  const h = rs.map(dataVersionHeader)
+  const re = new RegExp('^' + label + ':')
+  expect(h[0]).to.match(re)
+  expect(h[1]).to.match(re)
+  expect(h[0]).to.not.equal(h[1])
+  expect(h[1]).to.equal(h[2])
+  expect(h[1]).to.equal(h[3])
+}
+
+describe('data-version', function () {
+  let agent
+
+  before(function () {
+    agent = new Agent().auth()
+  })
+
+  describe('db', function () {
+    let dbDefaults
+    let dbPath
+
+    before(async function () {
+      dbDefaults = endpoint.db(agent.defaults())
+      dbPath = dbDefaults.path
+      await db.createAfterDel(agent, dbPath)
+    })
+
+    after(async function () {
+      await db.del(agent, dbPath)
+    })
+
+    describe('/api/document/..., /api/document/.../_meta', function () {
+      let docPath
+      let metaPath
+      let commitsPath
+
+      before(async function () {
+        docPath = endpoint.document(dbDefaults).path
+        metaPath = endpoint.documentMeta(dbDefaults).path
+        commitsPath = endpoint.documentCommits(dbDefaults).path
+      })
+
+      describe('has expected data version for insert', function () {
+        const objects = [
+          { schema: { '@id': randomType0, '@type': 'Class' } },
+          { instance: { '@id': randomType0 + '/0', '@type': randomType0 } },
+        ]
+        for (const object of objects) {
+          it(JSON.stringify(object), async function () {
+            // Arrays for collecting results of requests
+            const docs = []
+            const metas = []
+            const commits = []
+
+            // Options
+            const getInstances = { query: { as_list: true } }
+            const getSchemas = { query: { graph_type: 'schema', as_list: true } }
+
+            docs.push(await document.get(agent, docPath, getInstances).then(document.verifyGetSuccess))
+            metas.push(await document.get(agent, metaPath, getInstances).then(document.verifyGetSuccess))
+            commits.push(await document.get(agent, commitsPath, getInstances).then(document.verifyGetSuccess))
+
+            docs.push(await document.insert(agent, docPath, object).then(document.verifyInsertSuccess))
+
+            metas.push(await document.get(agent, metaPath, getInstances).then(document.verifyGetSuccess))
+            commits.push(await document.get(agent, commitsPath, getInstances).then(document.verifyGetSuccess))
+
+            docs.push(await document.get(agent, docPath, getSchemas).then(document.verifyGetSuccess))
+            metas.push(await document.get(agent, metaPath, getInstances).then(document.verifyGetSuccess))
+            commits.push(await document.get(agent, commitsPath, getInstances).then(document.verifyGetSuccess))
+
+            const header = lastDataVersionHeader(docs)
+            const headerMeta = lastDataVersionHeader(metas)
+            const headerCommits = lastDataVersionHeader(commits)
+
+            docs.push(await document.get(agent, docPath, getInstances).set('TerminusDB-Data-Version', header).then(document.verifyGetSuccess))
+            metas.push(await document.get(agent, metaPath, getInstances).set('TerminusDB-Data-Version', headerMeta).then(document.verifyGetSuccess))
+            commits.push(await document.get(agent, commitsPath, getInstances).set('TerminusDB-Data-Version', headerCommits).then(document.verifyGetSuccess))
+
+            expectHeaders('branch', docs)
+            expectHeaders('meta', metas)
+            expectHeaders('repo', commits)
+          })
+        }
+      })
+
+      it('fails on bad data version', async function () {
+        const r = await document
+          .get(agent, docPath)
+          .set('TerminusDB-Data-Version', '{}')
+          .then(document.verifyGetFailure)
+        expect(r.body['api:error']['@type']).to.equal('api:BadDataVersion')
+        expect(r.body['api:error']['api:data_version']).to.equal('{}')
+      })
+    })
+
+    describe('/api/woql/...', function () {
+      let woqlPath
+      let docPath
+      const simpleQuery = {
+        query: {
+          '@type': 'Equals',
+          left: { '@type': 'True' },
+          right: { '@type': 'True' },
+        },
+      }
+
+      before(async function () {
+        woqlPath = endpoint.woqlResource(dbDefaults).path
+        docPath = endpoint.document(dbDefaults).path
+      })
+
+      it('fails on bad data version', async function () {
+        const r = await woql
+          .post(agent, woqlPath, simpleQuery)
+          .set('TerminusDB-Data-Version', 'abc')
+          .then(woql.verifyGetFailure)
+        expect(r.body['api:error']['@type']).to.equal('api:BadDataVersion')
+        expect(r.body['api:error']['api:data_version']).to.equal('abc')
+      })
+
+      describe('handles data version headers', function () {
+        let h0
+
+        before(async function () {
+          await document
+            .insert(agent, docPath, { schema: { '@id': randomType2, '@type': 'Class' } })
+            .then(document.verifyInsertSuccess)
+          const r = await woql
+            .post(agent, woqlPath, simpleQuery)
+            .then(woql.verifyGetSuccess)
+          h0 = dataVersionHeader(r)
+          expect(h0).to.match(/^branch:/)
+        })
+
+        it('correct', async function () {
+          await woql
+            .post(agent, woqlPath, simpleQuery)
+            .set('TerminusDB-Data-Version', h0)
+            .then(woql.verifyGetSuccess)
+        })
+
+        it('wrong', async function () {
+          const header = h0.substring(0, h0.length - 1)
+          const r = await woql
+            .post(agent, woqlPath, simpleQuery)
+            .set('TerminusDB-Data-Version', header)
+            .then(woql.verifyGetFailure)
+          expect(r.body['api:error']['@type']).to.equal('api:DataVersionMismatch')
+          expect(r.body['api:error']['api:requested_data_version']).to.equal(header)
+          expect(r.body['api:error']['api:actual_data_version']).to.equal(h0)
+        })
+
+        it('InsertDocument', async function () {
+          const insertDocumentQuery = {
+            query: {
+              '@type': 'InsertDocument',
+              identifier: { '@type': 'NodeValue', node: randomType2 + '/0' },
+              document: {
+                '@type': 'Value',
+                dictionary: {
+                  '@type': 'DictionaryTemplate',
+                  data: [
+                    {
+                      '@type': 'FieldValuePair',
+                      field: '@type',
+                      value: { '@type': 'Value', data: randomType2 },
+                    },
+                    {
+                      '@type': 'FieldValuePair',
+                      field: '@id',
+                      value: { '@type': 'Value', data: randomType2 + '/0' },
+                    },
+                  ],
+                },
+              },
+            },
+            commit_info: { author: 'a', message: 'm' },
+          }
+
+          const r1 = await woql
+            .post(agent, woqlPath, insertDocumentQuery)
+            .set('TerminusDB-Data-Version', h0)
+            .then(woql.verifyGetSuccess)
+          const h1 = dataVersionHeader(r1)
+          const r2 = await woql
+            .post(agent, woqlPath, simpleQuery)
+            .set('TerminusDB-Data-Version', h1)
+          const h2 = dataVersionHeader(r2)
+
+          expect(h1).to.match(/^branch:/)
+          expect(h2).to.match(/^branch:/)
+          expect(h1).to.not.equal(h0)
+          expect(h1).to.equal(h2)
+        })
+      })
+    })
+  })
+
+  describe('/api/document/_system', function () {
+    let path
+
+    before(async function () {
+      path = endpoint.documentSystem().path
+    })
+
+    after(async function () {
+      const r = await document
+        .del(agent, path, { query: { id: randomType1 + '/0' } })
+        .then(document.verifyDelSuccess)
+      await document
+        .del(agent, path, { query: { graph_type: 'schema', id: randomType1 } })
+        .set('TerminusDB-Data-Version', dataVersionHeader(r))
+        .then(document.verifyDelSuccess)
+    })
+
+    describe('has expected data version for insert', function () {
+      const objects = [
+        { schema: { '@id': randomType1, '@type': 'Class' } },
+        { instance: { '@id': randomType1 + '/0', '@type': randomType1 } },
+      ]
+      for (const object of objects) {
+        it(JSON.stringify(object), async function () {
+          const rs = []
+
+          const getInstances = { query: { as_list: true } }
+          const getSchemas = { query: { graph_type: 'schema', as_list: true } }
+
+          rs.push(await document.get(agent, path, getInstances).then(document.verifyGetSuccess))
+          rs.push(await document.insert(agent, path, object).then(document.verifyInsertSuccess))
+          rs.push(await document.get(agent, path, getSchemas).then(document.verifyGetSuccess))
+
+          rs.push(await document.get(agent, path, getInstances).set('TerminusDB-Data-Version', lastDataVersionHeader(rs)).then(document.verifyGetSuccess))
+
+          expectHeaders('system', rs)
+        })
+      }
+    })
+  })
+})


### PR DESCRIPTION
* Read TerminusDB-Data-Version header
* Check it with the transaction data version and fail for mismatch
* Respond with possibly updated TerminusDB-Data-Version header
* Fixes #248