### PR TITLE
Catch bad variable names in WOQL

### DIFF
--- a/src/core/query/woql_compile.pl
+++ b/src/core/query/woql_compile.pl
@@ -204,6 +204,15 @@ lookup(Var_Name,Prolog_Var,[Record|_B0]) :-
 lookup(Var_Name,Prolog_Var,[_Record|B0]) :-
     lookup(Var_Name,Prolog_Var,B0).
 
+lookup_or_extend(Var_Name, _Prolog_Var) -->
+    {
+        (   \+ atom(Var_Name)
+        ;   \+ read_term_from_atom(Var_Name, Term, [variable_names([Var_Name=Term])])
+        ),
+        !,
+        format(atom(Output), "~w", [Var_Name]),
+        throw(error(woql_syntax_error(bad_variable_name(Output)), _))
+    }.
 lookup_or_extend(Var_Name, Prolog_Var) -->
     update(bindings,B0,B1),
     {
@@ -306,12 +315,6 @@ resolve(X,XEx) -->
 resolve(ID:Suf,U) -->
     !,
     resolve_prefix(ID,Suf,U).
-resolve(v(v(Var_Name)),_Var) -->
-    {
-        % This happens when the input string has "v(X)" instead of "v('X')".
-        format(atom(Output), "~w", [v(Var_Name)]),
-        throw(error(woql_syntax_error(bad_variable_name(Output)), _))
-    }.
 resolve(v(Var_Name),Var) -->
     !,
     lookup_or_extend(Var_Name,Var).

--- a/src/core/query/woql_compile.pl
+++ b/src/core/query/woql_compile.pl
@@ -206,9 +206,7 @@ lookup(Var_Name,Prolog_Var,[_Record|B0]) :-
 
 lookup_or_extend(Var_Name, _Prolog_Var) -->
     {
-        (   \+ atom(Var_Name)
-        ;   \+ read_term_from_atom(Var_Name, Term, [variable_names([Var_Name=Term])])
-        ),
+        \+ atom(Var_Name),
         !,
         format(atom(Output), "~w", [Var_Name]),
         throw(error(woql_syntax_error(bad_variable_name(Output)), _))


### PR DESCRIPTION
Being relatively new to WOQL, I encountered a problem where I used `v(X)` instead of `v('X')` as a variable name. The experience looked like this:

```
$ ./terminusdb query admin/issue188 "v(X)=a"
  [29] dict_create(_10512,_10514,[... = a])
  [26] findall_loop(_10558,query_response:(...,...),_10562,[]) at /Users/leather/.local/lib/swipl/boot/bags.pl:99
  [25] setup_call_catcher_cleanup('$bags':'$new_findall_bag','$bags':findall_loop(_10628,...,_10632,[]),_10610,'$bags':'$destroy_findall_bag') at /Users/leather/.local/lib/swipl/boot/init.pl:661
  [21] '<meta-call>'('<garbage_collected>') <foreign>
  [20] call('<garbage_collected>') at /Users/leather/.local/lib/swipl/boot/init.pl:499
  [19] catch(database:call(...),fail_transaction,database:(_10758=true)) at /Users/leather/.local/lib/swipl/boot/init.pl:561
  [18] database:with_transaction_(query_context{all_witnesses:false,authorization:'terminusdb://system/data/User/admin',bindings:[...],commit_info:commit_info{author:admin,message:'cli query'},default_collection:branch_descriptor{branch_name:"main",repository_descriptor: ...},files:[],filter:type_filter{types: ...},prefixes:_10884{'@base':"terminusdb:///data/",'@schema':"terminusdb:///schema#",'@type':'Context',api:'http://terminusdb.com/schema/api#',owl:'http://www.w3.org/2002/07/owl#',rdf:'http://www.w3.org/1999/02/22-rdf-syntax-ns#',rdfs:'http://www.w3.org/2000/01/rdf-schema#',sys:'http://terminusdb.com/schema/sys#',vio:'http://terminusdb.com/schema/vio#',woql:'http://terminusdb.com/schema/woql#',xdd:'http://terminusdb.com/schema/xdd#',xsd:'http://www.w3.org/2001/XMLSchema#'},selected:[],system:system_descriptor{},transaction_objects:[...],update_guard:true,write_graph:branch_graph{branch_name:"main",database_name:"issue188",organization_name:"admin",repository_name:"local",type:instance}},query_response:(...,...),_10800) at /Users/leather/projects/terminusdb/terminusdb/src/core/transaction/database.pl:233
  [17] setup_call_catcher_cleanup(database:pre_transaction_tabling,database:with_transaction_(...,...,_11048),_11026,database:post_transaction_tabling) at /Users/leather/.local/lib/swipl/boot/init.pl:661
  [15] database:with_transaction('<garbage_collected>','<garbage_collected>','<garbage_collected>') at /Users/leather/projects/terminusdb/terminusdb/src/core/transaction/database.pl:222
  [14] query_response:run_context_ast_jsonld_response('<garbage_collected>','<garbage_collected>',no_data_version,_11136,_11138) at /Users/leather/projects/terminusdb/terminusdb/src/core/query/query_response.pl:30
  [13] '<meta-call>'('<garbage_collected>') <foreign>
  [12] catch(cli:(...,...),error(type_error('dict-key',...),context(...,_11236)),cli:do_or_die(...,...)) at /Users/leather/.local/lib/swipl/boot/init.pl:561
  [11] catch_with_backtrace(cli:(...,...),error(type_error('dict-key',...),context(...,_11312)),cli:do_or_die(...,...)) at /Users/leather/.local/lib/swipl/boot/init.pl:629
```

The error stems from the fact that the WOQL parser turns the string `"v(X)=a"` into the AST `v(v('X'))=a`, which creates a problem when it tries to look up the variable name `v('X')` (which should really be just `'X'`).

This PR adds a check to ensure that the `X` in `v(X)` is really just an atom. If it is not, we throw a syntax error:

```
$ ./terminusdb query admin/issue188 "v(X)=a"
Error: Unknown syntax error in WOQL: "bad_variable_name('v(X)')"
{
  "@type":"api:WoqlErrorResponse",
  "api:error": {
    "@type":"api:WOQLSyntaxError",
    "api:error_term":"bad_variable_name('v(X)')"
  },
  "api:message":"Unknown syntax error in WOQL: \"bad_variable_name('v(X)')\"",
  "api:status":"api:failure"
}
```