### PR TITLE
Fix all_checks_pass_without_build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,9 @@ jobs:
     name: All checks pass
     runs-on: ubuntu-latest
     needs: is_build_required
-    if: needs.is_build_required.outputs.build_required == 'false'
+    if: >
+      needs.is_build_required.outputs.build_required == 'false' &&
+      needs.is_build_required.outputs.push_docker_required == 'false'
     steps:
       - run: echo "Nothing to be done. 😌"
 


### PR DESCRIPTION
It should succeed only if we do not need to push the Docker image.