### PR TITLE
Improve GitHub actions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,59 +1,40 @@
 name: Benchmark
 
 on:
-  push:
-    # We only use the `main` branch, because the benchmark graphs are linear.
-    # The results are confusing when commits from different branches are
-    # interleaved.
-    branches:
-      - main
-    # Don't run if only the docs are changed.
-    paths-ignore:
-      - 'docs/**'
-      - LICENSE
-      - README.md
-  workflow_dispatch:
+  workflow_call:
+
+env:
+  NODE_VERSION: '16'
 
 jobs:
+
   benchmark:
-    concurrency: benchmark
+    name: Run
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'terminusdb'
-    env:
-      SSH_AUTH_SOCK: /tmp/ssh_agent.sock
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2.3.1
-
-      - name: Check out terminusdb-http-perf
-        uses: actions/checkout@v2
+      - name: Download Docker image
+        uses: actions/download-artifact@v2
         with:
-          repository: terminusdb-labs/terminusdb-http-perf
-          path: terminusdb-http-perf
+          name: terminusdb-server-docker-image
 
-      - name: Add SSH Key
+      - name: Run server
         run: |
-          mkdir -p ${HOME}/.ssh
-          ssh-keyscan "${{ secrets.SSH_HOST }}" >> ${HOME}/.ssh/known_hosts
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ${HOME}/.ssh/github_actions
-          chmod 600 ${HOME}/.ssh/github_actions
-          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
-          ssh-add ${HOME}/.ssh/github_actions
+          docker load < terminusdb-server-docker-image.tar.gz
+          docker run \
+            --detach \
+            --net=host \
+            terminusdb/terminusdb-server:local
 
-
-      - name: Run benchmark
-        run: |
-          ssh "${{ secrets.SSH_USER }}"@"${{ secrets.SSH_HOST }}" "benchmark $GITHUB_SHA" > data-points.json
-
-      - name: Transform results
-        run: ./terminusdb-http-perf/metrics.sh data-points.json > results.json
-
-      - name: Store results
-        uses: terminusdb-labs/benchmark-tracker@beta
+      - uses: actions/setup-node@v2
         with:
