### PR TITLE
CLI doc insert: use singular and plural messages

### DIFF
--- a/src/cli/main.pl
+++ b/src/cli/main.pl
@@ -1227,14 +1227,16 @@ run_command(doc,insert,[Path], Opts) :-
 
     api_report_errors(
         insert_documents,
-        (   (   var(Data)
-            ->  with_memory_file(cli:doc_insert_memory_file(System_DB, Auth, Path, Graph_Type, Author, Message, Full, Ids))
-            ;   open_string(Data, Stream),
-                doc_insert_stream(System_DB, Auth, Path, Graph_Type, Author, Message, Full, Ids, Stream)
-            ),
-            length(Ids, Number_Inserted),
-            format("Document(s) inserted: ~d~n", [Number_Inserted])
+        (   var(Data)
+        ->  with_memory_file(cli:doc_insert_memory_file(System_DB, Auth, Path, Graph_Type, Author, Message, Full, Ids))
+        ;   open_string(Data, Stream),
+            doc_insert_stream(System_DB, Auth, Path, Graph_Type, Author, Message, Full, Ids, Stream)
         )
+    ),
+    length(Ids, Number_Inserted),
+    (   Number_Inserted = 1
+    ->  format(current_output, "Document inserted~n", [])
+    ;   format(current_output, "Documents inserted: ~d~n", [Number_Inserted])
     ).
 run_command(doc,delete, [Path], Opts) :-
     super_user_authority(Auth),

--- a/tests/test/cli-doc.js
+++ b/tests/test/cli-doc.js
@@ -30,7 +30,7 @@ describe('cli-doc', function () {
     const schema = { '@type': 'Class', '@id': util.randomString() }
     {
       const r = await exec(`./terminusdb.sh doc insert ${dbSpec} --graph_type=schema --data='${JSON.stringify(schema)}'`)
-      expect(r.stdout).to.match(/^Document\(s\) inserted: 1/)
+      expect(r.stdout).to.match(/^Document inserted/)
     }
     {
       const r = await exec(`./terminusdb.sh doc get ${dbSpec} --graph_type=schema`)
@@ -48,12 +48,12 @@ describe('cli-doc', function () {
     const schema = { '@type': 'Class', '@id': util.randomString(), x: 'xsd:integer' }
     {
       const r = await exec(`./terminusdb.sh doc insert ${dbSpec} --graph_type=schema --data='${JSON.stringify(schema)}'`)
-      expect(r.stdout).to.match(/^Document\(s\) inserted: 1/)
+      expect(r.stdout).to.match(/^Document inserted/)
     }
     const instance = { '@type': schema['@id'], '@id': `${schema['@id']}/0`, x: -88 }
     {
       const r = await exec(`./terminusdb.sh doc insert ${dbSpec} --graph_type=instance --data='${JSON.stringify(instance)}'`)
-      expect(r.stdout).to.match(/^Document\(s\) inserted: 1/)
+      expect(r.stdout).to.match(/^Document inserted/)
     }
     {
       const r = await exec(`./terminusdb.sh doc get ${dbSpec} --graph_type=instance`)


### PR DESCRIPTION
The use of `(s)` in `Document(s)` has been irritating me.