### PR TITLE
Adding worker count default as number of CPUs

### DIFF
--- a/src/config/terminus_config.pl
+++ b/src/config/terminus_config.pl
@@ -63,7 +63,8 @@ server_port(Value) :-
     getenv_default_number('TERMINUSDB_SERVER_PORT', 6363, Value).
 
 worker_amount(Value) :-
-    getenv_default_number('TERMINUSDB_SERVER_WORKERS', 8, Value).
+    current_prolog_flag(cpu_count,Integer),
+    getenv_default_number('TERMINUSDB_SERVER_WORKERS', Integer, Value).
 
 :- table max_transaction_retries/1 as shared.
 max_transaction_retries(Value) :-


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute!

Is this your first pull request? If you don't mind, please read this first.

<https://github.com/terminusdb/terminusdb/blob/main/docs/CONTRIBUTING.md>
-->
