### PR TITLE
ci: only delete dev tags older than 2 weeks

### DIFF
--- a/.github/remove-old-docker-images.py
+++ b/.github/remove-old-docker-images.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from datetime import datetime, timedelta
 import os
 import requests
 
@@ -12,10 +13,15 @@ def fetch_token():
     }).json()
     return req['token']
 
+def image_too_old(image: str, now: datetime) -> bool:
+    date_parsed = datetime.strptime(image['tag_last_pushed'], '%Y-%m-%dT%H:%M:%S.%fZ')
+    interval = now - date_parsed
+    return interval.days > 14
 
 def fetch_old_images():
     response = requests.get(f'{API_BASE_URL}/repositories/terminusdb/terminusdb-server/tags/?page_size=100&page=1').json()
-    return [x['name'] for x in response['results'] if x['name'].startswith("dev-")]
+    now = datetime.now()
+    return [x['name'] for x in response['results'] if x['name'].startswith("dev-") and image_too_old(x, now)]
 
 def remove_old_images(token: str, old_images: [str]):
     bearer_headers = {'Authorization': f'Bearer {token}'}


### PR DESCRIPTION
Deleting new dev tags is still possible, even if the cron only runs weekly. Therefore we now check the date of the image
and make sure that the image is older than 14 days AND contains the dev- prefix.