### PR TITLE
Marshall lits

### DIFF
--- a/src/core/triple/literals.pl
+++ b/src/core/triple/literals.pl
@@ -333,7 +333,7 @@ turtle_to_literal(literal(type(Type,A)),Val^^Type) :-
     atom_string(A,S),
     typecast(S^^'http://www.w3.org/2001/XMLSchema#string', Type, [], Val^^_),
     !.
-turtle_to_literal(literal(L),String@en) :-
+turtle_to_literal(literal(L),String^^xsd:string) :-
     (   atom(L)
     ->  atom_string(L,String)
     ;   L = String).

--- a/src/core/triple/literals.pl
+++ b/src/core/triple/literals.pl
@@ -333,7 +333,7 @@ turtle_to_literal(literal(type(Type,A)),Val^^Type) :-
     atom_string(A,S),
     typecast(S^^'http://www.w3.org/2001/XMLSchema#string', Type, [], Val^^_),
     !.
-turtle_to_literal(literal(L),String^^xsd:string) :-
+turtle_to_literal(literal(L),String^^'http://www.w3.org/2001/XMLSchema#string') :-
     (   atom(L)
     ->  atom_string(L,String)
     ;   L = String).

--- a/tests/lib/api/response.js
+++ b/tests/lib/api/response.js
@@ -360,6 +360,13 @@ module.exports = {
         'api:status': 'api:success',
       },
     },
+    updateSuccess: {
+      status: 200,
+      body: {
+        '@type': 'api:TriplesUpdateResponse',
+        'api:status': 'api:success',
+      },
+    },
     failure (errorObject) {
       const result = {
         status: 400,

--- a/tests/lib/triples.js
+++ b/tests/lib/triples.js
@@ -44,7 +44,6 @@ function insert (agent, path, turtle, params) {
   params = new Params(params)
   const author = params.string('author', 'default_author')
   const message = params.string('message', 'default_message')
-  params.assertEmpty()
 
   assert(
     util.isString(turtle),
@@ -68,8 +67,39 @@ function insert (agent, path, turtle, params) {
   }
 }
 
+function replace (agent, path, turtle, params) {
+  params = new Params(params)
+  const author = params.string('author', 'default_author')
+  const message = params.string('message', 'default_message')
+
+  assert(
+    util.isString(turtle),
+    `Unexpected type for 'turtle'. Expected string, got: ${util.typeString(turtle)}`,
+  )
+
+  const body = { commit_info: { author, message }, turtle }
+
+  const request = agent.post(path).send(body)
+
+  return {
+    then (resolve) {
+      resolve(request.then(api.response.verify(api.response.triples.insertSuccess)))
+    },
+    fails (error) {
+      return request.then(api.response.verify(api.response.triples.failure(error)))
+    },
+    unverified () {
+      return request
+    },
+  }
+}
+
 function insertIntoBranch (agent, turtle, params) {
   return insert(agent, api.path.triplesBranch(agent, params), turtle, params)
+}
+
+function replaceIntoBranch (agent, turtle, params) {
+  return replace(agent, api.path.triplesBranch(agent, params), turtle, params)
 }
 
 module.exports = {
@@ -77,5 +107,6 @@ module.exports = {
   getFromBranch,
   getFromSystem,
   insert,
+  replaceIntoBranch,
   insertIntoBranch,
 }

--- a/tests/lib/triples.js
+++ b/tests/lib/triples.js
@@ -83,7 +83,7 @@ function replace (agent, path, turtle, params) {
 
   return {
     then (resolve) {
-      resolve(request.then(api.response.verify(api.response.triples.insertSuccess)))
+      resolve(request.then(api.response.verify(api.response.triples.updateSuccess)))
     },
     fails (error) {
       return request.then(api.response.verify(api.response.triples.failure(error)))

--- a/tests/test/triples.js
+++ b/tests/test/triples.js
@@ -42,7 +42,7 @@ describe('triples', function () {
     await db.delete(agent)
   })
 
-  it('passes insert with string literals', async function () {
+  it('passes replace schema with string literals', async function () {
     // Create a database
     await db.create(agent)
     // Put the first triple
@@ -69,8 +69,7 @@ describe('triples', function () {
       sys:base "terminusdb:///data/" ;
       sys:schema "terminusdb:///schema#" .
     `
-    const r = await triples.replaceIntoBranch(agent, turtle, { graph: 'schema' })
-    console.log(r.body)
+    await triples.replaceIntoBranch(agent, turtle, { graph: 'schema' })
     // Delete the database
     await db.delete(agent)
   })

--- a/tests/test/triples.js
+++ b/tests/test/triples.js
@@ -42,6 +42,39 @@ describe('triples', function () {
     await db.delete(agent)
   })
 
+  it('passes insert with string literals', async function () {
+    // Create a database
+    await db.create(agent)
+    // Put the first triple
+    const turtle = `
+
+    @base <terminusdb:///schema#> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix woql: <http://terminusdb.com/schema/woql#> .
+    @prefix json: <http://terminusdb.com/schema/json#> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+    @prefix xdd: <http://terminusdb.com/schema/xdd#> .
+    @prefix vio: <http://terminusdb.com/schema/vio#> .
+    @prefix sys: <http://terminusdb.com/schema/sys#> .
+    @prefix api: <http://terminusdb.com/schema/api#> .
+    @prefix owl: <http://www.w3.org/2002/07/owl#> .
+    @prefix doc: <data/> .
+
+    <schema#Philosopher>
+      a sys:Class ;
+      <schema#name> xsd:string .
+    <terminusdb://context>
+      a sys:Context ;
+      sys:base "terminusdb:///data/" ;
+      sys:schema "terminusdb:///schema#" .
+    `
+    const r = await triples.replaceIntoBranch(agent, turtle, { graph: 'schema' })
+    console.log(r.body)
+    // Delete the database
+    await db.delete(agent)
+  })
+
   it('passes insert with trig', async function () {
     // Create a database
     await db.create(agent, { schema: false })


### PR DESCRIPTION
Fixes the triples marshalling. Previously, string literals we marshalled as "string"@en instead of "string"^^xsd:string.
