### PR TITLE
Improve Makefile and Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,15 @@
-.git
-# Prevent temporary emacs files from being included
 *~
+\#*\#
+.\#*
+.packs
+*.index*
+**/*.md
+**/.git*
+httpd.log
 docs
 storage
-src/rust/target
-src/rust/librust.*
+tmp
+**/target
+**/*.so
+**/*.dylib
 terminusdb

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,5 +4,5 @@
 docs
 storage
 src/rust/target
-src/rust/librust.so
+src/rust/librust.*
 terminusdb

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,7 @@
 *~
 \#*\#
 .\#*
-.packs
+.deps
 *.index*
 **/*.md
 **/.git*

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -185,6 +185,11 @@ jobs:
         with:
           name: terminusdb-server-docker-image
 
+      - uses: actions/checkout@v2
+        with:
+          repository: ${{ inputs.test_repository }}
+          ref: ${{ inputs.test_ref }}
+
         # Can be found on: https://github.com/terminusdb-labs/swipl-lint/
       - name: Download lint
         run: curl -L "https://raw.githubusercontent.com/terminusdb-labs/swipl-lint/$SWIPL_LINTER_VERSION/pl_lint.pl" > pl_lint.pl

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -194,5 +194,6 @@ jobs:
           docker load < terminusdb-server-docker-image.tar.gz
           docker run \
             -v $(pwd)/pl_lint.pl:/app/pl_lint.pl \
+            -v $(pwd):/app/terminusdb \
             terminusdb/terminusdb-server:local \
             swipl -f src/load_paths.pl src/core/query/expansions.pl /app/pl_lint.pl

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -176,29 +176,24 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    env:
-      SWIPL_LINTER_VERSION: v0.8
 
     steps:
-      - name: Download Docker image
-        uses: actions/download-artifact@v2
-        with:
-          name: terminusdb-server-docker-image
-
       - uses: actions/checkout@v2
         with:
           repository: ${{ inputs.test_repository }}
           ref: ${{ inputs.test_ref }}
 
-        # Can be found on: https://github.com/terminusdb-labs/swipl-lint/
-      - name: Download lint
-        run: curl -L "https://raw.githubusercontent.com/terminusdb-labs/swipl-lint/$SWIPL_LINTER_VERSION/pl_lint.pl" > pl_lint.pl
+      - name: Download Docker image
+        uses: actions/download-artifact@v2
+        with:
+          name: terminusdb-server-docker-image
+
+      - run: make download-lint
 
       - name: Run lint
         run: |
           docker load < terminusdb-server-docker-image.tar.gz
           docker run \
-            -v $(pwd)/pl_lint.pl:/app/pl_lint.pl \
             -v $(pwd):/app/terminusdb \
             terminusdb/terminusdb-server:local \
-            swipl -f src/load_paths.pl src/core/query/expansions.pl /app/pl_lint.pl
+            make lint

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 *~
 \#*\#
 .\#*
-.packs
+.deps
 config.pl
 *.index.v1-1
 prefix.db
@@ -18,3 +18,4 @@ terminusdb
 **/target/
 **/*.so
 **/*.dylib
+terminusdb-enterprise

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *~
 \#*\#
 .\#*
+.packs
 config.pl
 *.index.v1-1
 prefix.db

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,5 @@ nohup.out
 plugins/registry.pl
 terminusdb
 **/target/
