### PR TITLE
match prefixes that further colons are part of the suffix

### DIFF
--- a/src/core/query/jsonld.pl
+++ b/src/core/query/jsonld.pl
@@ -207,10 +207,10 @@ prefix_expand(K,Context,Key) :-
     (   uri_has_protocol(K)
     ->  K = Key
     %   Is prefixed
-    ;   re_match('^[^:]*:[^:]*',K) % uri_has_prefix(K)
-    ->  split_atom(K,':',[Prefix,Suffix]),
+    ;   re_matchsub('(?<prefix>^[^:]*):(?<suffix>.*)',K, Groups, []) % uri_has_prefix(K)
+    ->  atom_string(Prefix, Groups.prefix),
         (   get_dict(Prefix,Context,Expanded)
-        ->  atom_concat(Expanded,Suffix,Key)
+        ->  atom_concat(Expanded,(Groups.suffix),Key)
         ;   throw(error(key_has_unknown_prefix(K), _)))
     ;   is_at(K)
     ->  K = Key
@@ -288,6 +288,15 @@ test(expand_path, [])
     Result = (JSON_LD.'@context'),
 
     json{ '@base':'terminusdb:///system/data/'} :< Result.
+
+test(expand_prefix_with_colon, []) :-
+    Prefixes = _{'@base': "terminusdb:///data/",
+                 '@schema': "terminusdb:///schema#",
+                 'a': "http://example.org/a/"},
+
+    prefix_expand("@base:foo:bar", Prefixes, 'terminusdb:///data/foo:bar'),
+    prefix_expand("@schema:foo:bar", Prefixes, 'terminusdb:///schema#foo:bar'),
+    prefix_expand("a:foo:bar", Prefixes, 'http://example.org/a/foo:bar').
 
 :- end_tests(jsonld_expand).
 


### PR DESCRIPTION
As discussed in #1418 there is a bug in prefix matching where trying to insert an id like `@base:Foo/a:b` doesn't work. Our prefix expander expects only a single colon to appear in the id. However, it is actually allowed to have colons in the actual URI as well.

This change changes the prefix matching so that everything up to the first colon is considered the prefix, and everything after (including subsequent colon characters) is considered the suffix. 