-          tool: generic
-          output-file-path: results.json
-          benchmark-data-dir-path: benchmark
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: true
+          node-version: ${{ env.NODE_VERSION }}
+
+      - uses: actions/checkout@v2
+
+      - name: Run benchmarks
+        working-directory: tests
+        run: |
+          npm ci
+          npm run bench
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: Build
+
+on:
+  workflow_call:
+
+jobs:
+
+  build:
+    name: Docker image
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build Docker image
+        run: |
+          docker build . \
+            --file Dockerfile \
+            --tag terminusdb/terminusdb-server:local \
+            --build-arg TERMINUSDB_GIT_HASH="$(git rev-parse --verify HEAD)"
+          docker save terminusdb/terminusdb-server:local \
+            | gzip > terminusdb-server-docker-image.tar.gz
+
+      - name: Upload Docker image
+        uses: actions/upload-artifact@v2
+        with:
+            name: terminusdb-server-docker-image
+            path: terminusdb-server-docker-image.tar.gz

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,182 @@
+name: Check
+
+on:
+  workflow_call:
+
+env:
+  NODE_VERSION: '16'
+
+jobs:
+
+  unit:
+    name: Unit tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download Docker image
+        uses: actions/download-artifact@v2
+        with:
+          name: terminusdb-server-docker-image
+
+      - name: Run tests
+        run: |
+          docker load < terminusdb-server-docker-image.tar.gz
+          docker run \
+            terminusdb/terminusdb-server:local \
+            make test
+
+  python_client:
+    name: Python client tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download Docker image
+        uses: actions/download-artifact@v2
+        with:
+          name: terminusdb-server-docker-image
+
+      - name: Load Docker image
+        run: |
+          docker load < terminusdb-server-docker-image.tar.gz
+          # Tag a dev image because the docker-compose.yml uses
+          # a dev tag. We want it to fetch it locally instead of
+          # remotely from Docker Hub
+          docker image tag \
+            terminusdb/terminusdb-server:local \
+            terminusdb/terminusdb-server:dev
+
+      - uses: actions/checkout@v2
+        with:
+          repository: terminusdb/terminusdb-client-python
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install shed pytest tox
+          tox -e deps
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+      - name: Test with pytest
+        run: tox -e test
+
+  integration_tests_basic:
+    name: Integration tests (basic)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download Docker image
+        uses: actions/download-artifact@v2
+        with:
+          name: terminusdb-server-docker-image
+
+      - name: Run server
+        run: |
+          docker load < terminusdb-server-docker-image.tar.gz
+          docker run \
+            --detach \
+            --net=host \
+            terminusdb/terminusdb-server:local
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
+      - uses: actions/checkout@v2
+
+      - name: Run tests
+        working-directory: tests
+        env:
+          TERMINUSDB_DOCKER_IMAGE_TAG: terminusdb/terminusdb-server:local
+        run: |
+          npm install-ci-test
+          npm run check
+
+  integration_tests_header:
+    name: Integration tests (header)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download Docker image
+        uses: actions/download-artifact@v2
+        with:
+          name: terminusdb-server-docker-image
+
+      - name: Run server
+        run: |
+          docker load < terminusdb-server-docker-image.tar.gz
+          docker run \
+            --detach \
+            --net=host \
+            -e TERMINUSDB_INSECURE_USER_HEADER_ENABLED=true \
+            -e TERMINUSDB_INSECURE_USER_HEADER='X-Forwarded-User' \
+            terminusdb/terminusdb-server:local
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - uses: actions/checkout@v2
+
+      - name: Run tests
+        working-directory: tests
+        env:
+          TERMINUSDB_DOCKER_IMAGE_TAG: terminusdb/terminusdb-server:local
+          TERMINUSDB_INSECURE_USER_HEADER: X-Forwarded-User
+        run: npm install-ci-test
+
+  integration_tests_jwt:
+    name: Integration tests (JWT)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download Docker image
+        uses: actions/download-artifact@v2
+        with:
+          name: terminusdb-server-docker-image
+
+      - name: Run server
+        run: |
+          docker load < terminusdb-server-docker-image.tar.gz
+          docker run \
+            --detach \
+            --net=host \
+            -e TERMINUSDB_JWT_ENABLED=true \
+            -e TERMINUSDB_SERVER_JWKS_ENDPOINT='https://cdn.terminusdb.com/jwks.json' \
+            terminusdb/terminusdb-server:local
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - uses: actions/checkout@v2
+
+      - name: Run tests
+        working-directory: tests
+        env:
+          TERMINUSDB_DOCKER_IMAGE_TAG: terminusdb/terminusdb-server:local
+          TERMINUSDB_ACCESS_TOKEN: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InRlc3RrZXkifQ.eyJodHRwOi8vdGVybWludXNkYi5jb20vc2NoZW1hL3N5c3RlbSNhZ2VudF9uYW1lIjoiYWRtaW4iLCJodHRwOi8vdGVybWludXNkYi5jb20vc2NoZW1hL3N5c3RlbSN1c2VyX2lkZW50aWZpZXIiOiJhZG1pbkB1c2VyLmNvbSIsImlzcyI6Imh0dHBzOi8vdGVybWludXNodWIuZXUuYXV0aDAuY29tLyIsInN1YiI6ImFkbWluIiwiYXVkIjpbImh0dHBzOi8vdGVybWludXNodWIvcmVnaXN0ZXJVc2VyIiwiaHR0cHM6Ly90ZXJtaW51c2h1Yi5ldS5hdXRoMC5jb20vdXNlcmluZm8iXSwiaWF0IjoxNTkzNzY5MTgzLCJhenAiOiJNSkpuZEdwMHpVZE03bzNQT1RRUG1SSkltWTJobzBhaSIsInNjb3BlIjoib3BlbmlkIHByb2ZpbGUgZW1haWwifQ.Ru03Bi6vSIQ57bC41n6fClSdxlb61m0xX6Q34Yh91gql0_CyfYRWTuqzqPMFoCefe53hPC5E-eoSFdID_u6w1ih_pH-lTTqus9OWgi07Qou3QNs8UZBLiM4pgLqcBKs0N058jfg4y6h9GjIBGVhX9Ni2ez3JGNcz1_U45BhnreE
+        run: npm install-ci-test
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    env:
+      SWIPL_LINTER_VERSION: v0.7
+
+    steps:
+      - name: Download Docker image
+        uses: actions/download-artifact@v2
+        with:
+          name: terminusdb-server-docker-image
+
+        # Can be found on: https://github.com/terminusdb-labs/swipl-lint/
+      - name: Download lint
+        run: curl -L "https://raw.githubusercontent.com/terminusdb-labs/swipl-lint/$SWIPL_LINTER_VERSION/pl_lint.pl" > pl_lint.pl
+
+      - name: Run lint
+        run: |
+          docker load < terminusdb-server-docker-image.tar.gz
+          docker run \
+            -v $(pwd)/pl_lint.pl:/app/pl_lint.pl \
+            terminusdb/terminusdb-server:local \
+            swipl -f src/load_paths.pl /app/pl_lint.pl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,34 +2,21 @@ name: CI
 
 on:
   push:
