### PR TITLE
replace_document: check submitted ID against generated

### DIFF
--- a/src/core/api/api_error.pl
+++ b/src/core/api/api_error.pl
@@ -166,6 +166,35 @@ api_global_error_jsonld(error(http_open_error(Err), _), Type, JSON) :-
                               'api:reason' : Err },
              'api:message' : Msg
             }.
+api_global_error_jsonld(error(document_not_found(Id), _), Type, JSON) :-
+    error_type(Type, Type_Displayed),
+    format(string(Msg), "Document not found: ~q", [Id]),
+    JSON = _{'@type' : Type_Displayed,
+             'api:status' : "api:not_found",
+             'api:error' : _{ '@type' : 'api:DocumentNotFound',
+                              'api:document_id' : Id },
+             'api:message' : Msg
+            }.
+api_global_error_jsonld(error(document_not_found(Id, Document), _), Type, JSON) :-
+    error_type(Type, Type_Displayed),
+    format(string(Msg), "Document not found: ~q", [Id]),
+    JSON = _{'@type' : Type_Displayed,
+             'api:status' : "api:not_found",
+             'api:error' : _{ '@type' : 'api:DocumentNotFound',
+                              'api:document_id' : Id,
+                              'api:document': Document },
+             'api:message' : Msg
+            }.
+api_global_error_jsonld(error(submitted_id_does_not_match_generated_id(Submitted_Id, Generated_Id), _), Type, JSON) :-
+    error_type(Type, Type_Displayed),
+    format(string(Msg), "Document was submitted with id ~q, but id ~q was generated", [Submitted_Id, Generated_Id]),
+    JSON = _{'@type' : Type_Displayed,
+             'api:status' : "api:failure",
+             'api:error' : _{ '@type' : 'api:SubmittedIdDoesNotMatchGeneratedId',
+                              'api:submitted_id': Submitted_Id,
+                              'api:generated_id': Generated_Id },
+             'api:message' : Msg
+            }.
 
 :- multifile api_error_jsonld_/3.
 %% DB Exists
