### PR TITLE
Allow empty string for db_create in comment

### DIFF
--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -178,9 +178,13 @@ db_handler(post, Organization, DB, Request, System_DB, Auth) :-
         Request,
         (   http_read_json_required(json_dict(JSON), Request),
 
-            param_value_json_required(JSON, comment, string, Comment),
             param_value_json_required(JSON, label, string, Label),
 
+            % We do this because we want to allow an
+            % empty string to be a comment as well
+            (   get_dict(comment, JSON, Comment)
+            ->  true
+            ;   Comment = "" ),
             param_value_json_optional(JSON, prefixes, object, _{}, Input_Prefixes),
             Default_Prefixes = _{ '@base' : "terminusdb:///data/",
                                   '@schema' : "terminusdb:///schema#" },

--- a/tests/test/db-auth.js
+++ b/tests/test/db-auth.js
@@ -20,6 +20,15 @@ describe('db-auth', function () {
     await db.del(agent, path).then(db.verifyDeleteSuccess)
   })
 
+  it('accepts comment as empty string', async function () {
+    const { orgName, userName } = agent.defaults()
+    const dbName = util.randomString()
+    const { path } = endpoint.db({ orgName, userName, dbName })
+    // Create a database
+    await db.create(agent, path, { comment: '' }).then(db.verifyCreateSuccess)
+    await db.del(agent, path).then(db.verifyDeleteSuccess)
+  })
+
   it('fails delete with unknown database', async function () {
     const { path, orgName, dbName } = endpoint.db(agent.defaults())
     const r = await db.del(agent, path).then(db.verifyDeleteNotFound)

--- a/tests/test/db-noauth.js
+++ b/tests/test/db-noauth.js
@@ -31,9 +31,8 @@ describe('db-noauth', function () {
 
   describe('fails create with missing fields', function () {
     const parts = [
-      [{ }, 'comment'],
+      [{ }, 'label'],
       [{ comment: 'a comment' }, 'label'],
-      [{ label: 'a label' }, 'comment'],
     ]
     for (const [body, missingParam] of parts) {
       it(JSON.stringify(body), async function () {


### PR DESCRIPTION
We allow this because some clients were using empty strings as the default. This solution is in my opinion the best: it makes it an optional parameter but also allows it to be an empty string, which doesn't break the client's default preference.

Another way to handle this could perhaps be modifying the `param.pl` to accept an option to consider empty strings as valid input as well.