### PR TITLE
Implement layer pinning

### DIFF
--- a/.lint_config.pl
+++ b/.lint_config.pl
@@ -2,3 +2,4 @@
 ignore_predicate("dateTimeStamp/11").
 ignore_predicate("time/8").
 ignore_predicate("dateTime/11").
+ignore_predicate("woql_compile/5").

--- a/src/config/terminus_config.pl
+++ b/src/config/terminus_config.pl
@@ -27,12 +27,17 @@
               is_enterprise/0,
               check_insecure_user_header_enabled/1,
               clear_check_insecure_user_header_enabled/0,
-              clear_insecure_user_header_key/0
+              clear_insecure_user_header_key/0,
+              pinned_databases/1
           ]).
 
 :- use_module(library(pcre)).
 
 :- use_module(core(util)).
+:- use_module(core(query)).
+
+:- use_module(library(apply)).
+:- use_module(library(yall)).
 
 terminusdb_version('10.0.18').
 
@@ -241,3 +246,20 @@ check_all_env_vars :-
 
 is_enterprise :-
     current_prolog_flag(terminusdb_enterprise, true).
+
+parse_pinned_databases(Pinned_Env, Pinned) :-
+    merge_separator_split(Pinned_Env, ',', Pinned_Atoms),
+    maplist([Atom, Descriptor]>>(
+                do_or_die(resolve_absolute_string_descriptor(Atom, Descriptor),
+                          error(invalid_descriptor(Atom), _))
+            ),
+
+            Pinned_Atoms,
+            Pinned).
+
+:- table pinned_databases/1.
+pinned_databases(Pinned) :-
+    getenv('TERMINUSDB_PINNED_DATABASES', Pinned_Env),
+    !,
+    parse_pinned_databases(Pinned_Env, Pinned).
+pinned_databases([]).

--- a/src/core/transaction/descriptor.pl
+++ b/src/core/transaction/descriptor.pl
@@ -221,8 +221,7 @@ open_read_write_obj(Descriptor, Read_Write_Obj, Map, [Descriptor=Read_Write_Obj|
     ;   Type = inference,
         system_inference_name(Graph_Name)),
     storage(Store),
-    safe_open_named_graph(Store, Graph_Name, Graph),
-    head(Graph, Layer),
+    safe_open_graph_head(Store, Graph_Name, Layer),
     graph_descriptor_layer_to_read_write_obj(Descriptor, Layer, Read_Write_Obj).
 open_read_write_obj(Descriptor, Read_Write_Obj, Map, [Descriptor=Read_Write_Obj|Map]) :-
     Descriptor = labelled_graph{ label: Name,
@@ -254,8 +253,7 @@ open_read_write_obj(Descriptor, Read_Write_Obj, Map, [Descriptor=Read_Write_Obj|
     ;   Type = schema
     ->  repository_ontology(Repository_Name),
         storage(Store),
-        safe_open_named_graph(Store, Repository_Name, Graph),
-        head(Graph, Layer)
+        safe_open_graph_head(Store, Repository_Name, Layer)
     ),
     graph_descriptor_layer_to_read_write_obj(Descriptor, Layer, Read_Write_Obj).
 open_read_write_obj(Descriptor,
@@ -275,8 +273,7 @@ open_read_write_obj(Descriptor,
     ->  open_read_write_obj(Repo_Descriptor, Repository_Read_Write_Obj, Map, New_Map),
 
         repository_ontology(Repo_Name),
-        safe_open_named_graph(Store, Repo_Name, Repo_Graph),
-        head(Repo_Graph, Repo_Layer),
+        safe_open_graph_head(Store, Repo_Name, Repo_Layer),
 
         Repo_Layer_Desc =
         layer_descriptor{
@@ -290,8 +287,7 @@ open_read_write_obj(Descriptor,
     ;   Type = schema
     ->  New_Map = Map,
         ref_ontology(Ref_Name),
-        safe_open_named_graph(Store, Ref_Name, Graph),
-        head(Graph, Layer)
+        safe_open_graph_head(Store, Ref_Name, Layer)
     ),
     graph_descriptor_layer_to_read_write_obj(Descriptor, Layer, Read_Write_Obj).
 open_read_write_obj(Descriptor,

--- a/src/core/transaction/validate.pl
+++ b/src/core/transaction/validate.pl
@@ -34,6 +34,7 @@
 
 :- use_module(library(semweb/turtle)).
 :- use_module(library(lists)).
+:- use_module(library(apply)).
 :- use_module(library(yall)).
 :- use_module(library(sort)).
 :- use_module(library(plunit)).
@@ -464,7 +465,7 @@ layers_for_validation(Validation, Committed, Layers) :-
                 ),
                 Committed,
                 [Parent_Validation]),
-        write_layers_for_validation(Parent_Validation, Remainder)
+        layers_for_validation(Parent_Validation, Committed, Remainder)
     ;   Layers = Our_Layers).
 
 log_commits(_) :-

--- a/src/core/triple.pl
+++ b/src/core/triple.pl
@@ -93,6 +93,7 @@
               safe_create_named_graph/3,
               safe_named_graph_exists/2,
               safe_open_named_graph/3,
+              safe_open_graph_head/3,
               safe_delete_named_graph/2,
               xrdf/4,
               xquad/5,

--- a/src/core/triple/triplestore.pl
+++ b/src/core/triple/triplestore.pl
@@ -2,6 +2,7 @@
               safe_create_named_graph/3,
               safe_named_graph_exists/2,
               safe_open_named_graph/3,
+              safe_open_graph_head/3,
               safe_delete_named_graph/2,
               xrdf/4,
               xquad/5,
@@ -24,6 +25,7 @@
           ]).
 
 :- use_module(literals).
+:- use_module(constants).
 
 %:- reexport(core(util/syntax)).
 :- use_module(core(util)).
@@ -204,6 +206,30 @@ safe_named_graph_exists(Store, Graph_ID) :-
 safe_open_named_graph(Store, Graph_ID, Graph_Obj) :-
     www_form_encode(Graph_ID,Safe_Graph_ID),
     open_named_graph(Store,Safe_Graph_ID,Graph_Obj).
+
+%pinned_graph_label(X) :-
+%    system_schema_name(X).
+pinned_graph_label(X) :-
+    repository_ontology(X).
+pinned_graph_label(X) :-
+    ref_ontology(X).
+pinned_graph_label(X) :-
+    woql_ontology(X).
+
+safe_open_graph_head(Store, Graph_ID, Layer_Obj) :-
+    pinned_graph_label(Graph_ID),
+    safe_open_graph_head_pinned(Store, Graph_ID, Layer_Obj),
+    !.
+safe_open_graph_head(Store, Graph_ID, Layer_Obj) :-
+    safe_open_graph_head_(Store, Graph_ID, Layer_Obj).
+
+safe_open_graph_head_(Store, Graph_ID, Layer_Obj) :-
+    safe_open_named_graph(Store, Graph_ID, Graph_Obj),
+    head(Graph_Obj, Layer_Obj).
+
+:- table safe_open_graph_head_pinned/3.
+safe_open_graph_head_pinned(Store, Graph_ID, Layer_Obj) :-
+    safe_open_graph_head_(Store, Graph_ID, Layer_Obj).
 
 /*
  * safe_delete_named_graph(+Store, +Graph_ID) is semidet.


### PR DESCRIPTION
# layer pinning
## schema graphs for metadata
Most easy, always the same layer, users can't change it, can cache the initial result and never throw it away

## system database
This can change, so we have to check that what we're opening is still the most recent one.

## Arbitrary user databases
This is the most difficult, because we need to think of policy around when layers should be evicted from memory.
