### PR TITLE
swipl --on-error=halt --on-warning=halt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,10 @@ docker:
 # Install all pack dependencies.
 .PHONY: install-deps
 install-deps:
-	$(SWIPL) -g 'Options=[interactive(false), upgrade(true), test(false)], pack_install(tus, Options), halt'
+	$(SWIPL) \
+	  --on-error=halt \
+	  --on-warning=halt \
+	  -g 'Options=[interactive(false), upgrade(true), test(false)], pack_install(tus, Options), halt'
 
 # Download and run the lint tool.
 .PHONY: lint
@@ -78,7 +81,11 @@ debug: $(RUST_TARGET)
 # Run the unit tests in swipl.
 .PHONY: test
 test: $(RUST_TARGET)
-	$(SWIPL) -t 'run_tests, halt.' -f src/interactive.pl
+	$(SWIPL) \
+	  --on-error=halt \
+	  --on-warning=halt \
+	  -t 'run_tests, halt' \
+	  -f src/interactive.pl
 
 # Quick command for interactive
 .PHONY: i
@@ -114,11 +121,13 @@ docs-clean:
 ################################################################################
 
 $(TARGET): $(RUST_TARGET) $(PROLOG_FILES)
-	# Build the target and fail for errors and warnings. Ignore warnings
-	# having "qsave(strip_failed(..." that occur on macOS.
-	TERMINUSDB_ENTERPRISE=$(ENTERPRISE) $(SWIPL) -t 'main,halt.' -q -O -f src/bootstrap.pl 2>&1 | \
-	  grep -v 'qsave(strip_failed' | \
-	  (! grep -e ERROR -e Warning)
+	TERMINUSDB_ENTERPRISE=$(ENTERPRISE) $(SWIPL) \
+	  --on-error=halt \
+	  --on-warning=halt \
+	  --quiet \
+	  -O \
+	  -t 'main, halt' \
+	  -f src/bootstrap.pl
 
 $(RUST_TARGET): $(RUST_FILES)
 	cd $(RUST_SOURCE_DIR) && cargo build --release

--- a/src/bootstrap.pl
+++ b/src/bootstrap.pl
@@ -27,6 +27,12 @@
 
 :- use_module(library(qsave)).
 
+% Ignore these warnings from `qsave.pl` that occur on macOS.
+% When the next SWI-Prolog is released, it should have the following, which
+% would allow us to remove this `user:message_hook`.
+% <https://github.com/SWI-Prolog/swipl/pull/22>
+user:message_hook(qsave(strip_failed(_)), warning, _).
+
 main :-
     initialize_flags,
     bootstrap_files,


### PR DESCRIPTION
Use these flags with `swipl` in the `Makefile` to tell it to halt with a
non-zero exit code when the first error or warning occurs.

These flags have been available since SWI-Prolog 8.4. We are currently
on 8.4.2.

See for usage:
<https://swi-prolog.discourse.group/t/changes-in-error-handling/3930>

This also appears to fix #873, probably because I removed the `grep`
commands in the pipes. The next release of SWI-Prolog will not need
these thanks to: <https://github.com/SWI-Prolog/swipl/pull/22>