@@ -1404,14 +1433,6 @@ api_document_error_jsonld(Type, error(casting_error(Value, Destination_Type, Doc
                               'api:document' : Document },
              'api:message' : Msg
             }.
-api_document_error_jsonld(get_documents,error(document_not_found(Id),_), JSON) :-
-    format(string(Msg), "Document with id ~q not found", [Id]),
-    JSON = _{'@type' : 'api:GetDocumentErrorResponse',
-             'api:status' : 'api:not_found',
-             'api:error' : _{ '@type' : 'api:DocumentNotFound',
-                              'api:document_id' : Id},
-             'api:message' : Msg
-            }.
 api_document_error_jsonld(get_documents,error(query_is_only_supported_for_instance_graphs,_), JSON) :-
     format(string(Msg), "Query documents are currently only supported for instance graphs", []),
     JSON = _{'@type' : 'api:GetDocumentErrorResponse',
@@ -1564,24 +1585,6 @@ api_document_error_jsonld(insert_documents, error(no_context_found_in_schema, _)
     JSON = _{'@type' : 'api:InsertDocumentErrorResponse',
              'api:status' : "api:failure",
              'api:error' : _{ '@type' : 'api:NoContextFoundInSchema'},
-             'api:message' : Msg
-            }.
-api_document_error_jsonld(replace_documents, error(document_does_not_exist(Id, Document), _), JSON) :-
-    format(string(Msg), "Document submitted for replacement, but original is not found for ID ~q", [Id]),
-    JSON = _{'@type' : 'api:ReplaceDocumentErrorResponse',
-             'api:status' : "api:not_found",
-             'api:error' : _{ '@type' : 'api:OriginalDocumentNotFound',
-                              'api:document_id' : Id,
-                              'api:replacement_document': Document
-                            },
-             'api:message' : Msg
-            }.
-api_document_error_jsonld(delete_documents, error(document_does_not_exist(Id), _), JSON) :-
-    format(string(Msg), "Document with id ~q was not found", [Id]),
-    JSON = _{'@type' : 'api:DeleteDocumentErrorResponse',
-             'api:status' : "api:not_found",
-             'api:error' : _{ '@type' : 'api:DocumentNotFound',
-                              'api:document_id' : Id},
              'api:message' : Msg
             }.
 api_document_error_jsonld(delete_documents, error(missing_targets, _), JSON) :-

--- a/tests/lib/document.js
+++ b/tests/lib/document.js
@@ -211,8 +211,22 @@ function verifyReplaceFailure (r) {
   return r
 }
 
+function verifyReplaceNotFound (r) {
+  expect(r.status).to.equal(404)
+  expect(r.body['api:status']).to.equal('api:not_found')
+  expect(r.body['@type']).to.equal('api:ReplaceDocumentErrorResponse')
+  return r
+}
+
 function verifyDelSuccess (r) {
   expect(r.status).to.equal(200)
+  return r
+}
+
+function verifyDelNotFound (r) {
+  expect(r.status).to.equal(404)
+  expect(r.body['api:status']).to.equal('api:not_found')
+  expect(r.body['@type']).to.equal('api:DeleteDocumentErrorResponse')
   return r
 }
 
@@ -239,7 +253,9 @@ module.exports = {
   verifyInsertSuccess,
   verifyInsertFailure,
   verifyReplaceFailure,
+  verifyReplaceNotFound,
   verifyDelSuccess,
+  verifyDelNotFound,
   expectMissingField,
   expectMissingParameter,
 }

--- a/tests/lib/woql.js
+++ b/tests/lib/woql.js
@@ -44,9 +44,17 @@ function verifyGetFailure (r) {
   return r
 }
 
+function verifyNotFound (r) {
+  expect(r.status).to.equal(404)
+  expect(r.body['api:status']).to.equal('api:not_found')
+  expect(r.body['@type']).to.equal('api:WoqlErrorResponse')
+  return r
+}
+
 module.exports = {
   post,
   multipart,
   verifyGetSuccess,
   verifyGetFailure,
+  verifyNotFound,
 }

--- a/tests/test/document-auth.js
+++ b/tests/test/document-auth.js
@@ -62,6 +62,17 @@ describe('document', function () {
       }
     })
 
+    it('fails replace for document not found', async function () {
+      const instance = { '@id': util.randomString() }
+      const r = await document
+        .replace(agent, docPath, { instance })
+        .then(document.verifyReplaceNotFound)
+      console.error(r.body)
+      expect(r.body['api:error']['@type']).to.equal('api:DocumentNotFound')
+      expect(r.body['api:error']['api:document_id']).to.equal('terminusdb:///data/' + instance['@id'])
+      expect(r.body['api:error']['api:document']).to.deep.equal(instance)
+    })
+
     describe('fails on bad schema @id (#647)', function () {
       const identifiers = [
         '',

--- a/tests/test/document-delete.js
+++ b/tests/test/document-delete.js
@@ -1,5 +1,5 @@
 const { expect } = require('chai')
-const { Agent, db, document, endpoint } = require('../lib')
+const { Agent, db, document, endpoint, util } = require('../lib')
 
 describe('document-delete', function () {
   let agent
@@ -57,5 +57,14 @@ describe('document-delete', function () {
       .del(agent, docPath)
       .then(document.verifyDelFailure)
     expect(r.body['api:error']['@type']).to.equal('api:MissingTargets')
+  })
+
+  it('fails for document not found', async function () {
+    const id = util.randomString()
+    const r = await document
+      .del(agent, docPath, { query: { id } })
+      .then(document.verifyDelNotFound)
+    expect(r.body['api:error']['@type']).to.equal('api:DocumentNotFound')
+    expect(r.body['api:error']).to.have.property('api:document_id').that.equals(id)
   })
 })

--- a/tests/test/woql-auth.js
+++ b/tests/test/woql-auth.js
@@ -2,6 +2,7 @@ const { expect } = require('chai')
 const { Agent, db, document, endpoint, util, woql } = require('../lib')
 
 const randomType0 = util.randomString()
+const randomType1 = util.randomString()
 
 describe('woql-auth', function () {
   let agent
@@ -43,12 +44,6 @@ describe('woql-auth', function () {
     expect(r.body.transaction_retry_count).to.equal(0)
   })
 
-  const schema = {
-    '@id': randomType0,
-    '@type': 'Class',
-    something: 'xsd:string',
-  }
-
   const anInsertDocumentQuery = {
     query: {
       '@type': 'InsertDocument',
@@ -88,6 +83,12 @@ describe('woql-auth', function () {
   })
 
   describe('with schema', function () {
+    const schema = {
+      '@id': randomType0,
+      '@type': 'Class',
+      something: 'xsd:string',
+    }
+
     before(async function () {
       await document
         .insert(agent, docPath, { schema: schema })
@@ -219,6 +220,155 @@ describe('woql-auth', function () {
         expect(r.body.deletes).to.equal(2)
         expect(r.body.inserts).to.equal(0)
         expect(r.body.transaction_retry_count).to.equal(0)
+      }
+    })
+  })
+
+  describe('key type: Random', function () {
+    const schema = {
+      '@id': randomType1,
+      '@key': { '@type': 'Random' },
+      '@type': 'Class',
+      label: 'xsd:string',
+    }
+    const instance = {
+      '@type': randomType1,
+      label: 'Neel was here first.',
+    }
+    let id
+    let idFull
+
+    before(async function () {
+      await document.insert(agent, docPath, { schema }).then(document.verifyInsertSuccess)
+      const r = await document.insert(agent, docPath, { instance }).then(document.verifyInsertSuccess)
+      expect(r.body).to.be.an('array').that.has.lengthOf(1)
+      idFull = r.body[0]
+      id = idFull.replace('terminusdb:///data/', '')
+    })
+
+    after(async function () {
+      await document.del(agent, docPath, { query: { id } }).then(document.verifyDelSuccess)
+    })
+
+    function queryTemplate () {
+      return {
+        commit_info: { author: 'Not Neel', message: 'This is somebody else.' },
+        query: {
+          '@type': 'UpdateDocument',
+          document: {
+            '@type': 'Value',
+            dictionary: {
+              '@type': 'DictionaryTemplate',
+              data: [
+                {
+                  '@type': 'FieldValuePair',
+                  field: 'label',
+                  value: {
+                    '@type': 'Value',
+                    data: { '@type': 'xsd:string' },
+                  },
+                },
+                {
+                  '@type': 'FieldValuePair',
+                  field: '@type',
+                  value: {
+                    '@type': 'Value',
+                    data: { '@type': 'xsd:string', '@value': randomType1 },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      }
+    }
+
+    it('fails UpdateDocument with node identifier and missing @id', async function () {
+      const query = queryTemplate()
+      query.query.identifier = { '@type': 'NodeValue', node: id }
+      query.query.document.dictionary.data[0].value.data['@value'] = util.randomString()
+      const r = await woql.post(agent, woqlPath, query).then(woql.verifyGetFailure)
+      expect(r.body['api:error']).to.have.property('@type').that.equals('api:SubmittedIdDoesNotMatchGeneratedId')
+      expect(r.body['api:error']).to.have.property('api:submitted_id').that.equals(idFull)
+      const re = new RegExp('^' + 'terminusdb:///data/' + randomType1 + '/')
+      expect(r.body['api:error']).to.have.property('api:generated_id').that.matches(re)
+    })
+
+    it('fails UpdateDocument with missing @id', async function () {
+      const query = queryTemplate()
+      query.query.document.dictionary.data[0].value.data['@value'] = util.randomString()
+      const r = await woql.post(agent, woqlPath, query).then(woql.verifyNotFound)
+      expect(r.body['api:error']['@type']).to.equal('api:DocumentNotFound')
+      expect(r.body['api:error']['api:document']).to.deep.equal({
+        '@type': randomType1,
+        label: query.query.document.dictionary.data[0].value.data['@value'],
+      })
+      const re = new RegExp('^' + 'terminusdb:///data/' + randomType1 + '/')
+      expect(r.body['api:error']).to.have.property('api:document_id').that.matches(re)
+    })
+
+    it('passes UpdateDocument with node identifier', async function () {
+      const query = queryTemplate()
+      query.query.identifier = { '@type': 'NodeValue', node: id }
+      query.query.document.dictionary.data.push({
+        '@type': 'FieldValuePair',
+        field: '@id',
+        value: {
+          '@type': 'Value',
+          data: { '@type': 'xsd:string', '@value': id },
+        },
+      })
+      query.query.document.dictionary.data[0].value.data['@value'] = util.randomString()
+      {
+        // UpdateDocument
+        const r = await woql.post(agent, woqlPath, query).then(woql.verifyGetSuccess)
+        expect(r.body['api:variable_names']).to.be.an('array').that.has.lengthOf(0)
+        expect(r.body.bindings).to.be.an('array').that.has.lengthOf(1)
+        expect(r.body.bindings[0]).to.deep.equal({})
+        expect(r.body.deletes).to.equal(1)
+        expect(r.body.inserts).to.equal(1)
+        expect(r.body.transaction_retry_count).to.equal(0)
+      }
+      {
+        // GET
+        const r = await document.get(agent, docPath, { body: { id } }).then(document.verifyGetSuccess)
+        expect(r.body['@id']).to.equal(id)
+        expect(r.body['@type']).to.equal(randomType1)
+        expect(r.body.label).to.equal(query.query.document.dictionary.data[0].value.data['@value'])
+      }
+    })
+
+    it('passes UpdateDocument with variable identifier', async function () {
+      const query = queryTemplate()
+      query.query.identifier = { '@type': 'NodeValue', variable: 'Id' }
+      query.query.document.dictionary.data.push({
+        '@type': 'FieldValuePair',
+        field: '@id',
+        value: {
+          '@type': 'Value',
+          data: { '@type': 'xsd:string', '@value': idFull },
+        },
+      })
+      query.query.document.dictionary.data[0].value.data['@value'] = util.randomString()
+      {
+        // UpdateDocument
+        const r = await woql.post(agent, woqlPath, query).then(woql.verifyGetSuccess)
+        expect(r.body['api:variable_names']).to.be.an('array').that.has.lengthOf(1)
+        expect(r.body['api:variable_names'][0]).to.equal(query.query.identifier.variable)
+        expect(r.body.bindings).to.be.an('array').that.has.lengthOf(1)
+        const object = {}
+        object[query.query.identifier.variable] = id
+        expect(r.body.bindings[0]).to.deep.equal(object)
+        expect(r.body.deletes).to.equal(1)
+        expect(r.body.inserts).to.equal(1)
+        expect(r.body.transaction_retry_count).to.equal(0)
+      }
+      {
+        // GET
+        const r = await document.get(agent, docPath, { body: { id } }).then(document.verifyGetSuccess)
+        expect(r.body['@id']).to.equal(id)
+        expect(r.body['@type']).to.equal(randomType1)
+        expect(r.body.label).to.equal(query.query.document.dictionary.data[0].value.data['@value'])
       }
     })
   })


### PR DESCRIPTION
* Avoids a problem with the random key type where the submitted document does not contain an `@id`.
* Consolidate `document_does_not_exist` test into `document_not_found`
* Test for `document_not_found`
* Test for WOQL `UpdateDocument` with various configurations of IDs
* Refactor `json_idgen`: Lift out `key_descriptor`, pattern match on it in `json_idgen`
