### PR TITLE
Allow pipe in organization name

### DIFF
--- a/src/core/account/user_management.pl
+++ b/src/core/account/user_management.pl
@@ -78,6 +78,7 @@ add_user_organization_transaction(System_DB, Auth, Nick, Org) :-
                      _).
 
 add_user_organization(Context, Nick, Org, Organization_URI) :-
+    error_on_excluded_organization(Org),
 
     do_or_die(agent_name_exists(Context, Nick),
               error(unknown_user(Nick), _)),
@@ -112,6 +113,8 @@ add_organization_transaction(System_DB, Auth, Name) :-
                      _).
 
 add_organization(Name, Organization_URI) :-
+    error_on_excluded_organization(Org),
+
     create_context(system_descriptor{}, Context),
     with_transaction(Context,
                      add_organization(Context, Name, Organization_URI),

--- a/src/core/account/user_management.pl
+++ b/src/core/account/user_management.pl
@@ -113,7 +113,7 @@ add_organization_transaction(System_DB, Auth, Name) :-
                      _).
 
 add_organization(Name, Organization_URI) :-
-    error_on_excluded_organization(Org),
+    error_on_excluded_organization(Name),
 
     create_context(system_descriptor{}, Context),
     with_transaction(Context,

--- a/src/core/api/api_db.pl
+++ b/src/core/api/api_db.pl
@@ -10,6 +10,7 @@
 :- use_module(core(account)).
 :- use_module(core(query)).
 :- use_module(core(transaction)).
+:- use_module(core(triple)).
 
 :- use_module(library(lists)).
 :- use_module(library(plunit)).

--- a/src/core/api/api_db.pl
+++ b/src/core/api/api_db.pl
@@ -15,6 +15,8 @@
 :- use_module(library(plunit)).
 
 db_exists_api(System_DB, Auth, Organization, Database) :-
+    error_on_excluded_organization(Organization),
+    error_on_excluded_database(Database),
     resolve_absolute_descriptor([Organization,Database], Descriptor),
     check_descriptor_auth(System_DB, Descriptor, '@schema':'Action/instance_read_access', Auth).
 

--- a/src/core/api/api_error.pl
+++ b/src/core/api/api_error.pl
@@ -94,6 +94,24 @@ api_global_error_jsonld(error(type_not_found(Unknown_Type), _), Type, JSON) :-
                               'api:type' : Unknown_Type },
              'api:message' : Msg
             }.
+api_global_error_jsonld(error(invalid_organization_name(Organization), _), Type, JSON) :-
+    error_type(Type, Type_Displayed),
+    format(string(Msg), "Invalid organization name: ~q", [Organization]),
+    JSON = _{'@type' : Type_Displayed,
+             'api:status' : "api:failure",
+             'api:error' : _{ '@type' : 'api:InvalidOrganizationName',
+                              'api:organization_name' : Organization },
+             'api:message' : Msg
+            }.
+api_global_error_jsonld(error(invalid_database_name(DB), _), Type, JSON) :-
+    error_type(Type, Type_Displayed),
+    format(string(Msg), "Invalid database name: ~q", [DB]),
+    JSON = _{'@type' : Type_Displayed,
+             'api:status' : "api:failure",
+             'api:error' : _{ '@type' : 'api:InvalidDatabaseName',
+                              'api:database_name' : DB },
+             'api:message' : Msg
+            }.
 
 %% DB Exists
 api_error_jsonld_(check_db, error(unknown_database(Organization, Database), _), JSON) :-
@@ -1107,6 +1125,8 @@ api_error_jsonld_(delete_documents, Error, JSON) :-
     api_document_error_jsonld(delete_documents, Error, JSON).
 
 error_type(check_db, 'api:DbExistsErrorResponse').
+error_type(create_db, 'api:DbCreateErrorResponse').
+error_type(delete_db, 'api:DbDeleteErrorResponse').
 error_type(add_organization, 'api:AddOrganizationErrorResponse').
 error_type(woql, 'api:WoqlErrorResponse').
 error_type(get_documents, 'api:GetDocumentErrorResponse').

--- a/src/core/api/db_create.pl
+++ b/src/core/api/db_create.pl
@@ -163,6 +163,8 @@ validate_prefixes(Prefixes) :-
 
 create_db(System_DB, Auth, Organization_Name, Database_Name, Label, Comment, Schema, Public, Prefixes) :-
     validate_prefixes(Prefixes),
