### PR TITLE
Fix snap and non-docker tests by creating subdirs as well

### DIFF
--- a/docs/terminusdb.1.ronn
+++ b/docs/terminusdb.1.ronn
@@ -775,7 +775,7 @@ List remotes.
 The designation of databases, repositories, the associated commit
 graph of a database, and various graphs as used in the above command
 requires the use of an appropriate descriptor path which is referred to
-the DB_SPEC.
+as the DB_SPEC.
 
   * `_system`:
   This is the system meta-data, which contains the user information,

--- a/src/library/terminus_store.pl
+++ b/src/library/terminus_store.pl
@@ -694,7 +694,7 @@ clean(TestDir) :-
 createng(TestDir) :-
     random_string(RandomString),
     atomic_list_concat(["storage/testdir", RandomString], TestDir),
-    make_directory(TestDir),
+    make_directory_path(TestDir),
     open_directory_store(TestDir, X),
     create_named_graph(X, "sometestdb", _).
 
@@ -715,7 +715,7 @@ test(open_directory_store_atom_exception, [
     open_directory_store(234, _).
 
 test(create_db, [cleanup(clean(TestDir))]) :-
-    make_directory("storage/testdir"),
+    make_directory_path("storage/testdir"),
     TestDir = 'storage/testdir',
     open_directory_store("storage/testdir", X),
     create_named_graph(X, "sometestdb", _).

--- a/src/library/terminus_store.pl
+++ b/src/library/terminus_store.pl
@@ -693,7 +693,7 @@ clean(TestDir) :-
 
 createng(TestDir) :-
     random_string(RandomString),
-    atomic_list_concat(["storage/testdir", RandomString], TestDir),
+    atomic_list_concat(["/tmp/testdir", RandomString], TestDir),
     make_directory_path(TestDir),
     open_directory_store(TestDir, X),
     create_named_graph(X, "sometestdb", _).
@@ -715,9 +715,9 @@ test(open_directory_store_atom_exception, [
     open_directory_store(234, _).
 
 test(create_db, [cleanup(clean(TestDir))]) :-
-    make_directory_path("storage/testdir"),
+    make_directory_path("/tmp/testdir"),
     TestDir = 'storage/testdir',
-    open_directory_store("storage/testdir", X),
+    open_directory_store("/tmp/testdir", X),
     create_named_graph(X, "sometestdb", _).
 
 

--- a/src/library/terminus_store.pl
+++ b/src/library/terminus_store.pl
@@ -716,7 +716,7 @@ test(open_directory_store_atom_exception, [
 
 test(create_db, [cleanup(clean(TestDir))]) :-
     make_directory_path("/tmp/testdir"),
-    TestDir = 'storage/testdir',
+    TestDir = '/tmp/testdir',
     open_directory_store("/tmp/testdir", X),
     create_named_graph(X, "sometestdb", _).
 


### PR DESCRIPTION
The build fails otherwise. This change is needed because make_directory does not make subdirs. The storage directory is not always there already when running the tests.