### PR TITLE
Add proper CI support for Snap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,8 @@ jobs:
             -D LAST_RELEASED_VERSION=$LAST_RELEASED_VERSION \
             -D CURRENT_REPO_VERSION=$CURRENT_REPO_VERSION \
             docs/release-steps.md \
-            src/config/terminus_config.pl
+            src/config/terminus_config.pl \
+            distribution/snap/snapcraft.yaml
 
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v4
@@ -89,6 +90,7 @@ jobs:
           file_pattern: >-
             docs/release-steps.md
             src/config/terminus_config.pl
+            distribution/snap/snapcraft.yaml
 
   build:
     name: Build
@@ -218,6 +220,38 @@ jobs:
             -X POST \
             -H 'Accept: application/vnd.github.everest-preview+json' \
             -u rrooij:${{ secrets.PAT }} -d '{ "event_type": "Trigger from community", "client_payload": {"commit": "${{ github.sha }}" } }'
+
+  trigger_snap:
+    name: Trigger snap build
+    if: >-
+      github.repository == 'terminusdb/terminusdb' &&
+      github.event_name == 'push' &&
+      startsWith(github.ref, 'refs/tags/v')
+    needs:
+      - is_build_required
+      - all_checks_pass_with_build
+    uses: ./.github/workflows/snap.yml
+
+  release_snap:
+    name: Release the build snap
+    needs: trigger_snap
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download Snap image
+        uses: actions/download-artifact@v3
+        with:
+          name: terminusdb-snap
+          path: download_snap/
+      - name: Determine exact snap path
+        id: snap_path_step
+        run: echo "::set-output name=snap_path::$(find download_snap -name '*.snap')"
+      - uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
+        with:
+          snap: ${{ steps.snap_path_step.outputs.snap_path }}
+          release: stable
 
   trigger_docs_update:
     name: Trigger docs update

--- a/distribution/snap/snapcraft.yaml
+++ b/distribution/snap/snapcraft.yaml
@@ -1,6 +1,8 @@
 name: terminusdb
 title: TerminusDB
-version: v10.1.1
+# [[[cog import cog; cog.out(f"version: v{CURRENT_REPO_VERSION}") ]]]
+version: v10.1.2
+# [[[end]]]
 license: Apache-2.0
 summary: Document graph database
 description: |

--- a/docs/release-steps.md
+++ b/docs/release-steps.md
@@ -77,7 +77,13 @@ The current repository version is: <!--
       <!-- [[[end]]] -->
    2. Change the value for `CURRENT_REPO_VERSION` to the next planned version.
 
-7. Review the PR for correct version.
+7. (_PR_) Update the version in [`distribution/snap/snapcraft.yml`](../distribution/snap/snapcraft.yml).
+   1. Change the value for `version: ` to:
+      [[[cog cog.out(current_repo_version) ]]] -->
+      `v10.1.2`
+      <!-- [[[end]]] -->
+
+8. Review the PR for correct version.
    1. Wait for CI to pass.
    2. Approve.
    3. Merge.

--- a/docs/release-steps.md
+++ b/docs/release-steps.md
@@ -77,13 +77,7 @@ The current repository version is: <!--
       <!-- [[[end]]] -->
    2. Change the value for `CURRENT_REPO_VERSION` to the next planned version.
 
-7. (_PR_) Update the version in [`distribution/snap/snapcraft.yml`](../distribution/snap/snapcraft.yml).
-   1. Change the value for `version: ` to:
-      [[[cog cog.out(current_repo_version) ]]] -->
-      `v10.1.2`
-      <!-- [[[end]]] -->
-
-8. Review the PR for correct version.
+7. Review the PR for correct version.
    1. Wait for CI to pass.
    2. Approve.
    3. Merge.


### PR DESCRIPTION
The Snap will now be published on every release we do instead of manually.

This should make sure that every snap is released when we tag a new version. We use cog templating to change the version
number each time.

The CI works the following way:

1. We have a workflow file that builds a snap, it runs automatically each night. But is also callable from other GitHub workflows.
2. When we tag push, we call and trigger this workflow, download its artifact and publish it on snap.

Possible improvements for later:

- Instead of using cog, we can programmatically determine the version, see: https://snapcraft.io/docs/using-external-metadata#meta-scriptlet
- We could publish the nightly snap as an `edge` release instead of a stable one. This would be cool for users that to try a recent experimental non-published version.