### PR TITLE
Disable timeout on the document endpoint

### DIFF
--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -422,6 +422,7 @@ test(triples_update, [
                 [method(Method),
                  prefix,
                  chunked,
+                 time_limit(infinite),
                  methods([options,post,delete,get,put])]).
 
 document_handler(get, Path, Request, System_DB, Auth) :-


### PR DESCRIPTION
The document endpoint can take its sweet time to actually retrieve all documents if you're exporting a huge database. Since that use case is fine on localhost and not indicative of an error, I've disabled the timeout for this particular endpoint, much like how it is also disabled for various other endpoints.