-    branches:
-    tags:
     paths-ignore:
+      - '**.md'
       - 'docs/**'
       - LICENSE
-      - README.md
   pull_request:
-    # Don't run if only the docs are changed.
     paths-ignore:
+      - '**.md'
       - 'docs/**'
       - LICENSE
-      - README.md
   workflow_dispatch:
-
-env:
-  TERMINUSDB_DOCKER_IMAGE_NAME: terminusdb/terminusdb-server
-  TERMINUSDB_DOCKER_IMAGE_TAG: terminusdb/terminusdb-server:local
-  TERMINUSDB_STORE_PROLOG_VERSION: v0.19.7
-  TUS_VERSION: v0.0.5
-  SWIPL_LINTER_VERSION: v0.7
-  NODE_VERSION: '16'
 
 jobs:
 
-  # Check if this job is already running with the same or newer content.
-  #
-  # This should never skip push events: they are used by begin_deploy.
-  check_skip:
+  skip_duplicate_runs:
+    name: Skip duplicate runs
     runs-on: ubuntu-latest
 
     outputs:
@@ -39,251 +26,40 @@ jobs:
       - uses: fkirc/skip-duplicate-actions@master
         id: check_skip
         with:
+          # Skip a concurrent run triggered by a pull_request event if there is
+          # already a run triggered by a push event.
           concurrent_skipping: same_content_newer
+          # Cancel runs from outdated commits.
+          cancel_others: 'true'
+          # Do not skip push events. They are used by the push_docker job.
           do_not_skip: '["push", "workflow_dispatch", "schedule"]'
 
-  # Build the Docker image.
-  build_docker:
-    runs-on: ubuntu-latest
+  build:
+    name: Build
+    needs: skip_duplicate_runs
+    if: needs.skip_duplicate_runs.outputs.should_skip != 'true'
+    uses: ./.github/workflows/build.yml
 
-    # Check if this job needs to run. We skip a pull_request after a push.
-    needs: check_skip
-    if: needs.check_skip.outputs.should_skip != 'true'
+  check:
+    name: Check
+    needs: build
+    uses: ./.github/workflows/check.yml
 
-    steps:
-      - uses: actions/checkout@v2
+  benchmark:
+    name: Benchmark
+    needs: build
+    uses: ./.github/workflows/benchmark.yml
 
