### PR TITLE
Allow branches to be diffed directly, and small bugfix in uniqueness

### DIFF
--- a/docs/terminusdb.1.ronn
+++ b/docs/terminusdb.1.ronn
@@ -267,10 +267,10 @@ or two commits (path required).
   document id to use for comparisons
 
   * `-p`, `--before_commit`, `--before-commit`=[value]:
-  Commit of the *before* document(s)
+  Commit or branch of the *before* document(s)
 
   * `-s`, `--after_commit`, `--after-commit`=[value]:
-  Commit of the *after* document(s)
+  Commit or branch of the *after* document(s)
 
 ### apply
 

--- a/src/cli/main.pl
+++ b/src/cli/main.pl
@@ -422,13 +422,13 @@ or two commits (path required).',
            longflags([before_commit,'before-commit']),
            shortflags([p]),
            default('_'),
-           help('Commit of the *before* document(s)')],
+           help('Commit or branch of the *before* document(s)')],
           [opt(after_commit),
            type(atom),
            longflags([after_commit,'after-commit']),
            shortflags([s]),
            default('_'),
-           help('Commit of the *after* document(s)')]
+           help('Commit or branch of the *after* document(s)')]
          ]).
 opt_spec(apply,'terminusdb apply [Path] OPTIONS',
          'Apply a diff to path which is obtained from the differences between two commits',

--- a/tests/test/capabilities.js
+++ b/tests/test/capabilities.js
@@ -111,7 +111,7 @@ describe('capabilities', function () {
       })
 
     const userPass = Buffer.from(`${userName}:${userName}`).toString('base64')
-    const userAgent = new Agent({ orgName: orgName }).auth()
+    const userAgent = new Agent({ orgName }).auth()
     userAgent.set('Authorization', `Basic ${userPass}`)
     const bodyString = '{"label":"hello"}'
     await db.create(userAgent, { bodyString })

--- a/tests/test/cli-diff.js
+++ b/tests/test/cli-diff.js
@@ -43,4 +43,13 @@ describe('cli-diff', function () {
     expect(parsedJson[0]['@op']).to.equal('Delete')
     expect(parsedJson[0]['@delete'].name).to.equal('test')
   })
+
+  it('compares two branches with no differences using CLI', async function () {
+    const db = util.randomString()
+    await exec(`./terminusdb.sh db create admin/${db}`)
+    await exec(`./terminusdb.sh branch create admin/${db}/local/branch/test --origin=admin/${db}/local/branch/main`)
+    const r1 = await exec(`./terminusdb.sh diff admin/${db} --before-commit=main --after-commit=test`)
+    const parsedJson = JSON.parse(r1.stdout)
+    expect(parsedJson).to.have.lengthOf(0)
+  })
 })

--- a/tests/test/cli-diff.js
+++ b/tests/test/cli-diff.js
@@ -26,21 +26,21 @@ describe('cli-diff', function () {
     const r1 = await exec(`./terminusdb.sh diff admin/${db} --before-commit=main --after-commit=test`)
     const parsedJson = JSON.parse(r1.stdout)
     expect(parsedJson).to.have.lengthOf(1)
-    expect(parsedJson[0]["@op"]).to.equal("Insert")
-    expect(parsedJson[0]["@insert"]['name']).to.equal("test")
+    expect(parsedJson[0]['@op']).to.equal('Insert')
+    expect(parsedJson[0]['@insert'].name).to.equal('test')
   })
 
   it('compares two branches with removing a raw JSON document using CLI', async function () {
     const db = util.randomString()
     await exec(`./terminusdb.sh db create admin/${db}`)
     const r1 = await exec(`./terminusdb.sh doc insert -j admin/${db}/local/branch/main -d '{ "name": "test" }'`)
-    const documentId = r1.stdout.split("1: ")[1]
+    const documentId = r1.stdout.split('1: ')[1]
     await exec(`./terminusdb.sh branch create admin/${db}/local/branch/test --origin=admin/${db}/local/branch/main`)
     await exec(`./terminusdb.sh doc delete admin/${db}/local/branch/test --id=${documentId}`)
     const r2 = await exec(`./terminusdb.sh diff admin/${db} --before-commit=main --after-commit=test`)
     const parsedJson = JSON.parse(r2.stdout)
     expect(parsedJson).to.have.lengthOf(1)
-    expect(parsedJson[0]["@op"]).to.equal("Delete")
-    expect(parsedJson[0]["@delete"]['name']).to.equal("test")
+    expect(parsedJson[0]['@op']).to.equal('Delete')
+    expect(parsedJson[0]['@delete'].name).to.equal('test')
   })
 })

--- a/tests/test/cli-diff.js
+++ b/tests/test/cli-diff.js
@@ -1,0 +1,46 @@
+const fs = require('fs/promises')
+const exec = require('util').promisify(require('child_process').exec)
+const { expect } = require('chai')
+const { util } = require('../lib')
+
+describe('cli-diff', function () {
+  before(async function () {
+    this.timeout(30000)
+    process.env.TERMINUSDB_SERVER_DB_PATH = './storage/' + util.randomString()
+    {
+      const r = await exec('./terminusdb.sh store init --force')
+      expect(r.stdout).to.match(/^Successfully initialised database/)
+    }
+  })
+
+  after(async function () {
+    await fs.rm(process.env.TERMINUSDB_SERVER_DB_PATH, { recursive: true })
+    delete process.env.TERMINUSDB_SERVER_DB_PATH
+  })
+
+  it('compares two branches with added raw JSON document using CLI', async function () {
+    const db = util.randomString()
+    await exec(`./terminusdb.sh db create admin/${db}`)
+    await exec(`./terminusdb.sh branch create admin/${db}/local/branch/test --origin=admin/${db}/local/branch/main`)
+    await exec(`./terminusdb.sh doc insert -j admin/${db}/local/branch/test -d '{ "name": "test" }'`)
+    const r1 = await exec(`./terminusdb.sh diff admin/${db} --before-commit=main --after-commit=test`)
+    const parsedJson = JSON.parse(r1.stdout)
+    expect(parsedJson).to.have.lengthOf(1)
+    expect(parsedJson[0]["@op"]).to.equal("Insert")
+    expect(parsedJson[0]["@insert"]['name']).to.equal("test")
+  })
+
+  it('compares two branches with removing a raw JSON document using CLI', async function () {
+    const db = util.randomString()
+    await exec(`./terminusdb.sh db create admin/${db}`)
+    const r1 = await exec(`./terminusdb.sh doc insert -j admin/${db}/local/branch/main -d '{ "name": "test" }'`)
+    const documentId = r1.stdout.split("1: ")[1]
+    await exec(`./terminusdb.sh branch create admin/${db}/local/branch/test --origin=admin/${db}/local/branch/main`)
+    await exec(`./terminusdb.sh doc delete admin/${db}/local/branch/test --id=${documentId}`)
+    const r2 = await exec(`./terminusdb.sh diff admin/${db} --before-commit=main --after-commit=test`)
+    const parsedJson = JSON.parse(r2.stdout)
+    expect(parsedJson).to.have.lengthOf(1)
+    expect(parsedJson[0]["@op"]).to.equal("Delete")
+    expect(parsedJson[0]["@delete"]['name']).to.equal("test")
+  })
+})


### PR DESCRIPTION
There was a small bug where a full removal of a document didn't properly bind the ID for that deletion.

Also, it should now be possible to directly specify a branch to diff, instead of a commit id.