### PR TITLE
Revert "Dockerfile security enhancements (#1250)"

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -189,7 +189,7 @@ jobs:
         with:
           name: terminusdb-server-docker-image
 
-      - run: make download-lint && chmod -R 777 .deps
+      - run: make download-lint
 
       - name: Run lint
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,9 +74,4 @@ RUN set -eux; \
 
 # Build the ${DIST} executable. Set the default command.
 FROM base_${DIST}
-RUN groupadd -r -g 999 terminusdb && \
-    useradd -r -g terminusdb -u 999 terminusdb && \
-    mkdir storage && \
-    chown terminusdb:terminusdb storage
-USER terminusdb
 CMD ["/app/terminusdb/distribution/init_docker.sh"]

--- a/src/library/terminus_store.pl
+++ b/src/library/terminus_store.pl
@@ -693,7 +693,7 @@ clean(TestDir) :-
 
 createng(TestDir) :-
     random_string(RandomString),
-    atomic_list_concat(["storage/testdir", RandomString], TestDir),
+    atomic_list_concat(["testdir", RandomString], TestDir),
     make_directory(TestDir),
     open_directory_store(TestDir, X),
     create_named_graph(X, "sometestdb", _).
@@ -715,9 +715,9 @@ test(open_directory_store_atom_exception, [
     open_directory_store(234, _).
 
 test(create_db, [cleanup(clean(TestDir))]) :-
-    make_directory("storage/testdir"),
-    TestDir = 'storage/testdir',
-    open_directory_store("storage/testdir", X),
+    make_directory("testdir"),
+    TestDir = 'testdir',
+    open_directory_store("testdir", X),
     create_named_graph(X, "sometestdb", _).
 
 


### PR DESCRIPTION
This reverts commit 2abaea776f6d4d4beb3f081270b8aa09e8bdbf2d. We should have a better upgrade path to fix ownership issues with existing storage first.