-      - name: Build Docker image
-        run: |
-          docker build . \
-            --file Dockerfile \
-            --tag $TERMINUSDB_DOCKER_IMAGE_TAG \
-            --build-arg TERMINUSDB_GIT_HASH="$(git rev-parse --verify HEAD)"
-          docker save $TERMINUSDB_DOCKER_IMAGE_TAG | gzip > terminusdb-server-docker-image.tar.gz
-
-      - name: Upload Docker image
-        uses: actions/upload-artifact@v2
-        with:
-            name: terminusdb-server-docker-image
-            path: terminusdb-server-docker-image.tar.gz
-
-  lint:
-    runs-on: ubuntu-latest
-    needs: build_docker
-
-    steps:
-
-      - name: Download Docker image
-        uses: actions/download-artifact@v2
-        with:
-          name: terminusdb-server-docker-image
-
-        # Can be found on: https://github.com/terminusdb-labs/swipl-lint/
-      - name: Download script
-        run: curl -L "https://raw.githubusercontent.com/terminusdb-labs/swipl-lint/${SWIPL_LINTER_VERSION}/pl_lint.pl" > pl_lint.pl
-
-      - name: Run linter
-        run: |
-          docker load < terminusdb-server-docker-image.tar.gz
-          docker run --name terminusdb -v $(pwd)/pl_lint.pl:/app/pl_lint.pl $TERMINUSDB_DOCKER_IMAGE_TAG \
-            swipl -f src/load_paths.pl /app/pl_lint.pl
-
-  # Unit tests
-  unit_tests:
-    runs-on: ubuntu-latest
-    needs: build_docker
-
-    steps:
-      - name: Download Docker image
-        uses: actions/download-artifact@v2
-        with:
-          name: terminusdb-server-docker-image
-
-      - name: Run unit tests
-        run: |
-          docker load < terminusdb-server-docker-image.tar.gz
-          docker run --name terminusdb $TERMINUSDB_DOCKER_IMAGE_TAG /app/terminusdb/terminusdb test
-
-  python_integration_tests:
-    runs-on: ubuntu-latest
-    needs: build_docker
-
-    steps:
-      - name: Download Docker image
-        uses: actions/download-artifact@v2
-        with:
-          name: terminusdb-server-docker-image
-
-      - name: Load Docker image
-        run: |
-          docker load < terminusdb-server-docker-image.tar.gz
-          # Tag a dev image because the docker-compose.yml uses
-          # a dev tag. We want it to fetch it locally instead of
-          # remotely from Docker Hub
-          docker image tag $TERMINUSDB_DOCKER_IMAGE_TAG $TERMINUSDB_DOCKER_IMAGE_NAME:dev
-
-      - uses: actions/checkout@v2
-        with:
-          repository: terminusdb/terminusdb-client-python
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install shed pytest tox
-          tox -e deps
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-
-      - name: Test with pytest
-        run: tox -e test
-
-  # Integration tests
-  integration_tests:
-    runs-on: ubuntu-latest
-    needs: build_docker
-
-    steps:
-      - name: Download Docker image
-        uses: actions/download-artifact@v2
-        with:
-          name: terminusdb-server-docker-image
-
-      - name: Run server
-        run: |
-          docker load < terminusdb-server-docker-image.tar.gz
-          docker run \
-            --detach \
-            --net=host \
-            $TERMINUSDB_DOCKER_IMAGE_TAG
-
-      - uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - uses: actions/checkout@v2
-
-      - name: Run integration tests
-        working-directory: tests
-        run: |
-          npm install-ci-test
-          npm run check
-
-  # Integration tests with insecure user header
-  integration_tests_user_header:
-    runs-on: ubuntu-latest
-    needs: build_docker
-
-    steps:
-      - name: Download Docker image
-        uses: actions/download-artifact@v2
-        with:
-          name: terminusdb-server-docker-image
-
-      - name: Run server
-        run: |
-          docker load < terminusdb-server-docker-image.tar.gz
-          docker run \
-            --detach \
-            --net=host \
-            -e TERMINUSDB_INSECURE_USER_HEADER_ENABLED=true \
-            -e TERMINUSDB_INSECURE_USER_HEADER='X-Forwarded-User' \
-            $TERMINUSDB_DOCKER_IMAGE_TAG
-
-      - uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - uses: actions/checkout@v2
-
-      - name: Run integration tests
-        working-directory: tests
-        env:
-          TERMINUSDB_INSECURE_USER_HEADER: X-Forwarded-User
-        run: |
-          npm install-ci-test
-
-  # Integration tests with JWT
-  integration_tests_jwt:
-    runs-on: ubuntu-latest
-    needs: build_docker
-
-    steps:
-      - name: Download Docker image
-        uses: actions/download-artifact@v2
-        with:
-          name: terminusdb-server-docker-image
-
-      - name: Run server
-        run: |
-          docker load < terminusdb-server-docker-image.tar.gz
-          docker run \
-            --detach \
-            --net=host \
-            -e TERMINUSDB_JWT_ENABLED=true \
-            -e TERMINUSDB_SERVER_JWKS_ENDPOINT='https://cdn.terminusdb.com/jwks.json' \
-            $TERMINUSDB_DOCKER_IMAGE_TAG
-
-      - uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - uses: actions/checkout@v2
-
-      - name: Run integration tests
-        working-directory: tests
-        env:
-          TERMINUSDB_ACCESS_TOKEN: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InRlc3RrZXkifQ.eyJodHRwOi8vdGVybWludXNkYi5jb20vc2NoZW1hL3N5c3RlbSNhZ2VudF9uYW1lIjoiYWRtaW4iLCJodHRwOi8vdGVybWludXNkYi5jb20vc2NoZW1hL3N5c3RlbSN1c2VyX2lkZW50aWZpZXIiOiJhZG1pbkB1c2VyLmNvbSIsImlzcyI6Imh0dHBzOi8vdGVybWludXNodWIuZXUuYXV0aDAuY29tLyIsInN1YiI6ImFkbWluIiwiYXVkIjpbImh0dHBzOi8vdGVybWludXNodWIvcmVnaXN0ZXJVc2VyIiwiaHR0cHM6Ly90ZXJtaW51c2h1Yi5ldS5hdXRoMC5jb20vdXNlcmluZm8iXSwiaWF0IjoxNTkzNzY5MTgzLCJhenAiOiJNSkpuZEdwMHpVZE03bzNQT1RRUG1SSkltWTJobzBhaSIsInNjb3BlIjoib3BlbmlkIHByb2ZpbGUgZW1haWwifQ.Ru03Bi6vSIQ57bC41n6fClSdxlb61m0xX6Q34Yh91gql0_CyfYRWTuqzqPMFoCefe53hPC5E-eoSFdID_u6w1ih_pH-lTTqus9OWgi07Qou3QNs8UZBLiM4pgLqcBKs0N058jfg4y6h9GjIBGVhX9Ni2ez3JGNcz1_U45BhnreE
-        run: |
-          npm install-ci-test
-
-  # This is an empty job that can be used to automate merging.
+  # This is required for status checks.
   all_checks_pass:
