### PR TITLE
Use github.sha, not github.ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
     uses: ./.github/workflows/check.yml
     with:
       test_repository: ${{ github.repository }}
-      test_ref: ${{ github.ref }}
+      test_ref: ${{ github.sha }}
 
   benchmark:
     name: Benchmark


### PR DESCRIPTION
`github.ref` may point to `refs/head/main`, and the SHA to which it
points can change during the run.

`github.sha` points to `b389a2830b119c8b6c4b71a6984b733837231d3a`, which
never changes during a run.