### PR TITLE
revert set_prolog_flag

### DIFF
--- a/src/interactive.pl
+++ b/src/interactive.pl
@@ -6,7 +6,6 @@
 
 :- [load_paths].
 :- use_module(library(main)).
-:- set_prolog_flag(autoload, false).
 :- initialization(main).
 
 initialise_hup :-


### PR DESCRIPTION
Revert because it slows down development for now