### PR TITLE
Accept test_ref in check.yml

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,9 @@ on:
       test_repository:
         required: true
         type: string
+      test_ref:
+        required: true
+        type: string
 
 env:
   NODE_VERSION: '16'
@@ -88,6 +91,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: ${{ inputs.test_repository }}
+          ref: ${{ inputs.test_ref }}
 
       - name: Run tests
         working-directory: tests
@@ -124,6 +128,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: ${{ inputs.test_repository }}
+          ref: ${{ inputs.test_ref }}
 
       - name: Run tests
         working-directory: tests
@@ -159,6 +164,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: ${{ inputs.test_repository }}
+          ref: ${{ inputs.test_ref }}
 
       - name: Run tests
         working-directory: tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
     uses: ./.github/workflows/check.yml
     with:
       test_repository: ${{ github.repository }}
+      test_ref: ${{ github.ref }}
 
   benchmark:
     name: Benchmark


### PR DESCRIPTION
This allows us to use `check.yml` outside of the repository and
guarantee that every use of `actions/checkout` gets the same ref. It has
happened that the `HEAD` of the default branch changes in the middle of
these multiple checkouts. With this change, that won't happen.