### PR TITLE
Handle empty env var values

### DIFF
--- a/src/config/terminus_config.pl
+++ b/src/config/terminus_config.pl
@@ -6,12 +6,10 @@
               server_port/1,
               worker_amount/1,
               max_transaction_retries/1,
-              default_database_path/1,
+              db_path/1,
               jwt_jwks_endpoint/1,
               jwt_enabled/0,
-              registry_path/1,
               pack_dir/1,
-              tmp_path/1,
               server_worker_options/1,
               http_options/1,
               ignore_ref_and_repo_schema/0,
@@ -71,8 +69,19 @@ max_transaction_retries(Value) :-
     ;   worker_amount(Num_Workers),
         Value is Num_Workers * 2).
 
-default_database_path(Value) :-
-    getenv_default('TERMINUSDB_SERVER_DB_PATH', './storage/db', Value).
+% This is defined only for testing. Use db_path/1 since it is tabled.
+default_database_path(Path) :-
+    getenv_default('TERMINUSDB_SERVER_DB_PATH', './storage/db', Value),
+    absolute_file_name(Value, Path).
+
+/**
+ * db_path(-Path) is det.
+ *
+ * Database storage path.
+ */
+:- table db_path/1 as shared.
+db_path(Path) :-
+    default_database_path(Path).
 
 jwt_enabled_env_var :-
     getenv_default('TERMINUSDB_JWT_ENABLED', false, true).
@@ -98,15 +107,6 @@ jwt_jwks_endpoint(Endpoint) :-
 
 pack_dir(Value) :-
     getenv('TERMINUSDB_SERVER_PACK_DIR', Value).
-
-registry_path(Value) :-
-    once(expand_file_search_path(plugins('registry.pl'), Path)),
-    getenv_default('TERMINUSDB_SERVER_REGISTRY_PATH', Path, Value).
-
-tmp_path(Value) :-
-    user:file_search_path(terminus_home, Dir),
-    atom_concat(Dir,'/tmp',TmpPathRelative),
-    getenv_default('TERMINUSDB_SERVER_TMP_PATH', TmpPathRelative, Value).
 
 :- table file_upload_storage_path/1 as shared.
 file_upload_storage_path(Path) :-

--- a/src/core/api/api_init.pl
+++ b/src/core/api/api_init.pl
@@ -304,4 +304,36 @@ test("TERMINUSDB_INSECURE_USER_HEADER=TerminusDB-5",
      ]) :-
     insecure_user_header_key(Header_Key).
 
+test("TERMINUSDB_SERVER_DB_PATH is not set", [true(DB_Path = Expected_Path)]) :-
+    config:default_database_path(DB_Path),
+    working_directory(CWD, CWD),
+    directory_file_path(CWD, "storage/db", Expected_Path).
+
+test("TERMINUSDB_SERVER_DB_PATH is empty",
+     [ setup(setenv('TERMINUSDB_SERVER_DB_PATH', '')),
+       cleanup(unsetenv('TERMINUSDB_SERVER_DB_PATH')),
+       true(DB_Path = Expected_Path)
+     ]) :-
+    config:default_database_path(DB_Path),
+    working_directory(CWD, CWD),
+    directory_file_path(CWD, "storage/db", Expected_Path).
+
+test("TERMINUSDB_SERVER_DB_PATH=../relative/path",
+     [ setup(setenv('TERMINUSDB_SERVER_DB_PATH', "../relative/path")),
+       cleanup(unsetenv('TERMINUSDB_SERVER_DB_PATH')),
+       true(DB_Path = Expected_Path)
+     ]) :-
+    config:default_database_path(DB_Path),
+    working_directory(CWD, CWD),
+    directory_file_path(CWD, "..", Rel_Parent_Dir),
+    absolute_file_name(Rel_Parent_Dir, Parent_Dir),
+    directory_file_path(Parent_Dir, "relative/path", Expected_Path).
+
+test("TERMINUSDB_SERVER_DB_PATH=/absolute/path",
+     [ setup(setenv('TERMINUSDB_SERVER_DB_PATH', "/absolute/path")),
+       cleanup(unsetenv('TERMINUSDB_SERVER_DB_PATH')),
+       true(DB_Path = '/absolute/path')
+     ]) :-
+    config:default_database_path(DB_Path).
+
 :- end_tests(env_vars).

--- a/src/core/util.pl
+++ b/src/core/util.pl
@@ -6,7 +6,6 @@
 
               % file_utils.pl
               terminus_path/1,
-              db_path/1,
               touch/1,
               ensure_directory/1,
               sanitise_file_name/2,

--- a/src/core/util/file_utils.pl
+++ b/src/core/util/file_utils.pl
@@ -1,6 +1,5 @@
 :- module(file_utils,[
               terminus_path/1,
-              db_path/1,
               touch/1,
               ensure_directory/1,
               sanitise_file_name/2,
@@ -12,7 +11,6 @@
           ]).
 
 :- use_module(utils).
-:- use_module(config(terminus_config), [default_database_path/1]).
 
 :- use_module(library(apply)).
 :- use_module(library(yall)).
@@ -55,19 +53,6 @@
 terminus_path(Path) :-
     once(
         file_search_path(terminus_home,Path)
-    ).
-
-/**
- * db_path(-Path) is det.
- *
- */
-db_path(Path) :-
-    default_database_path(PathWithoutSlash),
-    (   re_matchsub('\\./(.*)', PathWithoutSlash, Dict, []),
-        get_dict(1,Dict,Sub)
-    ->  working_directory(CWD, CWD),
-        atomic_list_concat([CWD, Sub, '/'], Path)
-    ;   atomic_list_concat([PathWithoutSlash, '/'], Path)
     ).
 
 /**

--- a/src/core/util/utils.pl
+++ b/src/core/util/utils.pl
@@ -810,10 +810,11 @@ getenv_number(Name, Value) :-
 /*
  * getenv_default(+Env_Key, +Default, -Value)
  *
- * Get the env variable or the default value if it isn't set
+ * Get the env variable or the default value if it is unset or empty
  */
 getenv_default(Env_Key, Default, Value) :-
-    (   getenv(Env_Key, Value)
+    (   getenv(Env_Key, Value),
+        Value \= ''
     ->  true
     ;   Value = Default).
 


### PR DESCRIPTION
* Change `getenv_default` to use the default when the env var is empty
  This came up when using `TERMINUSDB_SERVER_DB_PATH=`, which resulted
  in `getenv('TERMINUSDB_SERVER_DB_PATH', '')`, which resulted in
  `db_path('/')`.
* Add tests for `TERMINUSDB_SERVER_DB_PATH`
* Use `absolute_file_name` to determine absolute path
* Remove unused path predicates (`registry_path`, `tmp_path`)