### PR TITLE
Use version of terminusdb-store that doesn't use read locks for labels

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -150,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cc00842eed744b858222c4c9faf7243aafc6d33f92f96935263ef4d8a41ce21"
+checksum = "bf6b561dcf059c85bbe388e0a7b0a1469acb3934cc0cfa148613a830629e3049"
 dependencies = [
  "glob",
  "libc",
@@ -503,9 +503,9 @@ checksum = "70048d97b51d107a6cf295d42210d298f0eb7d37f0518b88c816a74b8ce15f41"
 
 [[package]]
 name = "libc"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libloading"
@@ -674,11 +674,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9027b48e9d4c9175fa2218adf3557f91c1137021739951d4932f5f8268ac48aa"
+checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -722,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd249e82c21598a9a426a4e00dd7adc1d640b22445ec8545feef801d1a74c221"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -734,9 +734,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f51245e1e62e1f1629cbfec37b5793bbabcaeb90f30e94d2ba03564687353e4"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -784,9 +784,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "ryu"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
 name = "scopeguard"
@@ -842,12 +842,12 @@ checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "socket2"
-version = "0.4.5"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca642ba17f8b2995138b1d7711829c92e98c0a25ea019de790f4f09279c4e296"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
- "windows-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -858,9 +858,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "swipl"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2b98b973f28e775f54d07e6db4b78d5605a98fedbe15322af0f51fd4e9ae050"
+checksum = "3d809dc40a4fbfd6a84cadee59ab31f296ac8a767598a5104f37886497d74289"
 dependencies = [
  "lazy_static",
  "swipl-fli",
@@ -889,9 +889,9 @@ dependencies = [
 
 [[package]]
 name = "swipl-macros"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0405e02344511d55b247696212748d0b90f673b763121534fee73355d4020da"
+checksum = "5ad1822c58d627deb6a9aa4b9d13f56a0864fb0020e31873e76adae9781c2a64"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -901,13 +901,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.92"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff7c592601f11445996a06f8ad0c27f094a58857c2f89e97974ab9235b92c52"
+checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -932,8 +932,9 @@ dependencies = [
 
 [[package]]
 name = "terminus-store"
-version = "0.19.6"
-source = "git+https://github.com/terminusdb/terminusdb-store.git?branch=nolock-feature#20ed24331b39277c072984fd81c6c2f0af46a1a6"
+version = "0.19.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65774807fc4017f0f21ec08aeafeb8c83d779fb8e85ac763db5b22c371abeb3e"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -957,7 +958,6 @@ version = "0.1.0"
 dependencies = [
  "lcs",
  "swipl",
- "terminus-store",
  "terminusdb-store-prolog",
 ]
 
@@ -1056,9 +1056,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
+checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
 dependencies = [
  "bytes 1.1.0",
  "futures-core",
@@ -1084,16 +1084,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "urlencoding"

--- a/src/rust/terminusdb-community/Cargo.toml
+++ b/src/rust/terminusdb-community/Cargo.toml
@@ -9,5 +9,4 @@ publish = false
 [dependencies]
 swipl = "0.3.6"
 lcs = "0.2.0"
-terminus-store = {git = "https://github.com/terminusdb/terminusdb-store.git", branch="nolock-feature", features=["noreadlock"]}
 terminusdb-store-prolog = {path="../terminusdb-store-prolog"}

--- a/src/rust/terminusdb-store-prolog/Cargo.toml
+++ b/src/rust/terminusdb-store-prolog/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 [dependencies]
 swipl = "0.3.6"
 #swipl = {path = "../../swipl-rs/swipl"}
-terminus-store = {git = "https://github.com/terminusdb/terminusdb-store.git", branch="nolock-feature", features=["noreadlock"]}
+terminus-store = {version="=0.19.7", features=["noreadlock"]}
 csv = "1.1"
 sha-1 = "0.9.1"
 hex = "0.4.2"

--- a/src/rust/terminusdb-store-prolog/src/lib.rs
+++ b/src/rust/terminusdb-store-prolog/src/lib.rs
@@ -4,6 +4,8 @@ mod layer;
 mod named_graph;
 mod store;
 
+pub use terminus_store;
+
 pub fn install(module: Option<&str>) {
     csv::register_csv_iri_in_module(module);
     csv::register_csv_builder_in_module(module);


### PR DESCRIPTION
We do not need read locks for labels as reading a small file can be considered an atomic operation on posix filesystems. We therefore now build terminusdb with its store dependency's `noreadlock` feature enabled.