### PR TITLE
Use backwards-compatible capture group

### DIFF
--- a/src/core/util/utils.pl
+++ b/src/core/util/utils.pl
@@ -432,7 +432,7 @@ sfoldr(Pred,Generator,Zero,Result) :-
  * Replaces a string with its space trimmed equivalent
  */
 trim(String,Trimmed) :-
-    re_replace('^\\s*(.*?)\\s*$','\\1', String, Trimmed).
+    re_replace('^\\s*(.*?)\\s*$','$1', String, Trimmed).
 
 /*
  * get_dict_default(Key,Dict,Value,Default)
@@ -461,7 +461,7 @@ pattern_string_split(Pattern,String,List) :-
  * escape_pcre(String,Escaped) is det.
  */
 escape_pcre(String, Escaped) :-
-    re_replace('[-[\\]{}()*+?.,\\\\^$|#\\s]'/g, '\\\\0', String, Escaped).
+    re_replace('[-[\\]{}()*+?.,\\\\^$|#\\s]'/g, '\\$0', String, Escaped).
 
 /**
  * merge_separator_split(+Merge, +Separator,-Split) is det.


### PR DESCRIPTION
The SWI-Prolog devel distribution [updated][1] the pcre package, which broke our
`escape_pcre` predicate. The [issue][2] seems to be due to a change in backslash
(`\`) escaping. We can, however, use `$0` instead of `\0` to refer to the
capture group in both the stable and devel distributions.

[1]: https://github.com/SWI-Prolog/swipl-devel/commit/4c14056c65a8d7a78703184e0f3385ea52e9d984
[2]: https://github.com/SWI-Prolog/packages-pcre/issues/24