### PR TITLE
info: add unknown version of terminusdb-store if it isn't found

### DIFF
--- a/src/core/api/api_info.pl
+++ b/src/core/api/api_info.pl
@@ -10,7 +10,9 @@ info(_System_DB, Auth, Info) :-
         error(access_not_authorized(Auth),_)),
 
     version(TerminusDB_Version),
-    pack:pack_property(terminus_store_prolog, version(TerminusDB_Store_Version)),
+    (   pack:pack_property(terminus_store_prolog, version(TerminusDB_Store_Version))
+    ->  true
+    ;   TerminusDB_Store_Version = 'unknown'),
     get_db_version(Storage_Version),
 
     Info = _{


### PR DESCRIPTION
The pack_property predicate fails a lot when specific things aren't set up the way it expects. For instance, you have to name your pack directory *exactly* the same as the pack name even though this is not required to use packs at all.