### PR TITLE
ci: non-docker: make test

### DIFF
--- a/.github/workflows/non-docker.yml
+++ b/.github/workflows/non-docker.yml
@@ -44,4 +44,4 @@ jobs:
 
       - run: make
 
-      - run: ./terminusdb test
+      - run: make test


### PR DESCRIPTION
Run `make test` instead of `./terminusdb test`, since the latter does not run all of the unit tests.