### PR TITLE
Revert "ci: cache Docker layers (#1002)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-      # Ignore the failure of a step and avoid terminating the job.
-        continue-on-error: true
-
       - name: Build Docker image
         run: |
           docker build . --file Dockerfile --tag $DOCKER_IMAGE_NAME:local


### PR DESCRIPTION
This reverts commit 878744af3ee6c797b339ece2c88ca9f745c9b897.

It was a good attempt to speed up the Docker build, but it didn't always
work.

<!--
Thanks for taking the time to contribute!

Is this your first pull request? If you don't mind, please read this first.

<https://github.com/terminusdb/terminusdb/blob/main/docs/CONTRIBUTING.md>
-->
