### PR TITLE
README: fix CLI example

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ You can also install TerminusDB from the [Source Code](https://terminusdb.com/do
 A simple example creating a person with friends can be created as follows:
 
 ```shell
+./terminusdb db create admin/example1
 ./terminusdb doc insert --graph_type=schema admin/example1 <<EOF
 { "@id" : "Person",
   "@type" : "Class",
@@ -83,7 +84,7 @@ A simple example creating a person with friends can be created as follows:
   "friends" : { "@type" : "Set",
                 "@class" : "Person" }}
 EOF
-./terminusdb doc insert admin/example --message='adding Gavin' <<EOF 
+./terminusdb doc insert admin/example1 --message='adding Gavin' <<EOF
 { "@type" : "Person","name" : "Gavin", "occupation" : "Coder"}
 EOF
 ```


### PR DESCRIPTION
I noticed an error in the example:

First it adds a schema to `admin/example1` but then it inserts it in `admin/example`. This is not where the schema was created, so I changed both these examples to `admin/example`. I also added the db create command just in case people forget to create the database first.