+    name: All checks pass
     runs-on: ubuntu-latest
-    needs:
-      - unit_tests
-      - integration_tests
-      - integration_tests_user_header
-      - integration_tests_jwt
-      - python_integration_tests
-      - lint
-
+    needs: check
     steps:
       - run: echo "Celebrate! 🥳"
 
-  benchmark:
-    runs-on: ubuntu-latest
-    needs: build_docker
-
-    steps:
-      - name: Download Docker image
-        uses: actions/download-artifact@v2
-        with:
-          name: terminusdb-server-docker-image
-
-      - name: Run server
-        run: |
-          docker load < terminusdb-server-docker-image.tar.gz
-          docker run \
-            --detach \
-            --net=host \
-            $TERMINUSDB_DOCKER_IMAGE_TAG
-
-      - uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - uses: actions/checkout@v2
-
-      - name: Run benchmarks
-        working-directory: tests
-        run: |
-          npm ci
-          npm run bench
-
-  # Begin deployment only for push events and certain refs.
-  #
-  # This is an empty job that serves as a common dependency for downstream jobs
-  # in their `needs`.
-  begin_deploy:
+  push_docker:
+    name: Push Docker image
     runs-on: ubuntu-latest
     needs: all_checks_pass
     if: |
@@ -292,18 +68,6 @@ jobs:
         github.ref == 'refs/heads/main' ||
         startsWith(github.ref, 'refs/tags/v')
       )
