### PR TITLE
openapi: remove trailing slash in db endpoint

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -89,7 +89,7 @@ paths:
       responses:
         200:
           description: Succeeded
-  /db/:
+  /db:
     get:
       tags:
         - Database


### PR DESCRIPTION
The trailing slash is not how the api should be called.