### PR TITLE
Add data version support to commit resource

### DIFF
--- a/src/core/util/data_version.pl
+++ b/src/core/util/data_version.pl
@@ -178,6 +178,10 @@ extract_data_version(Descriptor, Object, data_version(Label, Layer_Id)) :-
     [Instance_Object] = Object.instance_objects,
     terminus_store:layer_to_id(Instance_Object.read, Layer_Id_String),
     atom_string(Layer_Id, Layer_Id_String).
+extract_data_version(Descriptor, _Object, data_version(commit, Commit_Id)) :-
+    commit_descriptor{ commit_id: Commit_Id_String } :< Descriptor,
+    !,
+    atom_string(Commit_Id, Commit_Id_String).
 
 /**
  * meta_data_version(+Object_With_Descriptor, +Meta_Data, -Data_Version) is det.

--- a/tests/lib/endpoint.js
+++ b/tests/lib/endpoint.js
@@ -35,6 +35,21 @@ function document (params) {
   }
 }
 
+function documentCommit (params) {
+  params = new Params(params)
+  const orgName = params.stringRequired('orgName')
+  const dbName = params.stringRequired('dbName')
+  const commitId = params.stringRequired('commitId')
+  const remoteName = params.string('remoteName', 'local')
+  return {
+    path: `/api/document/${orgName}/${dbName}/${remoteName}/commit/${commitId}`,
+    orgName: orgName,
+    dbName: dbName,
+    remoteName: remoteName,
+    commitId: commitId,
+  }
+}
+
 function documentCommits (params) {
   params = new Params(params)
   const orgName = params.stringRequired('orgName')
@@ -106,6 +121,7 @@ module.exports = {
   db,
   diff,
   document,
+  documentCommit,
   documentCommits,
   documentMeta,
   documentSystem,

--- a/tests/test/data-version.js
+++ b/tests/test/data-version.js
@@ -109,6 +109,26 @@ describe('data-version', function () {
       })
     })
 
+    it('/api/document/.../commit/...', async function () {
+      const commitsPath = endpoint.documentCommits(dbDefaults).path
+      const r1 = await document
+        .get(agent, commitsPath, { query: { as_list: true } })
+        .then(document.verifyGetSuccess)
+      const initialCommit = r1.body.find((i) => i['@type'] === 'InitialCommit')
+      if (util.isUndefinedOrNull(initialCommit)) {
+        throw new Error(`Missing InitialCommit in response: ${r1.body}`)
+      }
+      const commitId = initialCommit.identifier
+      const commitParams = Object.assign({ commitId: commitId }, dbDefaults)
+      const commitPath = endpoint.documentCommit(commitParams).path
+      const header = 'commit:' + commitId
+      const r2 = await document
+        .get(agent, commitPath, { query: { as_list: true } })
+        .set('TerminusDB-Data-Version', header)
+        .then(document.verifyGetSuccess)
+      expect(r2.header['terminusdb-data-version']).to.equal(header)
+    })
+
     describe('/api/woql/...', function () {
       let woqlPath
       let docPath


### PR DESCRIPTION
* Use the `commit_id` for a commit descriptor transaction.
* Fixes #922

<!--
Thanks for taking the time to contribute!

Is this your first pull request? If you don't mind, please read this first.

<https://github.com/terminusdb/terminusdb/blob/main/docs/CONTRIBUTING.md>
-->