-
-    steps:
-      - name: Begin deploy
-        run: |
-          echo "Deploying for:"
-          echo "  event: ${{ github.event_name }}"
-          echo "  ref:   ${{ github.ref }}"
-
-  # Push Docker image to container repository.
-  push_docker:
-    runs-on: ubuntu-latest
-    needs: begin_deploy
 
     steps:
       - name: Download Docker image
@@ -315,82 +79,49 @@ jobs:
         run: |
           echo '${{ secrets.DOCKER_PASS }}' | docker login -u terminusdb --password-stdin
 
-          IMAGE_ID=$TERMINUSDB_DOCKER_IMAGE_NAME
-          # Change all uppercase to lowercase
-          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
           # Strip git ref prefix from version
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          VERSION=$(echo "$GITHUB_REF" | sed -e 's,.*/\(.*\),\1,')
 
+          # Use Docker `dev` tag convention for main branch
           [ "$VERSION" == "main" ] && VERSION=dev
 
-          echo IMAGE_ID=$IMAGE_ID
-          echo VERSION=$VERSION
-
           docker load < terminusdb-server-docker-image.tar.gz
-          docker tag $TERMINUSDB_DOCKER_IMAGE_TAG $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID:$VERSION
 
-          # Use dev-COMMITHASH tag for each development
-          # version. We clean up after a certain amount of time.
+          # Image identifiers
+          LOCAL_IMAGE=terminusdb/terminusdb-server:local
+          VERSION_IMAGE=terminusdb/terminusdb-server:$VERSION
+          DEV_COMMIT_IMAGE=terminusdb/terminusdb-server:$VERSION-$GITHUB_SHA
+          LATEST_IMAGE=terminusdb/terminusdb-server:latest
+
+          # Tag and push the version image
+          docker tag $LOCAL_IMAGE $VERSION_IMAGE
+          docker push $VERSION_IMAGE
+
+          # Tag and push the dev-commit image. This is removed later.
           if [ "$VERSION" == "dev" ]; then
-             DEV_COMMIT_TAG=${IMAGE_ID}:${VERSION}-${GITHUB_SHA}
-             docker tag $TERMINUSDB_DOCKER_IMAGE_TAG $DEV_COMMIT_TAG
-             docker push $DEV_COMMIT_TAG
+            docker tag $LOCAL_IMAGE $DEV_COMMIT_IMAGE
+            docker push $DEV_COMMIT_IMAGE
           fi
 
-          # Use Docker `latest` tag convention when a version tag is pushed
+          # Tag and push the latest image when a version tag is pushed
           if [ $(echo "$GITHUB_REF" | grep "refs/tags/v") ]; then
-             docker tag $IMAGE_ID:$VERSION ${IMAGE_ID}:latest
-             docker push ${IMAGE_ID}:latest
+             docker tag $LOCAL_IMAGE $LATEST_IMAGE
+             docker push $LATEST_IMAGE
           fi
 
   trigger_enterprise_build:
