### PR TITLE
Fix validation

### DIFF
--- a/src/core/document/validation.pl
+++ b/src/core/document/validation.pl
@@ -70,6 +70,7 @@ only_needs_referential_integrity_validation(Validation_Object) :-
         instance_objects : Instance_Objects
     } :< Validation_Object,
     Schema_Objects \= [],
+    exists(validation_object_changed, Instance_Objects),
     \+ exists(validation_triple_update, Instance_Objects),
     \+ is_schemaless(Validation_Object).
 


### PR DESCRIPTION
Insufficiently strict about blast radius! This includes queries which change *nothing* which is a disaster since the prior layer is then rechecked on every search.