### PR TITLE
Remove jwt support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,8 +150,6 @@ jobs:
             --net=host \
             -e TERMINUSDB_INSECURE_USER_HEADER_ENABLED=true \
             -e TERMINUSDB_INSECURE_USER_HEADER='X-Forwarded-User' \
-            -e TERMINUSDB_JWT_ENABLED=true \
-            -e TERMINUSDB_SERVER_JWKS_ENDPOINT='https://cdn.terminusdb.com/jwks.json' \
             $DOCKER_IMAGE_NAME:local
 
       - name: Set up Node.js
@@ -176,16 +174,6 @@ jobs:
         env:
           TERMINUSDB_USER: admin
           TERMINUSDB_INSECURE_USER_HEADER: X-Forwarded-User
-        run: |
-          npm install
-          npm run check
-          npm test
-
-      - name: Run integration tests with JWT
-        working-directory: tests
-        env:
-          TERMINUSDB_ACCESS_TOKEN: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InRlc3RrZXkifQ.eyJodHRwOi8vdGVybWludXNkYi5jb20vc2NoZW1hL3N5c3RlbSNhZ2VudF9uYW1lIjoiYWRtaW4iLCJodHRwOi8vdGVybWludXNkYi5jb20vc2NoZW1hL3N5c3RlbSN1c2VyX2lkZW50aWZpZXIiOiJhZG1pbkB1c2VyLmNvbSIsImlzcyI6Imh0dHBzOi8vdGVybWludXNodWIuZXUuYXV0aDAuY29tLyIsInN1YiI6ImFkbWluIiwiYXVkIjpbImh0dHBzOi8vdGVybWludXNodWIvcmVnaXN0ZXJVc2VyIiwiaHR0cHM6Ly90ZXJtaW51c2h1Yi5ldS5hdXRoMC5jb20vdXNlcmluZm8iXSwiaWF0IjoxNTkzNzY5MTgzLCJhenAiOiJNSkpuZEdwMHpVZE03bzNQT1RRUG1SSkltWTJobzBhaSIsInNjb3BlIjoib3BlbmlkIHByb2ZpbGUgZW1haWwifQ.Ru03Bi6vSIQ57bC41n6fClSdxlb61m0xX6Q34Yh91gql0_CyfYRWTuqzqPMFoCefe53hPC5E-eoSFdID_u6w1ih_pH-lTTqus9OWgi07Qou3QNs8UZBLiM4pgLqcBKs0N058jfg4y6h9GjIBGVhX9Ni2ez3JGNcz1_U45BhnreE
-          TERMINUSDB_USER: admin
         run: |
           npm install
           npm run check

--- a/.lint_config.pl
+++ b/.lint_config.pl
@@ -2,3 +2,4 @@
 ignore_predicate("dateTimeStamp/11").
 ignore_predicate("time/8").
 ignore_predicate("dateTime/11").
+ignore_predicate("woql_compile/0").

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,6 @@ WORKDIR /app/terminusdb
 COPY ./ /app/terminusdb
 COPY --from=0 /usr/share/swi-prolog/pack/ /usr/share/swi-prolog/pack
 COPY --from=1 /app/rust/target/release/libterminusdb_dylib.so /app/terminusdb/src/rust/librust.so
