### PR TITLE
ci: don't delete old docker images on fork

### DIFF
--- a/.github/workflows/remove-old-docker.yml
+++ b/.github/workflows/remove-old-docker.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   remove_old_docker_images:
     runs-on: ubuntu-latest
+    if: github.repository == 'terminusdb/terminusdb'
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
They don't have access to the secrets which always make the CI cron fail.