### PR TITLE
Add configurable claim name for JWT tokens

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -154,6 +154,7 @@ jobs:
             --detach \
             --net=host \
             -e TERMINUSDB_JWT_ENABLED=true \
+            -e TERMINUSDB_JWT_AGENT_NAME_PROPERTY='http://terminusdb.com/schema/system#agent_name' \
             -e TERMINUSDB_SERVER_JWKS_ENDPOINT='https://cdn.terminusdb.com/jwks.json' \
             terminusdb/terminusdb-server:local
 

--- a/src/config/terminus_config.pl
+++ b/src/config/terminus_config.pl
@@ -111,7 +111,7 @@ jwt_jwks_endpoint(Endpoint) :-
     ;   Endpoint = Value).
 
 jwt_subject_claim_name(Name) :-
-    getenv_default('TERMINUSDB_JWT_SUBJ_CLAIM_NAME', 'http://terminusdb.com/schema/system#agent_name', Name).
+    getenv_default('TERMINUSDB_JWT_AGENT_NAME_PROPERTY', 'preferred_username', Name).
 
 registry_path(Value) :-
     once(expand_file_search_path(plugins('registry.pl'), Path)),

--- a/src/config/terminus_config.pl
+++ b/src/config/terminus_config.pl
@@ -9,6 +9,7 @@
               db_path/1,
               jwt_jwks_endpoint/1,
               jwt_enabled/0,
+              jwt_subject_claim_name/1,
               registry_path/1,
               tmp_path/1,
               server_worker_options/1,
@@ -108,6 +109,9 @@ jwt_jwks_endpoint(Endpoint) :-
     (   Value = ''
     ->  false
     ;   Endpoint = Value).
+
+jwt_subject_claim_name(Name) :-
+    getenv_default('TERMINUSDB_JWT_SUBJ_CLAIM_NAME', 'http://terminusdb.com/schema/system#agent_name', Name).
 
 registry_path(Value) :-
     once(expand_file_search_path(plugins('registry.pl'), Path)),

--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -3156,8 +3156,9 @@ fetch_jwt_data(Token, Username) :-
 
     do_or_die(
         (   atom_json_dict(Payload, PayloadDict, []),
+            jwt_subject_claim_name(ClaimName),
             % replace with dict key get (or whatever it is called)
-            get_dict('http://terminusdb.com/schema/system#agent_name', PayloadDict, UsernameString),
+            get_dict(ClaimName, PayloadDict, UsernameString),
             atom_string(Username, UsernameString)),
         error(malformed_jwt_payload(Payload))).
 :- else.


### PR DESCRIPTION
Introduce a new ENV variable called TERMINUSDB_JWT_SUBJ_CLAIM_NAME. By default it is set to the `http://terminusdb.com/schema/system#agent_name` but it can be configured by the user to mean something else as well.

This should solve: https://github.com/terminusdb/terminusdb/issues/1237