+    name: Trigger enterprise build
     runs-on: ubuntu-latest
-    needs: [push_docker]
+    needs: push_docker
     if: |
       github.repository == 'terminusdb/terminusdb' &&
-      github.event_name == 'push' && (
-        github.ref == 'refs/heads/main'
-      )
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main'
 
     steps:
-      - name: Deploy Stage
+      - name: Run
         run: |
-          curl -X POST https://api.github.com/repos/${{ secrets.ENTERPRISE_REPO_OWNER }}/${{ secrets.ENTERPRISE_REPO }}/dispatches \
+          curl https://api.github.com/repos/${{ secrets.ENTERPRISE_REPO_OWNER }}/${{ secrets.ENTERPRISE_REPO }}/dispatches \
+            -X POST \
             -H 'Accept: application/vnd.github.everest-preview+json' \
             -u rrooij:${{ secrets.PAT }} -d '{ "event_type": "Trigger from community" }'
-  deploy:
-    runs-on: ubuntu-latest
-    needs: [push_docker]
-    if: |
-      github.repository == 'terminusdb/terminusdb' &&
-      github.event_name == 'push' && (
-        startsWith(github.ref, 'refs/tags/v')
-      )
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Set release name
-      id: release_name
-      run: |
-        TAG=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-        TAG_WITH_SUFFIX="$TAG"
-        echo "::set-output name=tag::$TAG_WITH_SUFFIX"
-
-    - name: Delete tag and release
-      uses: dev-drprasad/delete-tag-and-release@v0.1.2
-      env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ steps.release_name.outputs.tag }}
-      continue-on-error: true
-
-    - name: Create a Release
-      id: create_release
-      uses: softprops/action-gh-release@v1
-      env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ steps.release_name.outputs.tag }}
-        prerelease: ${{ !contains(github.ref, 'tags') }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,22 @@
+name: Docs
+
+on:
+  push:
+    paths:
+      - '**.md'
+      - 'docs/**'
+      - LICENSE
+  pull_request:
+    paths:
+      - '**.md'
+      - 'docs/**'
+      - LICENSE
+
+jobs:
+
+  # This is required for status checks.
+  all_checks_pass:
+    name: All checks pass
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Nothing to be checked! 😌"

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ docs-clean:
 $(TARGET): $(RUST_TARGET) $(PROLOG_FILES)
 	# Build the target and fail for errors and warnings. Ignore warnings
 	# having "qsave(strip_failed(..." that occur on macOS.
-	TERMINUSDB_ENTERPRISE=$(ENTERPRISE) $(SWIPL) -t 'main,halt.' -q -f src/bootstrap.pl 2>&1 | \
+	TERMINUSDB_ENTERPRISE=$(ENTERPRISE) $(SWIPL) -t 'main,halt.' -q -O -f src/bootstrap.pl 2>&1 | \
 	  grep -v 'qsave(strip_failed' | \
 	  (! grep -e ERROR -e Warning)
 

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,11 @@ enterprise-module: $(RUST_TARGET)
 debug: $(RUST_TARGET)
 	echo "main, halt." | $(SWIPL) -f src/bootstrap.pl
 
+# Run the unit tests in swipl.
+.PHONY: test
+test: $(RUST_TARGET)
+	$(SWIPL) -t 'run_tests, halt.' -f src/interactive.pl
+
 # Quick command for interactive
 .PHONY: i
 i: $(RUST_TARGET)


### PR DESCRIPTION
* Separate CI and PR workflows
  - Use concurrency with commit SHA instead of `skip-duplicate-actions` to prevent redundant runs.
* Create reusable workflows for Build, Check, Benchmark.
  - These are used by CI and PR.
* Create Docs workflow for ignoring docs changes but still running the required check of 'All checks passed'.
* Run unit tests with `swipl` instead of `terminusdb test`.
* Remove `deploy` since it doesn't work.