-RUN apt-get update && apt-get install -y --no-install-recommends make openssl \
+RUN apt-get update && apt-get install -y --no-install-recommends make \
     && rm -rf /var/cache/apt/* && rm -rf /var/lib/apt/lists/* && make
 CMD ["/app/terminusdb/distribution/init_docker.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
 FROM terminusdb/terminus_store_prolog:v0.19.7
 ENV TUS_VERSION v0.0.5
 WORKDIR /app/pack
-RUN export BUILD_DEPS="git build-essential make libjwt-dev libssl-dev pkg-config" \
+RUN export BUILD_DEPS="git build-essential make pkg-config" \
         && apt-get update && apt-get install $BUILD_DEPS -y --no-install-recommends \
-        && git clone --single-branch --branch v0.0.5 https://github.com/terminusdb-labs/jwt_io.git jwt_io \
         && git clone --single-branch --branch $TUS_VERSION https://github.com/terminusdb/tus.git tus \
-        && swipl -g "pack_install('file:///app/pack/jwt_io', [interactive(false)])" \
         && swipl -g "pack_install('file:///app/pack/tus', [interactive(false)])"
 
 FROM terminusdb/terminus_store_prolog:v0.19.7
@@ -23,8 +21,6 @@ WORKDIR /app/terminusdb
 COPY ./ /app/terminusdb
 COPY --from=0 /usr/share/swi-prolog/pack/ /usr/share/swi-prolog/pack
 COPY --from=1 /app/rust/target/release/libterminusdb_dylib.so /app/terminusdb/src/rust/librust.so
-ARG TERMINUSDB_JWT_ENABLED=true
-ENV TERMINUSDB_JWT_ENABLED=${TERMINUSDB_JWT_ENABLED}
-RUN apt-get update && apt-get install -y --no-install-recommends libjwt0 make openssl \
+RUN apt-get update && apt-get install -y --no-install-recommends make openssl \
     && rm -rf /var/cache/apt/* && rm -rf /var/lib/apt/lists/* && make
 CMD ["/app/terminusdb/distribution/init_docker.sh"]

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ align="right"
 - **Schema Evolution:** continue to evolve your schema as your application grows 
 - **Data Ingestion:** ingest data from anywhere 
 - **UI Config:** use our [UI library](https://github.com/terminusdb/terminusdb-documents-ui) to generate a custom UI (under active development)
-- **Authentication & Authorization:** simple set up using JWT (tutorial under active development)
+- **Authentication & Authorization:** simple set up using forward headers
 - **HTTP Client:** easily allow your users to interact with your application
 - **Rich Query Language:** [Datalog](https://en.wikipedia.org/wiki/Datalog) (WOQL) query interface that can be used to express complex joins and recursive graph traversals
 - **Python Client:** process data in TerminusDB python client

--- a/src/config/terminus_config.pl
+++ b/src/config/terminus_config.pl
@@ -7,8 +7,6 @@
               worker_amount/1,
               max_transaction_retries/1,
               default_database_path/1,
-              jwt_jwks_endpoint/1,
-              jwt_enabled/0,
               registry_path/1,
               pack_dir/1,
               tmp_path/1,
@@ -68,28 +66,6 @@ max_transaction_retries(Value) :-
 
 default_database_path(Value) :-
     getenv_default('TERMINUSDB_SERVER_DB_PATH', './storage/db', Value).
-
-jwt_enabled_env_var :-
-    getenv_default('TERMINUSDB_JWT_ENABLED', false, true).
-
-% jwt_enabled is used for conditional compilation of jwt_io, but want to use the
-% value passed to TERMINUSDB_JWT_ENABLED at compile time, which may be different
-% from runtime. Therefore, we save the TERMINUSDB_JWT_ENABLED value for runtime
-% again using conditional compilation here.
-:- if(jwt_enabled_env_var).
-jwt_enabled :-
-    true.
-:- else.
-jwt_enabled :-
-    false.
-:- endif.
-
-jwt_jwks_endpoint(Endpoint) :-
-    getenv('TERMINUSDB_SERVER_JWKS_ENDPOINT', Value),
-    % Ignore an empty value in the environment variable.
-    (   Value = ''
-    ->  false
-    ;   Endpoint = Value).
 
 pack_dir(Value) :-
     getenv('TERMINUSDB_SERVER_PACK_DIR', Value).

--- a/src/core/util/test_utils.pl
+++ b/src/core/util/test_utils.pl
@@ -412,8 +412,7 @@ spawn_server_1(Path, URL, PID, Options) :-
         'LC_PAPER'='en_US.UTF-8',
 
         'TERMINUSDB_SERVER_PORT'=Port,
-        'TERMINUSDB_SERVER_DB_PATH'=Path,
-        'TERMINUSDB_SERVER_JWKS_ENDPOINT'='https://cdn.terminusdb.com/jwks.json'
+        'TERMINUSDB_SERVER_DB_PATH'=Path
     ],
 
     (   memberchk(env_vars(Env_List_User), Options)
@@ -428,7 +427,6 @@ spawn_server_1(Path, URL, PID, Options) :-
                          'TEMP', % Again...
                          'TERMINUSDB_ADMIN_PASSWD',
                          'TERMINUSDB_SERVER_PACK_DIR',
-                         'TERMINUSDB_JWT_ENABLED',
                          'TERMINUSDB_SERVER_TMP_PATH',
                          'PATH'
                      ],

--- a/src/load_paths.pl
+++ b/src/load_paths.pl
@@ -31,13 +31,6 @@ add_cli_path :-
 
 :- add_cli_path.
 
-add_jwt_path :-
-    user:file_search_path(terminus_home, Dir),
-    atom_concat(Dir,'/prolog_jwt/prolog',Library),
-    asserta(user:file_search_path(library, Library)).
-
-:- add_jwt_path.
-
 add_config_path :-
     % Global directory
     % asserta(user:file_search_path(config, '/etc')),

--- a/src/server/main.pl
+++ b/src/server/main.pl
@@ -15,9 +15,7 @@
 :- use_module(core(api)).
 
 % configuration predicates
-:- use_module(config(terminus_config),[jwt_enabled/0,
-                                       jwt_jwks_endpoint/1,
-                                       server/1,
+:- use_module(config(terminus_config),[server/1,
                                        server_port/1,
                                        worker_amount/1,
                                        is_enterprise/0]).
@@ -34,32 +32,11 @@
 
 :- use_module(library(option)).
 
-% JWT IO library
-:- if(jwt_enabled).
-
-% Load the library only if JWT is enabled
-:- use_module(library(jwt_io)).
-
-% Set up JWKS only if we have an endpoint
-load_jwt_conditionally :-
-    (   jwt_jwks_endpoint(Endpoint)
-    ->  jwt_io:setup_jwks(Endpoint)
-    ;   true).
-
-:- else.
-
-% Otherwise, do nothing
-load_jwt_conditionally :-
-    true.
-
-:- endif.
-
 
 terminus_server(Argv,Wait) :-
     server(Server),
     server_port(Port),
     worker_amount(Workers),
-    load_jwt_conditionally,
     HTTPOptions = [port(Port), workers(Workers)],
     catch(http_server(http_dispatch, HTTPOptions),
           E,

--- a/tests/lib/agent.js
+++ b/tests/lib/agent.js
@@ -33,19 +33,14 @@ class Agent {
     this.userName = process.env.TERMINUSDB_USER
     assert(this.userName, 'Missing environment variable: TERMINUSDB_USER')
 
-    const token = process.env.TERMINUSDB_ACCESS_TOKEN
     const insecureUserHeader = process.env.TERMINUSDB_INSECURE_USER_HEADER
-    if (token) {
-      this.agent.use((request) => {
-        request.auth(token, { type: 'bearer' })
-      })
-    } else if (insecureUserHeader) {
+    if (insecureUserHeader) {
       this.agent.use((request) => {
         request.set(insecureUserHeader, this.userName)
       })
     } else {
       const pass = process.env.TERMINUSDB_PASS
-      assert(pass, 'Missing environment variable: TERMINUSDB_ACCESS_TOKEN, TERMINUSDB_INSECURE_USER_HEADER, or TERMINUSDB_PASS')
+      assert(pass, 'Missing environment variable: TERMINUSDB_INSECURE_USER_HEADER or TERMINUSDB_PASS')
       this.agent.use((request) => {
         request.auth(this.userName, pass)
       })

--- a/tests/test/auth.js
+++ b/tests/test/auth.js
@@ -47,16 +47,4 @@ describe('auth', function () {
 
     it('fails create', create)
   })
-
-  describe('bearer: unknown token', function () {
-    before(function () {
-      const token = util.randomString()
-      agent = new Agent()
-      agent.set('Authorization', `Bearer ${token}`)
-    })
-
-    it('fails connect', connect)
-
-    it('fails create', create)
-  })
 })


### PR DESCRIPTION
We rely on a Prolog JWT library which is not very well maintained anymore. API gateways like Kong provide
better JWT support and should be used instead of doing the same verification twice.

The insecure user header can be used instead to configure a proxy to check for the JWTs.

The Python tests fail because they still test for JWT. If we decide to merge this, we should remove the JWT test from the Python client.