-src/rust/librust.so
-src/rust/librust.dylib
-terminusdb-enterprise
+**/*.so
+**/*.dylib

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,20 @@
-FROM terminusdb/swipl:v8.4.2 as pack_installer
+# syntax=docker/dockerfile:1.3
+
+ARG DIST=community
+
+# Install the SWI-Prolog pack dependencies.
+FROM terminusdb/swipl:v8.4.2 AS pack_installer
 RUN set -eux; \
     BUILD_DEPS="git build-essential make libjwt-dev libssl-dev pkg-config"; \
     apt-get update; \
     apt-get install -y --no-install-recommends ${BUILD_DEPS}; \
     rm -rf /var/lib/apt/lists/*
 WORKDIR /app/pack
-COPY ./Makefile .
-RUN set -eux; \
-    make install-tus; \
-    make install-jwt
+COPY distribution/Makefile.deps Makefile
+RUN make
 
-FROM terminusdb/swipl:v8.4.2 AS rust_builder
+# Install Rust. Prepare to build the Rust code.
+FROM terminusdb/swipl:v8.4.2 AS rust_builder_base
 RUN set -eux; \
     BUILD_DEPS="git build-essential curl clang ca-certificates"; \
     apt-get update; \
@@ -18,28 +22,55 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/*
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
-# Update the crates.io index git repo to cache it before building.
+# Initialize the crates.io index git repo to cache it.
 RUN cargo install lazy_static 2> /dev/null || true
 WORKDIR /app/rust
-COPY ./src/rust .
-RUN cargo build --release
+COPY distribution/Makefile.rust Makefile
+COPY src/rust src/rust/
 
-FROM terminusdb/swipl:v8.4.2
+# Build the community dylib.
+FROM rust_builder_base AS rust_builder_community
+RUN make DIST=community
+
+# Build the enterprise dylib.
+FROM rust_builder_base AS rust_builder_enterprise
+COPY terminusdb-enterprise/rust terminusdb-enterprise/rust/
+RUN make DIST=enterprise
+
+# Build the ${DIST} dylib.
+FROM rust_builder_${DIST} AS rust_builder
+
+# Copy the packs and dylib. Prepare to build the Prolog code.
+FROM terminusdb/swipl:v8.4.2 AS base
 RUN set -eux; \
+    RUNTIME_DEPS="libjwt0 make openssl"; \
     apt-get update; \
-    apt-get install -y --no-install-recommends libjwt0 make openssl; \
+    apt-get install -y --no-install-recommends ${RUNTIME_DEPS}; \
     rm -rf /var/cache/apt/*; \
     rm -rf /var/lib/apt/lists/*
-WORKDIR /app/terminusdb
-COPY ./ .
-COPY --from=pack_installer /root/.local/share/swi-prolog/pack/ /usr/share/swi-prolog/pack
-COPY --from=rust_builder /app/rust/target/release/libterminusdb_dylib.so /app/terminusdb/src/rust/librust.so
-ARG MAKE_ARGS=""
 ARG TERMINUSDB_GIT_HASH=null
 ENV TERMINUSDB_GIT_HASH=${TERMINUSDB_GIT_HASH}
 ARG TERMINUSDB_JWT_ENABLED=true
 ENV TERMINUSDB_JWT_ENABLED=${TERMINUSDB_JWT_ENABLED}
+COPY --from=pack_installer /root/.local/share/swi-prolog/pack/ /usr/share/swi-prolog/pack
+WORKDIR /app/terminusdb
+COPY distribution/Makefile.prolog Makefile
+COPY src src/
+COPY --from=rust_builder /app/rust/src/rust/librust.so src/rust/
+
+# Build the community executable.
+FROM base AS base_community
 RUN set -eux; \
     touch src/rust/librust.so; \
-    make $MAKE_ARGS
+    make DIST=community
+
+# Build the enterprise executable.
+FROM base AS base_enterprise
+COPY terminusdb-enterprise/prolog terminusdb-enterprise/prolog/
+RUN set -eux; \
+    touch src/rust/librust.so; \
+    make DIST=enterprise
+
+# Build the ${DIST} executable. Set the default command.
+FROM base_${DIST}
 CMD ["/app/terminusdb/distribution/init_docker.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ ARG TERMINUSDB_JWT_ENABLED=true
 ENV TERMINUSDB_JWT_ENABLED=${TERMINUSDB_JWT_ENABLED}
 COPY --from=pack_installer /root/.local/share/swi-prolog/pack/ /usr/share/swi-prolog/pack
 WORKDIR /app/terminusdb
+COPY distribution/init_docker.sh distribution/
 COPY distribution/Makefile.prolog Makefile
 COPY src src/
 COPY --from=rust_builder /app/rust/src/rust/librust.so src/rust/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,35 @@
 FROM terminusdb/swipl:v8.4.2 as pack_installer
-ENV TUS_VERSION v0.0.10
+RUN set -eux; \
+    BUILD_DEPS="git build-essential make libjwt-dev libssl-dev pkg-config"; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ${BUILD_DEPS}; \
+    rm -rf /var/lib/apt/lists/*
 WORKDIR /app/pack
-RUN export BUILD_DEPS="git build-essential make libjwt-dev libssl-dev pkg-config" \
-        && apt-get update && apt-get install $BUILD_DEPS -y --no-install-recommends \
-        && git clone --single-branch --branch v0.0.5 https://github.com/terminusdb-labs/jwt_io.git jwt_io \
-        && git clone --single-branch --branch $TUS_VERSION https://github.com/terminusdb/tus.git tus \
-        && swipl -g "pack_install('file:///app/pack/jwt_io', [interactive(false)])" \
-        && swipl -g "pack_install('file:///app/pack/tus', [interactive(false)])"
+COPY ./Makefile .
+RUN set -eux; \
+    make install-tus; \
+    make install-jwt
 
 FROM terminusdb/swipl:v8.4.2 AS rust_builder
-WORKDIR /app/rust
-COPY ./src/rust /app/rust
-RUN BUILD_DEPS="git build-essential curl clang" && apt-get update \
-	&& apt-get install -y --no-install-recommends $BUILD_DEPS \
-        ca-certificates
+RUN set -eux; \
+    BUILD_DEPS="git build-essential curl clang ca-certificates"; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ${BUILD_DEPS}; \
+    rm -rf /var/lib/apt/lists/*
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
+WORKDIR /app/rust
+COPY ./src/rust .
 RUN cargo build --release
 
 FROM terminusdb/swipl:v8.4.2
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends libjwt0 make openssl; \
+    rm -rf /var/cache/apt/*; \
+    rm -rf /var/lib/apt/lists/*
 WORKDIR /app/terminusdb
-COPY ./ /app/terminusdb
+COPY ./ .
 COPY --from=pack_installer /root/.local/share/swi-prolog/pack/ /usr/share/swi-prolog/pack
 COPY --from=rust_builder /app/rust/target/release/libterminusdb_dylib.so /app/terminusdb/src/rust/librust.so
 ARG MAKE_ARGS=""
@@ -28,10 +37,7 @@ ARG TERMINUSDB_GIT_HASH=null
 ENV TERMINUSDB_GIT_HASH=${TERMINUSDB_GIT_HASH}
 ARG TERMINUSDB_JWT_ENABLED=true
 ENV TERMINUSDB_JWT_ENABLED=${TERMINUSDB_JWT_ENABLED}
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends libjwt0 make openssl && \
-    rm -rf /var/cache/apt/* && \
-    rm -rf /var/lib/apt/lists/* && \
-    touch src/rust/librust.so && \
+RUN set -eux; \
+    touch src/rust/librust.so; \
     make $MAKE_ARGS
 CMD ["/app/terminusdb/distribution/init_docker.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/*
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
+# Update the crates.io index git repo to cache it before building.
+RUN cargo install lazy_static 2> /dev/null || true
 WORKDIR /app/rust
 COPY ./src/rust .
 RUN cargo build --release

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ TARGET=terminusdb
 # Build the binary (default).
 .PHONY: default
 default:
-	$(MAKE) -f distribution/Makefile.prolog
+	@$(MAKE) -f distribution/Makefile.prolog
 
 # Build the binary and the documentation.
 .PHONY: all
@@ -33,37 +33,37 @@ install-deps: install-tus
 # Install the tus pack.
 .PHONY: install-tus
 install-tus:
-	$(MAKE) -f distribution/Makefile.deps $@
+	@$(MAKE) -f distribution/Makefile.deps $@
 
 # Install the jwt_io pack.
 .PHONY: install-jwt
 install-jwt:
-	$(MAKE) -f distribution/Makefile.deps $@
+	@$(MAKE) -f distribution/Makefile.deps $@
 
 # Download and run the lint tool.
 .PHONY: lint
 lint:
-	$(MAKE) -f distribution/Makefile.prolog $@
+	@$(MAKE) -f distribution/Makefile.prolog $@
 
 # Build the dylib.
 .PHONY: rust
 rust:
-	$(MAKE) -f distribution/Makefile.rust
+	@$(MAKE) -f distribution/Makefile.rust
 
 # Run the unit tests in swipl.
 .PHONY: test
 test:
-	$(MAKE) -f distribution/Makefile.prolog $@
+	@$(MAKE) -f distribution/Makefile.prolog $@
 
 # Quick command for interactive
 .PHONY: i
 i:
-	$(MAKE) -f distribution/Makefile.prolog $@
+	@$(MAKE) -f distribution/Makefile.prolog $@
 
 # Remove the binary.
 .PHONY: clean
 clean:
-	$(MAKE) -f distribution/Makefile.prolog $@
+	@$(MAKE) -f distribution/Makefile.prolog $@
 
 # Remove everything.
 .PHONY: realclean
@@ -72,12 +72,12 @@ realclean: clean realclean-rust
 # Remove the dylib.
 .PHONY: clean-rust
 clean-rust:
-	$(MAKE) -f distribution/Makefile.rust clean
+	@$(MAKE) -f distribution/Makefile.rust clean
 
 # Remove the dylib and all Rust build files.
 .PHONY: realclean-rust
 realclean-rust:
-	$(MAKE) -f distribution/Makefile.rust realclean
+	@$(MAKE) -f distribution/Makefile.rust realclean
 
 # Build the documentation.
 .PHONY: docs

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,11 @@ install-tus:
 install-jwt:
 	@$(MAKE) -f distribution/Makefile.deps $@
 
+# Download the lint tool.
+.PHONY: download-lint
+download-lint:
+	@$(MAKE) -f distribution/Makefile.prolog $@
+
 # Download and run the lint tool.
 .PHONY: lint
 lint:

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ TARGET=terminusdb
 ENTERPRISE=false
 
 RUST_SOURCE_DIR := src/rust
-RUST_FILES = src/rust/Cargo.toml src/rust/Cargo.lock $(shell find src/rust/terminusdb-community/src/ -type f -name '*.rs')
-PROLOG_FILES = $(shell find ./ -not -path './rust/*' \( -name '*.pl' -o -name '*.ttl' -o -name '*.json' \))
+RUST_FILES = ""
+PROLOG_FILES = ""
 
 ifeq ($(shell uname), Darwin)
 	RUST_LIB_NAME := libterminusdb_dylib.dylib
@@ -20,8 +20,13 @@ RUST_LIBRARY_FILE:=src/rust/target/release/$(RUST_LIB_NAME)
 ENTERPRISE_RUST_LIBRARY_FILE:=terminusdb-enterprise/rust/target/release/$(RUST_LIB_NAME)
 RUST_TARGET:=src/rust/$(RUST_LIB_TARGET_NAME)
 
+TUS_VERSION=v0.0.10
+JWT_VERSION=v0.0.5
+
 SWIPL_LINT_VERSION=v0.8
 SWIPL_LINT_PATH=./tmp/pl_lint-$(SWIPL_LINT_VERSION).pl
+
+PACK_INSTALL_OPTIONS=[interactive(false), link(true), git(true)]
 
 ################################################################################
 
@@ -51,10 +56,35 @@ docker:
 	  --tag terminusdb/terminusdb-server:local \
 	  --build-arg TERMINUSDB_GIT_HASH="$(git rev-parse --verify HEAD)"
 
-# Install all pack dependencies.
+# Install minimal pack dependencies.
 .PHONY: install-deps
-install-deps:
-	$(SWIPL) -g 'Options=[interactive(false), upgrade(true), test(false)], pack_install(tus, Options), halt'
+install-deps: install-tus
+
+# Install the tus pack.
+.PHONY: install-tus
+install-tus: REPO_URL=https://github.com/terminusdb/tus.git
+install-tus: PACK_NAME=tus
+install-tus: BRANCH=$(TUS_VERSION)
+install-tus: install-pack
+
+# Install the jwt_io pack.
+.PHONY: install-jwt
+install-jwt: REPO_URL=https://github.com/terminusdb-labs/jwt_io.git
+install-jwt: PACK_NAME=jwt_io
+install-jwt: BRANCH=$(JWT_VERSION)
+install-jwt: install-pack
+
+# Install a given pack from a given git repository.
+.PHONY: install-pack
+install-pack:
+	mkdir -p .packs/$(PACK_NAME)
+	git clone --depth 1 $(REPO_URL) .packs/$(PACK_NAME) 2> /dev/null || git -C .packs/$(PACK_NAME) pull --quiet
+	(cd .packs/$(PACK_NAME); git checkout --quiet $(BRANCH))
+	$(SWIPL) \
+	  -g "pack_remove($(PACK_NAME))" \
+	  -g "pack_install('file://$(CURDIR)/.packs/$(PACK_NAME)', $(PACK_INSTALL_OPTIONS))" \
+	  -g "pack_info($(PACK_NAME))" \
+	  -g halt
 
 # Download and run the lint tool.
 .PHONY: lint
@@ -113,6 +143,7 @@ docs-clean:
 
 ################################################################################
 
+$(TARGET): PROLOG_FILES += $(shell find ./ -not -path './rust/*' \( -name '*.pl' -o -name '*.ttl' -o -name '*.json' \))
 $(TARGET): $(RUST_TARGET) $(PROLOG_FILES)
 	# Build the target and fail for errors and warnings. Ignore warnings
 	# having "qsave(strip_failed(..." that occur on macOS.
@@ -120,6 +151,7 @@ $(TARGET): $(RUST_TARGET) $(PROLOG_FILES)
 	  grep -v 'qsave(strip_failed' | \
 	  (! grep -e ERROR -e Warning)
 
+$(RUST_TARGET): RUST_FILES += src/rust/Cargo.toml src/rust/Cargo.lock $(shell find src/rust/terminusdb-community/src/ -type f -name '*.rs')
 $(RUST_TARGET): $(RUST_FILES)
 	cd $(RUST_SOURCE_DIR) && cargo build --release
 	cp $(RUST_LIBRARY_FILE) $(RUST_TARGET)

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ JWT_VERSION=v0.0.5
 SWIPL_LINT_VERSION=v0.8
 SWIPL_LINT_PATH=./tmp/pl_lint-$(SWIPL_LINT_VERSION).pl
 
-PACK_INSTALL_OPTIONS=[interactive(false), link(true), git(true)]
+PACK_INSTALL_OPTIONS=[interactive(false), git(true)]
 
 ################################################################################
 

--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,10 @@ TARGET=terminusdb
 
 ################################################################################
 
-# Build the binary (default).
+# Build the binary.
 .PHONY: default
 default:
 	@$(MAKE) -f distribution/Makefile.prolog
-
-# Build the binary and the documentation.
-.PHONY: all
-all: default docs
 
 # Build the Docker image for development and testing. To use the TerminusDB
 # container, see: https://github.com/terminusdb/terminusdb-bootstrap
@@ -87,11 +83,6 @@ realclean-rust:
 # Build the documentation.
 .PHONY: docs
 docs: $(ROFF_FILE)
-
-# Remove the documentation.
-.PHONY: docs-clean
-docs-clean:
-	rm -f $(RONN_FILE) $(ROFF_FILE)
 
 ################################################################################
 

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,6 @@ TARGET=terminusdb
 ENTERPRISE=false
 
 RUST_SOURCE_DIR := src/rust
-RUST_FILES = ""
-PROLOG_FILES = ""
 
 ifeq ($(shell uname), Darwin)
 	RUST_LIB_NAME := libterminusdb_dylib.dylib
@@ -143,16 +141,14 @@ docs-clean:
 
 ################################################################################
 
-$(TARGET): PROLOG_FILES += $(shell find ./ -not -path './rust/*' \( -name '*.pl' -o -name '*.ttl' -o -name '*.json' \))
-$(TARGET): $(RUST_TARGET) $(PROLOG_FILES)
+$(TARGET): $(RUST_TARGET) $(shell find ./ -not -path './rust/*' \( -name '*.pl' -o -name '*.ttl' -o -name '*.json' \)) $(PROLOG_FILES)
 	# Build the target and fail for errors and warnings. Ignore warnings
 	# having "qsave(strip_failed(..." that occur on macOS.
 	TERMINUSDB_ENTERPRISE=$(ENTERPRISE) $(SWIPL) -t 'main,halt.' -q -O -f src/bootstrap.pl 2>&1 | \
 	  grep -v 'qsave(strip_failed' | \
 	  (! grep -e ERROR -e Warning)
 
-$(RUST_TARGET): RUST_FILES += src/rust/Cargo.toml src/rust/Cargo.lock $(shell find src/rust/terminusdb-community/src/ -type f -name '*.rs')
-$(RUST_TARGET): $(RUST_FILES)
+$(RUST_TARGET): src/rust/Cargo.toml src/rust/Cargo.lock $(shell find src/rust/terminusdb-community/src/ -type f -name '*.rs') $(RUST_FILES)
 	cd $(RUST_SOURCE_DIR) && cargo build --release
 	cp $(RUST_LIBRARY_FILE) $(RUST_TARGET)
 

--- a/distribution/Makefile.deps
+++ b/distribution/Makefile.deps
@@ -26,13 +26,13 @@ install-jwt: install-pack
 
 .PHONY: install-pack
 install-pack:
-	mkdir -p .packs/$(PACK_NAME)
-	git clone --depth 1 $(REPO_URL) .packs/$(PACK_NAME) 2> /dev/null || git -C .packs/$(PACK_NAME) pull --quiet
-	(cd .packs/$(PACK_NAME); git checkout --quiet $(BRANCH))
+	mkdir -p .deps/$(PACK_NAME)
+	git clone --depth 1 $(REPO_URL) .deps/$(PACK_NAME) 2> /dev/null || git -C .deps/$(PACK_NAME) pull --quiet
+	(cd .deps/$(PACK_NAME); git checkout --quiet $(BRANCH))
 	$(SWIPL) \
 	  --on-error=halt \
 	  --on-warning=halt \
 	  -g "pack_remove($(PACK_NAME))" \
-	  -g "pack_install('file://$(CURDIR)/.packs/$(PACK_NAME)', $(PACK_INSTALL_OPTIONS))" \
+	  -g "pack_install('file://$(CURDIR)/.deps/$(PACK_NAME)', $(PACK_INSTALL_OPTIONS))" \
 	  -g "pack_info($(PACK_NAME))" \
 	  -g halt

--- a/distribution/Makefile.deps
+++ b/distribution/Makefile.deps
@@ -9,8 +9,8 @@ PACK_INSTALL_OPTIONS := [interactive(false), git(true)]
 
 .PHONY: default
 default:
-	$(MAKE) install-tus
-	$(MAKE) install-jwt
+	@$(MAKE) install-tus
+	@$(MAKE) install-jwt
 
 .PHONY: install-tus
 install-tus: REPO_URL=https://github.com/terminusdb/tus.git

--- a/distribution/Makefile.deps
+++ b/distribution/Makefile.deps
@@ -1,0 +1,38 @@
+TUS_VERSION := v0.0.10
+JWT_VERSION := v0.0.5
+
+SWIPL = LANG=C.UTF-8 $(SWIPL_DIR)swipl
+
+PACK_INSTALL_OPTIONS := [interactive(false), git(true)]
+
+################################################################################
+
+.PHONY: default
+default:
+	$(MAKE) install-tus
+	$(MAKE) install-jwt
+
+.PHONY: install-tus
+install-tus: REPO_URL=https://github.com/terminusdb/tus.git
+install-tus: PACK_NAME=tus
+install-tus: BRANCH=$(TUS_VERSION)
+install-tus: install-pack
+
+.PHONY: install-jwt
+install-jwt: REPO_URL=https://github.com/terminusdb-labs/jwt_io.git
+install-jwt: PACK_NAME=jwt_io
+install-jwt: BRANCH=$(JWT_VERSION)
+install-jwt: install-pack
+
+.PHONY: install-pack
+install-pack:
+	mkdir -p .packs/$(PACK_NAME)
+	git clone --depth 1 $(REPO_URL) .packs/$(PACK_NAME) 2> /dev/null || git -C .packs/$(PACK_NAME) pull --quiet
+	(cd .packs/$(PACK_NAME); git checkout --quiet $(BRANCH))
+	$(SWIPL) \
+	  --on-error=halt \
+	  --on-warning=halt \
+	  -g "pack_remove($(PACK_NAME))" \
+	  -g "pack_install('file://$(CURDIR)/.packs/$(PACK_NAME)', $(PACK_INSTALL_OPTIONS))" \
+	  -g "pack_info($(PACK_NAME))" \
+	  -g halt

--- a/distribution/Makefile.prolog
+++ b/distribution/Makefile.prolog
@@ -72,7 +72,7 @@ $(TARGET): $(shell find $(SRC_DIRS) \( -name '*.pl' -o -name '*.ttl' -o -name '*
 	  -f src/bootstrap.pl
 
 $(RUST_TARGET):
-	$(MAKE) $@
+	@$(MAKE) $@
 
 $(SWIPL_LINT_PATH):
 	curl -L --create-dirs -o $@ "https://raw.githubusercontent.com/terminusdb-labs/swipl-lint/$(SWIPL_LINT_VERSION)/pl_lint.pl"

--- a/distribution/Makefile.prolog
+++ b/distribution/Makefile.prolog
@@ -75,7 +75,7 @@ $(TARGET): $(shell find $(SRC_DIRS) \( -name '*.pl' -o -name '*.ttl' -o -name '*
 	  -f src/bootstrap.pl
 
 $(RUST_TARGET):
-	@$(MAKE) $@
+	@$(MAKE) -f distribution/Makefile.rust $@
 
 $(SWIPL_LINT_PATH):
 	curl -L --create-dirs -o $@ "https://raw.githubusercontent.com/terminusdb-labs/swipl-lint/$(SWIPL_LINT_VERSION)/pl_lint.pl"

--- a/distribution/Makefile.prolog
+++ b/distribution/Makefile.prolog
@@ -1,7 +1,7 @@
 DIST ?= community
 
 SWIPL_LINT_VERSION := v0.8
-SWIPL_LINT_PATH = ./tmp/pl_lint-$(SWIPL_LINT_VERSION).pl
+SWIPL_LINT_PATH = .deps/pl_lint-$(SWIPL_LINT_VERSION).pl
 
 COMMUNITY_SRC_DIR := src
 ENTERPRISE_SRC_DIR := terminusdb-enterprise/prolog
@@ -50,6 +50,9 @@ test: $(RUST_TARGET)
 	  --on-warning=halt \
 	  -t 'run_tests, halt' \
 	  -f src/interactive.pl
+
+.PHONY: download-lint
+download-lint: $(SWIPL_LINT_PATH)
 
 .PHONY: lint
 lint: $(SWIPL_LINT_PATH)

--- a/distribution/Makefile.prolog
+++ b/distribution/Makefile.prolog
@@ -1,0 +1,78 @@
+DIST ?= community
+
+SWIPL_LINT_VERSION := v0.8
+SWIPL_LINT_PATH = ./tmp/pl_lint-$(SWIPL_LINT_VERSION).pl
+
+COMMUNITY_SRC_DIR := src
+ENTERPRISE_SRC_DIR := terminusdb-enterprise/prolog
+
+SRC_DIRS := $(COMMUNITY_SRC_DIR)
+
+export TERMINUSDB_ENTERPRISE := false
+
+ifeq "$(DIST)" "enterprise"
+  ifeq "$(wildcard $(ENTERPRISE_SRC_DIR))" ""
+    $(error Error! Directory not found: $(CURDIR)/$(ENTERPRISE_SRC_DIR))
+  endif
+  SRC_DIRS += $(ENTERPRISE_SRC_DIR)
+  export TERMINUSDB_ENTERPRISE := true
+else ifneq "$(DIST)" "community"
+  $(error Error! Unknown $$DIST: $(DIST))
+endif
+
+ifeq "$(wildcard $(COMMUNITY_SRC_DIR))" ""
+  $(error Error! Directory not found: $(CURDIR)/$(COMMUNITY_SRC_DIR))
+endif
+
+ifeq "$(shell uname)" "Darwin"
+  DYLIB_EXT := dylib
+else
+  DYLIB_EXT := so
+endif
+
+SWIPL = LANG=C.UTF-8 $(SWIPL_DIR)swipl
+TARGET := terminusdb
+RUST_TARGET := src/rust/librust.$(DYLIB_EXT)
+
+################################################################################
+
+.PHONY: default
+default: $(TARGET)
+
+.PHONY: i
+i: $(RUST_TARGET)
+	$(SWIPL) -f src/interactive.pl
+
+.PHONY: test
+test: $(RUST_TARGET)
+	$(SWIPL) \
+	  --on-error=halt \
+	  --on-warning=halt \
+	  -t 'run_tests, halt' \
+	  -f src/interactive.pl
+
+.PHONY: lint
+lint: $(SWIPL_LINT_PATH)
+	$(SWIPL) -f src/load_paths.pl src/core/query/expansions.pl $(SWIPL_LINT_PATH)
+
+.PHONY: clean
+clean:
+	$(RM) $(TARGET)
+
+################################################################################
+
+$(TARGET): $(RUST_TARGET)
+$(TARGET): $(shell find $(SRC_DIRS) \( -name '*.pl' -o -name '*.ttl' -o -name '*.json' \))
+	$(SWIPL) \
+	  --on-error=halt \
+	  --on-warning=halt \
+	  --quiet \
+	  -O \
+	  -t 'main, halt' \
+	  -f src/bootstrap.pl
+
+$(RUST_TARGET):
+	$(MAKE) $@
+
+$(SWIPL_LINT_PATH):
+	curl -L --create-dirs -o $@ "https://raw.githubusercontent.com/terminusdb-labs/swipl-lint/$(SWIPL_LINT_VERSION)/pl_lint.pl"

--- a/distribution/Makefile.rust
+++ b/distribution/Makefile.rust
@@ -1,0 +1,51 @@
+DIST ?= community
+PROFILE ?= release
+
+COMMUNITY_SRC_DIR := src/rust
+ENTERPRISE_SRC_DIR := terminusdb-enterprise/rust
+
+ifeq "$(wildcard $(COMMUNITY_SRC_DIR))" ""
+  $(error Error! Directory not found: $(CURDIR)/$(COMMUNITY_SRC_DIR))
+endif
+
+ifeq "$(DIST)" "enterprise"
+  ifeq "$(wildcard $(ENTERPRISE_SRC_DIR))" ""
+    $(error Error! Directory not found: $(CURDIR)/$(ENTERPRISE_SRC_DIR))
+  endif
+  BUILD_DIR := $(ENTERPRISE_SRC_DIR)
+else ifeq "$(DIST)" "community"
+  BUILD_DIR := $(COMMUNITY_SRC_DIR)
+else
+  $(error Error! Unknown $$DIST: $(DIST))
+endif
+
+ifeq "$(shell uname)" "Darwin"
+  DYLIB_EXT := dylib
+else
+  DYLIB_EXT := so
+endif
+
+TARGET := $(COMMUNITY_SRC_DIR)/librust.$(DYLIB_EXT)
+CARGO_BUILD_TARGET := $(BUILD_DIR)/target/$(PROFILE)/libterminusdb_dylib.$(DYLIB_EXT)
+
+################################################################################
+
+.PHONY: default
+default: $(TARGET)
+
+.PHONY: clean
+clean:
+	$(RM) $(TARGET)
+
+.PHONY: realclean
+realclean: clean
+	cd $(COMMUNITY_SRC_DIR) && cargo clean
+	cd $(ENTERPRISE_SRC_DIR) 2> /dev/null && cargo clean || true
+
+################################################################################
+
+$(TARGET): $(CARGO_BUILD_TARGET)
+	cp $< $@
+
+$(CARGO_BUILD_TARGET): $(shell find $(COMMUNITY_SRC_DIR) $(BUILD_DIR) -type f \( -name '*.rs' -o -name 'Cargo.*' \))
+	cd $(BUILD_DIR) && cargo build --profile $(PROFILE)

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -153,11 +153,20 @@ brew install swi-prolog
 > :memo: All of the following commands assume your current working directory is
 > the top-level directory of this repository.
 
-Install the library dependencies with:
+Install the minimal library dependencies with:
 
 ```sh
 make install-deps
 ```
+
+If you are using [JSON web tokens][jwt] (JWT), install the necessary dependency
+with:
+
+```sh
+make install-jwt
+```
+
+[jwt]: https://en.wikipedia.org/wiki/JSON_Web_Token
 
 For documentation on managing packs in general, see
 [`prolog_pack.pl`][prolog_pack].

--- a/src/bootstrap.pl
+++ b/src/bootstrap.pl
@@ -27,9 +27,9 @@
 
 :- use_module(library(qsave)).
 
-% Ignore these warnings from `qsave.pl` that occur on macOS.
-% When the next SWI-Prolog is released, it should have the following, which
-% would allow us to remove this `user:message_hook`.
+% Ignore warnings from `qsave.pl` that occur on macOS. When the next
+% SWI-Prolog is released, it should have the following PR, which would allow us
+% to remove this `user:message_hook`.
 % <https://github.com/SWI-Prolog/swipl/pull/22>
 user:message_hook(qsave(strip_failed(_)), warning, _).
 

--- a/src/bootstrap.pl
+++ b/src/bootstrap.pl
@@ -27,6 +27,12 @@
 
 :- use_module(library(qsave)).
 
+% Ignore these warnings from `qsave.pl` that occur on macOS.
+% When the next SWI-Prolog is released, it should have the following, which
+% would allow us to remove this `user:message_hook`.
+% <https://github.com/SWI-Prolog/swipl/pull/22>
+user:message_hook(qsave(strip_failed(_)), warning, _).
+
 main :-
     initialize_flags,
     bootstrap_files,


### PR DESCRIPTION
* Split the `Makefile` into parts that can by copied by the `Dockerfile` for
  different stages of the build.
* Use `Makefile`s for key parts of the build in the `Dockerfile` to reduce
  duplication of the build process.
* Improve build caching in the `Dockerfile` by putting `apt-get` before `COPY`.
  - This has the effect of speeding up the Docker build significantly. Cached
    builds now take on the order of 10-15 seconds.
* Change these to allow the `Dockerfile` to support building both the community
  and enterprise distributions:
  - `make enterprise` ->
    `make DIST=enterprise`
  - `docker build . --build-arg MAKE_ARGS=enterprise` ->
    `docker build . --build-arg DIST=enterprise`
* `make install-deps` now always updates and rebuilds the packs.
  - `swipl` doesn't update if the pack directory is there.
* Fix an issue with the `Dockerfile` not building the enterprise Rust dylib.
* Closes #1195
  - Use `swipl --on-error=halt --on-warning=halt`, so that `swipl` halts with a
    non-zero exit code when the first error or warning occurs.
* Closes #873
  - Remove the `grep` usage in the `Makefile`. The next `swipl` release will not
    need these: <https://github.com/SWI-Prolog/swipl/pull/22>