### PR TITLE
Refute schema for type family with unknown class

### DIFF
--- a/src/core/document/schema.pl
+++ b/src/core/document/schema.pl
@@ -727,38 +727,49 @@ refute_type(Validation_Object,Type,Witness) :-
 refute_type(Validation_Object,Type,Witness) :-
     database_schema(Validation_Object, Schema),
     xrdf(Schema, Type, rdf:type, sys:'Set'),
-    \+  xrdf(Schema, Type, sys:class, _),
-    Witness = json{ '@type' : set_has_no_class,
-                    type : Type }.
+    (   xrdf(Schema, Type, sys:class, Class)
+    ->  refute_class_or_base_type(Validation_Object, Class, Witness)
+    ;   Witness = json{ '@type' : set_has_no_class,
+                        type : Type }
+    ).
 refute_type(Validation_Object,Type,Witness) :-
     database_schema(Validation_Object,Schema),
     xrdf(Schema, Type, rdf:type, sys:'List'),
-    \+ xrdf(Schema, Type, sys:class, _),
-    Witness = json{ '@type' : list_has_no_class,
-                    type : Type }.
+    (   xrdf(Schema, Type, sys:class, Class)
+    ->  refute_class_or_base_type(Validation_Object, Class, Witness)
+    ;   Witness = json{ '@type' : list_has_no_class,
+                        type : Type }
+    ).
 refute_type(Validation_Object,Type,Witness) :-
     database_schema(Validation_Object,Schema),
     xrdf(Schema, Type, rdf:type, sys:'Table'),
-    \+ xrdf(Schema, Type, sys:class, _),
-    Witness = json{ '@type' : table_has_no_class,
-                    type : Type }.
+    (   xrdf(Schema, Type, sys:class, Class)
+    ->  refute_class_or_base_type(Validation_Object, Class, Witness)
+    ;   Witness = json{ '@type' : table_has_no_class,
+                        type : Type }
+    ).
 refute_type(Validation_Object,Type,Witness) :-
     database_schema(Validation_Object, Schema),
     xrdf(Schema, Type, rdf:type, sys:'Optional'),
-    \+ xrdf(Schema, Type, sys:class, _),
-    Witness = json{ '@type' : optional_has_no_class,
-                    type : Type }.
+    (   xrdf(Schema, Type, sys:class, Class)
+    ->  refute_class_or_base_type(Validation_Object, Class, Witness)
+    ;   Witness = json{ '@type' : optional_has_no_class,
+                        type : Type }
+    ).
 refute_type(Validation_Object,Type,Witness) :-
     database_schema(Validation_Object, Schema),
     xrdf(Schema, Type, rdf:type, sys:'Array'),
-    \+ xrdf(Schema, Type, sys:class, _),
-    Witness = json{ '@type' : array_has_no_class,
-                    type : Type }.
+    (   xrdf(Schema, Type, sys:class, Class)
+    ->  refute_class_or_base_type(Validation_Object, Class, Witness)
+    ;   Witness = json{ '@type' : array_has_no_class,
+                        type : Type }
+    ).
 refute_type(Validation_Object,Type,Witness) :-
     database_schema(Validation_Object, Schema),
     xrdf(Schema, Type, rdf:type, sys:'Cardinality'),
