### PR TITLE
Allow turtle to be returned from triples endpoint

### DIFF
--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -378,7 +378,11 @@ triples_handler(get,Path,Request, System_DB, Auth) :-
     ->  atom_string(Format_Atom,Format)
     ;   Format = "turtle"
     ),
-    memberchk(accept(Accepted), Request),
+
+    (   memberchk(accept(Accepted), Request)
+    ->  true
+    ;   Accepted = []),
+
     api_report_errors(
         triples,
         Request,

--- a/tests/test/triples.js
+++ b/tests/test/triples.js
@@ -112,7 +112,8 @@ describe('triples', function () {
   // TODO: Create test for this, it responds with an application/json type now... which it isn't.
   // See issue: https://github.com/terminusdb/terminusdb/issues/981
   it('responds with a turtle mimetype', async function () {
-    this.skip()
+    const response = await agent.get(api.path.triplesSystem()).set('Accept', 'text/turtle')
+    expect(response.headers['content-type']).to.equal('text/turtle; charset=UTF-8')
   })
 
   it('responds with proper status code on anonymous request', async function () {


### PR DESCRIPTION
If the accept header has "text/turtle" it will now return a turtle string instead of a turtle string as JSON.