### PR TITLE
ci: try to run python tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,9 @@ jobs:
       - name: Load Docker image
         run: |
           docker load < terminusdb-server-docker-image.tar.gz
+          # Tag a dev image because the docker-compose.yml uses
+          # a dev tag. We want it to fetch it locally instead of
+          # remotely from Docker Hub
           docker image tag $DOCKER_IMAGE_NAME:local $DOCKER_IMAGE_NAME:dev
 
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,34 @@ jobs:
           docker load < terminusdb-server-docker-image.tar.gz
           docker run --name terminusdb $DOCKER_IMAGE_NAME:local /app/terminusdb/terminusdb test
 
+  python_integration_tests:
+    runs-on: ubuntu-latest
+    needs: build_docker
+
+    steps:
+      - name: Download Docker image
+        uses: actions/download-artifact@v2
+        with:
+          name: terminusdb-server-docker-image
+
+      - name: Load Docker image
+        run: |
+          docker load < terminusdb-server-docker-image.tar.gz
+          docker image tag $DOCKER_IMAGE_NAME:local $DOCKER_IMAGE_NAME:dev
+
+      - uses: actions/checkout@v2
+        with:
+          repository: terminusdb/terminusdb-client-python
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install shed pytest tox
+          tox -e deps
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Test with pytest
+        run: tox -e test
+
+
   # Integration tests
   integration_tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We need to make sure that we don't have regressions with the client's behavior. Therefore we need to run the client integration tests as well.