### PR TITLE
Add missing exports to fix unit tests

### DIFF
--- a/src/config/terminus_config.pl
+++ b/src/config/terminus_config.pl
@@ -25,7 +25,9 @@
               insecure_user_header_key/1,
               check_all_env_vars/0,
               is_enterprise/0,
-              check_insecure_user_header_enabled/1
+              check_insecure_user_header_enabled/1,
+              clear_check_insecure_user_header_enabled/0,
+              clear_insecure_user_header_key/0
           ]).
 
 :- use_module(library(pcre)).


### PR DESCRIPTION
Two predicates were missing from terminus_config.pl, which were causing unit tests to fail locally (though not in the docker container and therefore not on CI).

These are now exported properly.