### PR TITLE
Cache docker build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Pull existing dev image
+        run: docker pull terminusdb/terminusdb-server:dev
+
       - name: Build Docker image
         run: |
           docker build . \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Pull existing dev image
-        run: docker pull terminusdb/terminusdb-server:dev
-
-
       - name: Build and export
         uses: docker/build-push-action@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,7 @@ jobs:
           outputs: type=docker,dest=terminusdb-server-docker-image.tar
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-args:
-            - TERMINUSDB_GIT_HASH=${{ github.sha }}
+          build-args: TERMINUSDB_GIT_HASH=${{ github.sha }}
 
       - name: Compress image
         run: gzip terminusdb-server-docker-image.tar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,14 +19,20 @@ jobs:
       - name: Pull existing dev image
         run: docker pull terminusdb/terminusdb-server:dev
 
-      - name: Build Docker image
-        run: |
-          docker build . \
-            --file Dockerfile \
-            --tag terminusdb/terminusdb-server:local \
-            --build-arg TERMINUSDB_GIT_HASH="$(git rev-parse --verify HEAD)"
-          docker save terminusdb/terminusdb-server:local \
-            | gzip > terminusdb-server-docker-image.tar.gz
+
+      - name: Build and export
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          tags: terminusdb/terminusdb-server:local
+          outputs: type=docker,dest=terminusdb-server-docker-image.tar
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args:
+            - TERMINUSDB_GIT_HASH=${{ github.sha }}
+
+      - name: Compress image
+        run: gzip terminusdb-server-docker-image.tar
 
       - name: Upload Docker image
         uses: actions/upload-artifact@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,5 +29,5 @@ ENV TERMINUSDB_GIT_HASH=${TERMINUSDB_GIT_HASH}
 ARG TERMINUSDB_JWT_ENABLED=true
 ENV TERMINUSDB_JWT_ENABLED=${TERMINUSDB_JWT_ENABLED}
 RUN apt-get update && apt-get install -y --no-install-recommends libjwt0 make openssl \
-    && rm -rf /var/cache/apt/* && rm -rf /var/lib/apt/lists/* && make $MAKE_ARGS
+    && rm -rf /var/cache/apt/* && rm -rf /var/lib/apt/lists/* && make $MAKE_ARGS -d
 CMD ["/app/terminusdb/distribution/init_docker.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,5 +29,6 @@ ENV TERMINUSDB_GIT_HASH=${TERMINUSDB_GIT_HASH}
 ARG TERMINUSDB_JWT_ENABLED=true
 ENV TERMINUSDB_JWT_ENABLED=${TERMINUSDB_JWT_ENABLED}
 RUN apt-get update && apt-get install -y --no-install-recommends libjwt0 make openssl \
-    && rm -rf /var/cache/apt/* && rm -rf /var/lib/apt/lists/* && make $MAKE_ARGS -d
+    && rm -rf /var/cache/apt/* && rm -rf /var/lib/apt/lists/* && touch src/rust/librust.so \
+    && make $MAKE_ARGS
 CMD ["/app/terminusdb/distribution/init_docker.sh"]


### PR DESCRIPTION
The Docker builds take quite a long time, therefore it made sense to inspect how we could speed this up. One way to do this is caching. Especially the rust parts shouldn't be rebuild every time which is why caching makes sense.

I implemented caching using a GH-action from Docker itself.  It seems to be quite an improvement already. Sometimes the build only takes ~1 minute.