### PR TITLE
Force autoloading disabled on src/interactive.pl

### DIFF
--- a/src/core/account/capabilities.pl
+++ b/src/core/account/capabilities.pl
@@ -42,6 +42,7 @@
 
 :- use_module(library(crypto)).
 :- use_module(library(lists)).
+:- use_module(library(plunit)).
 
 /**
  * username_user_id(+DB, +Username, -User_ID) is semidet.

--- a/src/core/account/user_management.pl
+++ b/src/core/account/user_management.pl
@@ -30,6 +30,7 @@
 
 :- use_module(library(crypto)).
 :- use_module(library(lists)).
+:- use_module(library(plunit)).
 
 /** <module> User
  *

--- a/src/core/api/db_fast_forward.pl
+++ b/src/core/api/db_fast_forward.pl
@@ -5,6 +5,7 @@
 :- use_module(core(util)).
 :- use_module(core(query)).
 :- use_module(core(transaction)).
+:- use_module(library(plunit)).
 
 fast_forward_branch(Our_Branch_Descriptor, Their_Branch_Descriptor, Applied_Commit_Ids) :-
     Our_Repo_Descriptor = Our_Branch_Descriptor.repository_descriptor,

--- a/src/core/document/diff.pl
+++ b/src/core/document/diff.pl
@@ -5,6 +5,7 @@
 
 :- use_module(library(dicts)).
 :- use_module(library(lists)).
+:- use_module(library(plunit)).
 
 simple_diff(Before,After,Keep,Diff) :-
     simple_diff(Before,After,Keep,_,Diff).

--- a/src/core/document/json.pl
+++ b/src/core/document/json.pl
@@ -68,6 +68,7 @@
 :- use_module(library(dicts)).
 :- use_module(library(solution_sequences)).
 :- use_module(library(random)).
+:- use_module(library(plunit)).
 
 :- use_module(core(util)).
 :- use_module(core(query)).

--- a/src/core/document/patch.pl
+++ b/src/core/document/patch.pl
@@ -7,6 +7,7 @@
 :- use_module(library(dicts)).
 :- use_module(library(lists)).
 :- use_module(library(when)).
+:- use_module(library(plunit)).
 
 /*
 

--- a/src/core/document/query.pl
+++ b/src/core/document/query.pl
@@ -13,6 +13,7 @@
 :- use_module(library(terminus_store)).
 :- use_module(library(http/json)).
 :- use_module(library(lists)).
+:- use_module(library(plunit)).
 
 :- use_module(core(util)).
 :- use_module(core(query)).

--- a/src/core/query/woql_compile.pl
+++ b/src/core/query/woql_compile.pl
@@ -49,6 +49,7 @@
 :- use_module(library(yall)).
 :- use_module(library(sort)).
 :- use_module(library(apply_macros)).
+:- use_module(library(plunit)).
 
 /*
  * Ctx is a context object which is used in WOQL queries to

--- a/src/core/triple/casting.pl
+++ b/src/core/triple/casting.pl
@@ -20,6 +20,7 @@
 :- use_module(library(lists)).
 
 :- use_module(library(apply)).
+:- use_module(library(plunit)).
 :- use_module(library(yall)).
 :- use_module(library(apply_macros)).
 :- use_module(library(url)).

--- a/src/interactive.pl
+++ b/src/interactive.pl
@@ -5,6 +5,8 @@
  */
 
 :- [load_paths].
+:- use_module(library(main)).
+:- set_prolog_flag(autoload, false).
 :- initialization(main).
 
 initialise_hup :-

--- a/src/interactive.pl
+++ b/src/interactive.pl
@@ -46,6 +46,8 @@ prolog:message(server_missing_config(BasePath)) -->
 :- use_module(core(query/json_woql),[initialise_woql_contexts/0]).
 :- use_module(core(api), [bootstrap_files/0]).
 
+:- use_module(library(plunit)).
+
 :- set_test_options([run(manual)]). % ,concurrent(true)]).
 
 :- use_module(cli(main)).


### PR DESCRIPTION
My linter does not pick up `plunit` because it is not mentioned on the documentation here:

https://www.swi-prolog.org/pldoc/man?section=library

Therefore I had to import it manually. This pull request does the following:

- It imports plunit everywhere it needs to
- It forces autoloading to be disabled when you run `src/interactive.pl`. This increases the likelihood of missing library imports to be found since our developers use `src/interactive.pl` extensively. It's how I found out about the missing plunit imports as well.

It would be even better to disable autoloading entirely on the whole program. Unfortunately, this is not feasible right now as the SWI Prolog stable standard library contains an autoloading error itself, which Jan Wielemaker and I fixed here but which is not yet available in a stable version of SWI Prolog:
https://github.com/SWI-Prolog/swipl-devel/commit/18690d80fbdc842a5bad3da1fb81a083e55b1b24
