### PR TITLE
Simplify release process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  LAST_RELEASED_VERSION: 10.0.24
+  CURRENT_REPO_VERSION: 10.0.25
+
 jobs:
 
   is_duplicate_run:
@@ -51,11 +55,37 @@ jobs:
             change_other_than_docs_alone:
               - '!(**.md|docs/**|LICENSE)'
 
-  build:
-    name: Build
+  versions:
+    name: Versions
+    runs-on: ubuntu-latest
     needs:
       - is_duplicate_run
       - is_build_required
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run Cog to update versions in files
+        run: |
+          pip install cogapp
+          cog -v
+          cog -r \
+            -D LAST_RELEASED_VERSION=$LAST_RELEASED_VERSION \
+            -D CURRENT_REPO_VERSION=$CURRENT_REPO_VERSION \
+            docs/release-steps.md \
+            src/config/terminus_config.pl
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Update versions
+          file_pattern: >-
+            docs/release-steps.md
+            src/config/terminus_config.pl
+
+  build:
+    name: Build
+    needs: versions
     # Build if we need to push a Docker image or there is no duplicate run in
     # progress and a build is required due to changed files.
     if: |

--- a/docs/release-steps.md
+++ b/docs/release-steps.md
@@ -65,23 +65,19 @@ The current repository version is: <!--
    ```
    <!-- [[[end]]] -->
 
-5. Create a new release for: <!--
+5. Create a new GitHub release for the tag: <!--
    [[[cog cog.out(current_repo_version_link) ]]] -->
    [`v10.0.25`](https://github.com/terminusdb/terminusdb/releases/tag/v10.0.25)
    <!-- [[[end]]] -->
 
-6. Review the PR for unexpected commits.
-   1. Approve.
-   2. Merge.
-
-7. (_PR_) Update the versions in [`version.yml`](../.github/workflows/version.yml):
+6. (_PR_) Update the versions in [`version.yml`](../.github/workflows/version.yml):
    1. Change the value for `LAST_RELEASED_VERSION` to: <!--
       [[[cog cog.out(current_repo_version) ]]] -->
       `v10.0.25`
       <!-- [[[end]]] -->
    2. Change the value for `CURRENT_REPO_VERSION` to the next planned version.
 
-8. Review the PR for correct version.
+7. Review the PR for correct version.
    1. Wait for CI to pass.
    2. Approve.
    3. Merge.

--- a/docs/release-steps.md
+++ b/docs/release-steps.md
@@ -2,16 +2,37 @@
 
 This document describes the steps we go through we making a new release.
 
-1. Note the current release branch: `v10.0`.
+<!-- [[[cog
+import cog
+last_released_version = f'`v{LAST_RELEASED_VERSION}`'
+last_released_version_link = f'[{last_released_version}](https://github.com/terminusdb/terminusdb/releases/tag/v{LAST_RELEASED_VERSION})'
+changes_since_last_released_version_link = f'[`{LAST_RELEASED_VERSION}...main`](https://github.com/terminusdb/terminusdb/compare/v{LAST_RELEASED_VERSION}...main)'
+current_repo_version = f'`v{CURRENT_REPO_VERSION}`'
+current_repo_version_link = f'[{current_repo_version}](https://github.com/terminusdb/terminusdb/releases/tag/v{CURRENT_REPO_VERSION})'
+]]] -->
+<!-- [[[end]]] -->
 
-2. Choose the version number for the new release. Save it (mentally) as `$VERSION`.
+The last released version of TerminusDB is: <!--
+[[[cog cog.out(last_released_version_link) ]]] -->
+[`v10.0.24`](https://github.com/terminusdb/terminusdb/releases/tag/v10.0.24)
+<!-- [[[end]]] -->
 
-3. Look at the changes between `main` and the current release branch:
+The current repository version is: <!--
+[[[cog cog.out(current_repo_version) ]]] -->
+`v10.0.25`
+<!-- [[[end]]] -->
 
-   https://github.com/terminusdb/terminusdb/compare/v10.0...main
+1. Look at the changes to `main` since the last released version: <!--
+   [[[cog cog.out(changes_since_last_released_version_link) ]]] -->
+   [`10.0.24...main`](https://github.com/terminusdb/terminusdb/compare/v10.0.24...main)
+   <!-- [[[end]]] -->
 
-4. (_PR_) Update [`RELEASE_NOTES.md`](./RELEASE_NOTES.md) in `main`:
-   1. Add a new section for `$VERSION` at the beginning of the file.
+2. (_PR_) Update [`RELEASE_NOTES.md`](./RELEASE_NOTES.md) in `main`:
+   1. Add a new section for <!--
+      [[[cog cog.out(current_repo_version) ]]] -->
+      `v10.0.25`
+      <!-- [[[end]]] -->
+      at the beginning of the file.
    2. Use the following subsection headers:
       - New
       - Bug fixes
@@ -20,43 +41,47 @@ This document describes the steps we go through we making a new release.
    3. Add a bullet point for each item under the above subsections. If no items
       can be identified for that subsection, omit that subsection.
 
-5. Review the PR for release notes.
+3. Review the PR for release notes.
    1. Approve.
    2. Merge.
 
-6. (_PR_) Merge from `main` to the current release branch:
+4. Create a new tag on `main`:
+   <!-- [[[cog
+   cog.out(f"""
+   ```
+   git checkout main
+   git pull
+   git tag v{CURRENT_REPO_VERSION}
+   git push origin v{CURRENT_REPO_VERSION}
+   ```
+   """)
+   ]]] -->
 
-   https://github.com/terminusdb/terminusdb/compare/v10.0...main
+   ```
+   git checkout main
+   git pull
+   git tag v10.0.25
+   git push origin v10.0.25
+   ```
+   <!-- [[[end]]] -->
 
-7. Review the PR for unexpected commits.
+5. Create a new release for: <!--
+   [[[cog cog.out(current_repo_version_link) ]]] -->
+   [`v10.0.25`](https://github.com/terminusdb/terminusdb/releases/tag/v10.0.25)
+   <!-- [[[end]]] -->
+
+6. Review the PR for unexpected commits.
+   1. Approve.
+   2. Merge.
+
+7. (_PR_) Update the versions in [`version.yml`](../.github/workflows/version.yml):
+   1. Change the value for `LAST_RELEASED_VERSION` to: <!--
+      [[[cog cog.out(current_repo_version) ]]] -->
+      `v10.0.25`
+      <!-- [[[end]]] -->
+   2. Change the value for `CURRENT_REPO_VERSION` to the next planned version.
+
+8. Review the PR for correct version.
    1. Wait for CI to pass.
    2. Approve.
    3. Merge.
-
-8. Create a new tag for `$VERSION` on the current release branch:
-
-   ```
-   git checkout v10.0
-   git pull
-   git tag $VERSION
-   git push origin $VERSION
-   ```
-
-9. Create a new release for this tag on GitHub:
-
-   https://github.com/terminusdb/terminusdb/tags
-
-10. (_PR_) Merge from the current release branch to `main`:
-
-    https://github.com/terminusdb/terminusdb/compare/main...v10.0
-
-11. Review the PR for unexpected commits.
-    1. Approve.
-    2. Merge.
-
-12. (_PR_) Update the version number in [`terminus_config.pl`](../src/config/terminus_config.pl).
-
-13. Review the PR for correct version.
-    1. Wait for CI to pass.
-    2. Approve.
-    3. Merge.

--- a/src/config/terminus_config.pl
+++ b/src/config/terminus_config.pl
@@ -38,7 +38,9 @@
 :- use_module(library(apply)).
 :- use_module(library(yall)).
 
+/* [[[cog import cog; cog.out(f"terminusdb_version('{CURRENT_REPO_VERSION}').") ]]] */
 terminusdb_version('10.0.25').
+/* [[[end]]] */
 
 bootstrap_config_files :-
     initialize_system_ssl_certs.


### PR DESCRIPTION
* Remove use of release branch (currently `v10.0`) and use only tags
* Automate updating of versions by setting them in
  `.github/workflows/ci.yml`:
  - `LAST_RELEASED_VERSION`
  - `CURRENT_REPO_VERSION`
* Generate parts of files with the versions above:
  - `docs/release-steps.md`
  - `src/config/terminus_config.pl`