### PR TITLE
Fix JS lint order

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -99,7 +99,6 @@ jobs:
           TERMINUSDB_DOCKER_IMAGE_TAG: terminusdb/terminusdb-server:local
         run: |
           npm install-ci-test
-          npm run check
 
   integration_tests_header:
     name: Integration tests (header)

--- a/tests/package.json
+++ b/tests/package.json
@@ -14,7 +14,7 @@
     "check": "eslint --ext .js,.json .",
     "lint": "eslint --ext .js,.json --fix .",
     "start-server": "http-server ./served -c-1 --port 7474",
-    "test": "npm run test-local && npm run test-served",
+    "test": "npm run check && npm run test-local && npm run test-served",
     "test-local": "mocha test",
     "test-served": "start-server-and-test start-server http://127.0.0.1:7474/ 'mocha test-served'"
   },


### PR DESCRIPTION
Lint JS first and not after the tests. This saves a lot of time, since sometimes you are waiting for tests to pass and then suddenly see the linting fail.
