### PR TITLE
Casting should allow sys:Top, and use prefixes to expand.

### DIFF
--- a/src/core/query/woql_compile.pl
+++ b/src/core/query/woql_compile.pl
@@ -1412,7 +1412,8 @@ compile_wf(get(Spec,resource(Resource,Format,Options),Has_Header), Prog) -->
             throw(error(M)))
     }.
 compile_wf(typecast(Val,Type,_Hints,Cast),
-           (typecast(ValE, TypeE, [], CastE))) -->
+           (   typecast(ValE, TypeE, [prefixes(Prefixes)], CastE))) -->
+    view(prefixes,Prefixes),
     resolve(Val,ValE),
     resolve(Type,TypeE),
     resolve(Cast,CastE).


### PR DESCRIPTION
Fix bug in casting of URIs, add `sys:Top` as a cast for strings to URIs.