-    (   \+ xrdf(Schema, Type, sys:class, _)
-    ->  Witness = json{ '@type' : cardinality_has_no_class,
+    (   xrdf(Schema, Type, sys:class, Class)
+    ->  refute_class_or_base_type(Validation_Object, Class, Witness)
+    ;   Witness = json{ '@type' : cardinality_has_no_class,
                         type : Type }
     ;   \+ xrdf(Schema, Type, sys:cardinality, _)
     ->  Witness = json{ '@type' : cardinality_has_no_bound,

--- a/tests/test/document-auth.js
+++ b/tests/test/document-auth.js
@@ -550,29 +550,6 @@ describe('document', function () {
         .then(document.verifyInsertSuccess)
     })
 
-    it('fails when adding non-optional field to schema (#780)', async function () {
-      // Insert an initial schema.
-      const schema = { '@id': util.randomString(), '@type': 'Class' }
-      await document
-        .insert(agent, docPath, { schema: schema })
-        .then(document.verifyInsertSuccess)
-      // Insert an initial instance.
-      const instance = { '@type': schema['@id'] }
-      await document
-        .insert(agent, docPath, { instance: instance })
-        .then(document.verifyInsertSuccess)
-      // Update the schema with a new field that is not Optional.
-      schema.name = 'xsd:string'
-      const r = await document
-        .replace(agent, docPath, { schema: schema })
-        .then(document.verifyReplaceFailure)
-      expect(r.body['api:error']['@type']).to.equal('api:SchemaCheckFailure')
-      expect(r.body['api:error']['api:witnesses']).to.be.an('array').that.has.lengthOf(1)
-      expect(r.body['api:error']['api:witnesses'][0]['@type']).to.equal('instance_not_cardinality_one')
-      expect(r.body['api:error']['api:witnesses'][0].class).to.equal('http://www.w3.org/2001/XMLSchema#string')
-      expect(r.body['api:error']['api:witnesses'][0].predicate).to.equal('terminusdb:///schema#name')
-    })
-
     it('accepts & returns subdocument schema with @documentation (#670)', async function () {
       const schema =
         {

--- a/tests/test/schema-check-failures.js
+++ b/tests/test/schema-check-failures.js
@@ -1,0 +1,84 @@
+const { expect } = require('chai')
+const { Agent, db, document, endpoint, util } = require('../lib')
+
+describe('schema-check-failures', function () {
+  let agent
+
+  before(async function () {
+    agent = new Agent().auth()
+    await db.createAfterDel(agent, endpoint.db(agent.defaults()).path)
+  })
+
+  after(async function () {
+    await db.del(agent, endpoint.db(agent.defaults()).path)
+  })
+
+  it('fails replace schema with new non-optional field (#780)', async function () {
+    // Insert an initial schema.
+    const schema = { '@id': util.randomString(), '@type': 'Class' }
+    const path = endpoint.document(agent.defaults()).path
+    await document.insert(agent, path, { schema }).then(document.verifyInsertSuccess)
+    // Insert an initial instance.
+    const instance = { '@type': schema['@id'] }
+    await document.insert(agent, path, { instance }).then(document.verifyInsertSuccess)
+    // Update the schema with a new field that is not Optional.
+    schema.name = 'xsd:string'
+    const r = await document.replace(agent, path, { schema }).then(document.verifyReplaceFailure)
+    expect(r.body['api:error']['@type']).to.equal('api:SchemaCheckFailure')
+    expect(r.body['api:error']['api:witnesses']).to.be.an('array').that.has.lengthOf(1)
+    expect(r.body['api:error']['api:witnesses'][0]['@type']).to.equal('instance_not_cardinality_one')
+    expect(r.body['api:error']['api:witnesses'][0].class).to.equal('http://www.w3.org/2001/XMLSchema#string')
+    expect(r.body['api:error']['api:witnesses'][0].predicate).to.equal('terminusdb:///schema#name')
+  })
+
+  it('fails insert schema with unknown class in field', async function () {
+    const schema = {
+      '@id': util.randomString(),
+      '@type': 'Class',
+      field: util.randomString(),
+    }
+    const path = endpoint.document(agent.defaults()).path
+    const r = await document.insert(agent, path, { schema }).then(document.verifyInsertFailure)
+    expect(r.body['api:error']['@type']).to.equal('api:SchemaCheckFailure')
+    expect(r.body['api:error']['api:witnesses']).to.be.an('array').that.has.lengthOf(1)
+    expect(r.body['api:error']['api:witnesses'][0]['@type']).to.equal('not_a_class_or_base_type')
+    expect(r.body['api:error']['api:witnesses'][0].class).to.equal('terminusdb:///schema#' + schema.field)
+  })
+
+  describe('fails insert schema for type family with unknown @class (#1019)', function () {
+    let schema
+    const types = [
+      'Array',
+      'Cardinality',
+      'List',
+      'Optional',
+      'Set',
+      'Table',
+    ]
+
+    before(function () {
+      schema = {
+        '@id': util.randomString(),
+        '@type': 'Class',
+        field: {
+          '@class': util.randomString(),
+          // The '@cardinality' field is here to avoid triggering a different
+          // error when the '@type' is 'Cardinality'.
+          '@cardinality': 2,
+        },
+      }
+    })
+
+    for (const type of types) {
+      it(type, async function () {
+        schema.field['@type'] = type
+        const path = endpoint.document(agent.defaults()).path
+        const r = await document.insert(agent, path, { schema }).then(document.verifyInsertFailure)
+        expect(r.body['api:error']['@type']).to.equal('api:SchemaCheckFailure')
+        expect(r.body['api:error']['api:witnesses']).to.be.an('array').that.has.lengthOf(1)
+        expect(r.body['api:error']['api:witnesses'][0]['@type']).to.equal('not_a_class_or_base_type')
+        expect(r.body['api:error']['api:witnesses'][0].class).to.equal('terminusdb:///schema#' + schema.field['@class'])
+      })
+    }
+  })
+})


### PR DESCRIPTION
The schema check fails when attempting to insert this schema via the document interface:

```json
{
  "@id": "unknown1"
  "@type": "Class",
  "field": "unknown2"
}
```

But the schema check does not fail with this schema:

```json
{
  "@id": "unknown3"
  "@type": "Class",
  "field": { "@type": "Optional", "@class": "unknown4" }
}
```

I could not find a similar issue for this problem, so I created a test for it and submitted this PR as the issue. We should update this PR branch with the fix.