### PR TITLE
Allow a push to overwrite a branch containing just an initial commit

### DIFF
--- a/src/core/api/db_push.pl
+++ b/src/core/api/db_push.pl
@@ -81,7 +81,8 @@ push(System_DB, Auth, Branch, Remote_Name, Remote_Branch, _Options,
                        Remote_Branch)
         ->  (   branch_head_commit(Remote_Repository_Context,
                                    Remote_Branch,
-                                   Remote_Commit_Uri)
+                                   Remote_Commit_Uri),
+                \+ commit_uri_is_initial(Remote_Repository_Context, Remote_Commit_Uri)
             ->  Remote_Commit_Uri_Option = some(Remote_Commit_Uri)
             ;   Remote_Commit_Uri_Option = none
             ),

--- a/src/core/transaction.pl
+++ b/src/core/transaction.pl
@@ -76,6 +76,8 @@
               apply_commit_on_branch/8,
               apply_commit_on_commit/7,
               apply_commit_on_commit/8,
+              commit_uri_is_valid/2,
+              commit_uri_is_initial/2,
               commit_is_valid/2,
               commit_is_initial/2,
               commit_type/3,

--- a/src/core/transaction/ref_entity.pl
+++ b/src/core/transaction/ref_entity.pl
@@ -32,6 +32,8 @@
               apply_commit_on_branch/8,
               apply_commit_on_commit/7,
               apply_commit_on_commit/8,
+              commit_uri_is_valid/2,
+              commit_uri_is_initial/2,
               commit_is_valid/2,
               commit_is_initial/2,
               invalidate_commit/2,
@@ -1073,15 +1075,21 @@ test(common_ancestor_after_branch_and_some_commits,
 
 :- end_tests(common_ancestor).
 
-commit_is_valid(Context, Commit_Id) :-
-    commit_id_uri(Context, Commit_Id, Commit_Uri),
+commit_uri_is_valid(Context, Commit_Uri) :-
     once(ask(Context,
              t(Commit_Uri, rdf:type, '@schema':'ValidCommit'))).
 
-commit_is_initial(Context, Commit_Id) :-
+commit_is_valid(Context, Commit_Id) :-
     commit_id_uri(Context, Commit_Id, Commit_Uri),
+    commit_uri_is_valid(Context, Commit_Uri).
+
+commit_uri_is_initial(Context, Commit_Uri) :-
     once(ask(Context,
              t(Commit_Uri, rdf:type, '@schema':'InitialCommit'))).
+
+commit_is_initial(Context, Commit_Id) :-
+    commit_id_uri(Context, Commit_Id, Commit_Uri),
+    commit_uri_is_initial(Context, Commit_Uri).
 
 invalidate_commit(Context, Commit_Id) :-
     (   commit_is_valid(Context, Commit_Id)


### PR DESCRIPTION
The InitialCommit is a special type of commit that just contains prefix information. It gets overwritten by a ValidCommit on first commit. However, the current push logic sees this initialcommit and thinks it is a potential conflict.

This pull request will consider the InitialCommit to be equivalent to there not being a commit at all, and happily overwites it.