### PR TITLE
set the document handler to chunked to support streaming output

### DIFF
--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -421,6 +421,7 @@ test(triples_update, [
 :- http_handler(api(document/Path), cors_handler(Method, document_handler(Path), [add_payload(false)]),
                 [method(Method),
                  prefix,
+                 chunked,
                  methods([options,post,delete,get,put])]).
 
 document_handler(get, Path, Request, System_DB, Auth) :-


### PR DESCRIPTION
This adds `chunked` to the configuration of the document handler. Doing this should allow streaming output, though unfortunately I don't have a local test set large enough to actually test this properly.