### PR TITLE
Upgrade tus library to latest version in the docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM terminusdb/terminus_store_prolog:v0.19.7
-ENV TUS_VERSION v0.0.5
+ENV TUS_VERSION v0.0.6
 WORKDIR /app/pack
 RUN export BUILD_DEPS="git build-essential make libjwt-dev libssl-dev pkg-config" \
         && apt-get update && apt-get install $BUILD_DEPS -y --no-install-recommends \


### PR DESCRIPTION
We were apparently on a version of tus that was more than a year old, causing a discrepancy between the library version we were using locally on dev machines and the one that ships with the container.