+    error_on_excluded_organization(Organization_Name),
+    error_on_excluded_database(Database_Name),
 
     create_db_unfinalized(System_DB, Auth, Organization_Name, Database_Name, Label, Comment, Schema, Public, Prefixes, Db_Uri),
 

--- a/src/core/api/db_delete.pl
+++ b/src/core/api/db_delete.pl
@@ -47,6 +47,8 @@ delete_db_from_system(Organization,DB) :-
  * Deletes a database if it exists, fails if it doesn't.
  */
 delete_db(System, Auth, Organization,DB_Name, Force) :-
+    error_on_excluded_organization(Organization),
+    error_on_excluded_database(DB_Name),
     create_context(System, System_Context),
     with_transaction(
         System_Context,

--- a/src/core/triple.pl
+++ b/src/core/triple.pl
@@ -13,6 +13,10 @@
               database_inference/2,
               database_schema/2,
               organization_database_name/3,
+              excluded_organization/1,
+              excluded_database/1,
+              error_on_excluded_organization/1,
+              error_on_excluded_database/1,
 
               % iana.pl
               iana/3,

--- a/src/core/triple/database_utils.pl
+++ b/src/core/triple/database_utils.pl
@@ -34,6 +34,7 @@
 :- use_module(library(pcre)).
 :- use_module(library(plunit)).
 :- use_module(library(yall)).
+:- use_module(library(lists)).
 
 /**
  * system_graph_layer(-Graph,-Layer) is det.

--- a/src/core/triple/database_utils.pl
+++ b/src/core/triple/database_utils.pl
@@ -78,24 +78,43 @@ database_schema(Transaction_Object, Schemas) :-
     Schemas = Transaction_Object.schema_objects.
 
 excluded_organization(Organization) :-
-    re_match('\\||^(console|api|db|home|profile)$', Organization).
+    re_match('^(console|api|db|home|profile)$', Organization).
 
 error_on_excluded_organization(Organization) :-
     do_or_die(\+ excluded_organization(Organization),
-              error(invalid_organization_name(Organization))).
+              error(invalid_organization_name(Organization),_)).
 
 error_on_pipe(Name) :-
     do_or_die(\+ re_match('\\|', Name),
-              error(ceci_n_est_pas_une_pipe(Name),_)).
+              error(invalid_database_name(Name), _)).
 
 /**
  * organization_database_name(User,DB,Name) is det.
  *
  */
-organization_database_name(Organization,DB,Name) :-
-    freeze(Organization,error_on_excluded_organization(Organization)),
-    freeze(DB,error_on_pipe(DB)),
-    merge_separator_split(Name,'|',[Organization,DB]).
+organization_database_name(Organization, DB, Name) :-
+    ground(Organization),
+    !,
+    error_on_excluded_organization(Organization),
+    atom_concat(Organization, '|', Organization_Pipe),
+    atom_concat(Organization_Pipe, DB, Name),
+    error_on_pipe(DB).
+organization_database_name(Organization, DB, Name) :-
+    ground(DB),
+    !,
+    error_on_pipe(DB),
+    atom_concat('|', DB, DB_Pipe),
+    atom_concat(Organization, DB_Pipe, Name),
+    error_on_excluded_organization(Organization),
+    error_on_pipe(DB).
+organization_database_name(Organization, DB, Name) :-
+    ground(Name),
+    merge_separator_split(Name,'|',Elts),
+    last(Elts, DB),
+    atom_concat('|', DB, DB_Pipe),
+    atom_concat(Organization, DB_Pipe, Name),
+    error_on_excluded_organization(Organization),
+    error_on_pipe(DB).
 
 :- begin_tests(database_utils).
 
@@ -104,11 +123,13 @@ test(excluded_organization_bad_names) :-
     excluded_organization("api"),
     excluded_organization("db"),
     excluded_organization("home"),
-    excluded_organization("profile"),
-    excluded_organization("john|smith"),
-    excluded_organization("|"),
-    excluded_organization("smith|"),
-    excluded_organization("|amy").
+    excluded_organization("profile").
+
+test(excluded_organization_pipe_names) :-
+    \+ excluded_organization("john|smith"),
+    \+ excluded_organization("|"),
+    \+ excluded_organization("smith|"),
+    \+ excluded_organization("|amy").
 
 
 test(excluded_organization_good_names) :-
@@ -125,5 +146,42 @@ test(excluded_organization_normal_names) :-
     \+ excluded_organization("megacorp"),
     \+ excluded_organization("littlecorp"),
     \+ excluded_organization("jane").
+
+test(merge_organization_db_name_properly) :-
+    organization_database_name(foo, bar, 'foo|bar'),
+    organization_database_name('foo|', bar, 'foo||bar'),
+    organization_database_name('|f|o|o|', bar, '|f|o|o||bar').
+test(split_organization_db_name_properly_normal) :-
+    organization_database_name(O,D, 'foo|bar'),
+    O = 'foo',
+    D = 'bar'.
+test(split_organization_db_name_properly_pipe) :-
+    organization_database_name(O,D, '|foo||bar'),
+    O = '|foo|',
+    D = 'bar'.
+test(split_organization_db_name_properly_db_ground) :-
+    organization_database_name(O,'bar', '|foo||bar'),
+    O = '|foo|'.
+test(split_organization_db_name_properly_org_ground) :-
+    organization_database_name('|foo|',D, '|foo||bar'),
+    D = 'bar'.
+test(db_name_pipe_error_merge,
+    [error(invalid_database_name('|bar'))]) :-
+    organization_database_name(foo, '|bar', _).
+test(db_name_pipe_error_split,
+    [error(invalid_database_name('|bar'))]) :-
+    organization_database_name('foo', _, 'foo||bar').
+test(db_name_pipe_error_split_db_ground,
+    [error(invalid_database_name('|bar'))]) :-
+    organization_database_name(_, '|bar', 'foo||bar').
+test(org_name_excluded_org_merge_error,
+     [error(invalid_organization_name('profile'))]) :-
+    organization_database_name(profile, 'bar', _).
+test(org_name_excluded_org_split_error,
+     [error(invalid_organization_name('profile'))]) :-
+    organization_database_name(_,_, 'profile|bar').
+test(org_name_excluded_org_split_error_db_ground,
+     [error(invalid_organization_name('profile'))]) :-
+    organization_database_name(_,bar, 'profile|bar').
 
 :- end_tests(database_utils).

--- a/tests/lib/organization.js
+++ b/tests/lib/organization.js
@@ -48,6 +48,13 @@ function verifyAddSuccess (r) {
   return r
 }
 
+function verifyDelSuccess (r) {
+  expect(r.status).to.equal(200)
+  expect(r.body['api:status']).to.equal('api:success')
+  expect(r.body['@type']).to.equal('api:AddOrganizationResponse')
+  return r
+}
+
 function verifyAddFailure (r) {
   expect(r.status).to.equal(400)
   expect(r.body['api:status']).to.equal('api:failure')
@@ -66,6 +73,7 @@ module.exports = {
   add,
   del,
   verifyAddSuccess,
+  verifyDelSuccess,
   verifyAddFailure,
   verifyDelFailure,
 }

--- a/tests/test/organization.js
+++ b/tests/test/organization.js
@@ -24,13 +24,50 @@ describe('organization', function () {
     }
   })
 
-  it('succeeds adding unknown organization', async function () {
-    await organization
-      .add(agent, {
+  describe('with random organization name', function () {
+    let params
+    before(async function () {
+      params = {
         organization_name: util.randomString(),
-        user_name: agent.defaults().userName,
-      })
-      .then(organization.verifyAddSuccess)
+      }
+    })
+    after(async function () {
+      // deleting organizations is unfortunately broken right now.
+      /*
+      await organization
+        .del(agent, params)
+        .then(organization.verifyDelSuccess)
+      */
+    })
+
+    it('succeeds adding organization', async function () {
+      await organization
+        .add(agent, params)
+        .then(organization.verifyAddSuccess)
+    })
+  })
+
+  describe('with random organization name with pipe', function () {
+    let params
+    before(async function () {
+      params = {
+        organization_name: util.randomString() + '|pipe',
+      }
+    })
+    after(async function () {
+      // deleting organizations is unfortunately broken right now.
+      /*
+      await organization
+        .del(agent, params)
+        .then(organization.verifyDelSuccess)
+      */
+    })
+
+    it('succeeds adding organization', async function () {
+      await organization
+        .add(agent, params)
+        .then(organization.verifyAddSuccess)
+    })
   })
 
   it('fails adding unknown user', async function () {


### PR DESCRIPTION
This pull will make it so that organization names are allowed to have a pipe in them. It also improves validation and error reporting on organization and database names.

This fixes #929.