### PR TITLE
Update swipl-rs and terminus_store_prolog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
 
 env:
-  TERMINUSDB_STORE_PROLOG_VERSION: v0.19.5
+  TERMINUSDB_STORE_PROLOG_VERSION: v0.19.6
   TUS_VERSION: v0.0.5
   DOCKER_IMAGE_NAME: terminusdb/terminusdb-server
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM terminusdb/terminus_store_prolog:v0.19.5
+FROM terminusdb/terminus_store_prolog:v0.19.6
 ENV TUS_VERSION v0.0.5
 WORKDIR /app/pack
 RUN export BUILD_DEPS="git build-essential make libjwt-dev libssl-dev pkg-config" \
@@ -8,7 +8,7 @@ RUN export BUILD_DEPS="git build-essential make libjwt-dev libssl-dev pkg-config
         && swipl -g "pack_install('file:///app/pack/jwt_io', [interactive(false)])" \
         && swipl -g "pack_install('file:///app/pack/tus', [interactive(false)])"
 
-FROM terminusdb/terminus_store_prolog:v0.19.5
+FROM terminusdb/terminus_store_prolog:v0.19.6
 WORKDIR /app/rust
 COPY ./src/rust /app/rust
 RUN BUILD_DEPS="git build-essential curl clang" && apt-get update \
@@ -18,7 +18,7 @@ RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 RUN cargo build --release
 
-FROM terminusdb/terminus_store_prolog:v0.19.5
+FROM terminusdb/terminus_store_prolog:v0.19.6
 WORKDIR /app/terminusdb
 COPY ./ /app/terminusdb
 COPY --from=0 /usr/share/swi-prolog/pack/ /usr/share/swi-prolog/pack

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -161,9 +161,9 @@ checksum = "70048d97b51d107a6cf295d42210d298f0eb7d37f0518b88c816a74b8ce15f41"
 
 [[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
 
 [[package]]
 name = "libloading"
@@ -233,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
@@ -273,9 +273,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "serde"
-version = "1.0.133"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
+checksum = "2cf9235533494ea2ddcdb794665461814781c53f19d87b76e571a1c35acbad2b"
 
 [[package]]
 name = "shlex"
@@ -291,9 +291,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "swipl"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643507ed49b904015ac166c579664a20346e655adc7980c7cbc260ef6cec8945"
+checksum = "c2b98b973f28e775f54d07e6db4b78d5605a98fedbe15322af0f51fd4e9ae050"
 dependencies = [
  "lazy_static",
  "swipl-fli",
@@ -303,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "swipl-fli"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faae0c7a45e3969f07432778774130bcb730f639f888cd8ee96ddd8dd64e5b9e"
+checksum = "97401209985d55fc7513fc9ba5f73e0de3886f42620e6d0d9e945c636dcd4102"
 dependencies = [
  "bindgen",
  "swipl-info",
@@ -313,9 +313,9 @@ dependencies = [
 
 [[package]]
 name = "swipl-info"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1b7cf6cbfa5484d916d67858e629874fcc76136aee299d184e81b9751c74828"
+checksum = "d3c24ee13ef4f59cce23ccaff3006a861c7f8b02984c2a7821e7f1ced54b6c1a"
 dependencies = [
  "regex",
 ]
@@ -334,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -416,9 +416,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "which"
-version = "4.2.2"
+version = "4.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea187a8ef279bc014ec368c27a920da2024d2a711109bfbe3440585d5cf27ad9"
+checksum = "2a5a7e487e921cf220206864a94a89b6c6905bfc19f1057fa26a4cb360e5c1d2"
 dependencies = [
  "either",
  "lazy_static",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -10,5 +10,5 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-swipl = "0.3.5"
+swipl = "0.3.6"
 lcs = "0.2.0"


### PR DESCRIPTION
New version of swipl-rs released, with various fixes and new dictionary support. This updates our module dependency, as well as terminus_store_prolog, which is now built with this new version of swipl-rs.