### PR TITLE
Error when retrieving log on something with no history

### DIFF
--- a/src/core/api/api_error.pl
+++ b/src/core/api/api_error.pl
@@ -1380,6 +1380,15 @@ api_error_jsonld_(delete_documents, Error, JSON) :-
     api_document_error_jsonld(delete_documents, Error, JSON).
 api_error_jsonld_(diff, Error, JSON) :-
     api_document_error_jsonld(diff, Error, JSON).
+api_error_jsonld_(log, error(resource_has_no_history(Descriptor), _), JSON) :-
+    resolve_absolute_string_descriptor(Path, Descriptor),
+    format(string(Msg), "Resource has no history, so log unavailable: ~s", [Path]),
+    JSON = _{'@type' : 'api:LogErrorResponse',
+             'api:status' : "api:failure",
+             'api:message' : Msg,
+             'api:error' : _{ '@type' : "api:ResourceHasNoHistory",
+                              'api:absolute_descriptor' : Path}
+            }.
 
 error_type(API, Type) :-
     do_or_die(

--- a/src/core/api/api_log.pl
+++ b/src/core/api/api_log.pl
@@ -14,24 +14,33 @@ descriptor_has_history(Descriptor) :-
     Type{} :< Descriptor,
     descriptor_type_has_history(Type).
 
+loggable_commit_uri(Descriptor, Repository_Descriptor, Commit_Uri) :-
+    branch_descriptor{repository_descriptor: Repository_Descriptor,
+                      branch_name: Branch_Name} :< Descriptor,
+    !,
+    branch_head_commit(Repository_Descriptor,
+                       Branch_Name,
+                       Commit_Uri).
+loggable_commit_uri(Descriptor, Repository_Descriptor, Commit_Uri) :-
+    commit_descriptor{commit_id: Commit_Id,
+                      repository_descriptor: Repository_Descriptor} :< Descriptor,
+    commit_id_uri(Repository_Descriptor, Commit_Id, Commit_Uri).
+
 api_log(System_DB, Auth, Path, Log, Options) :-
     do_or_die(
-        resolve_absolute_string_descriptor(Path,Branch_Descriptor),
+        resolve_absolute_string_descriptor(Path,Descriptor),
         error(invalid_absolute_path(Path),_)),
 
-    do_or_die(descriptor_has_history(Branch_Descriptor),
-              error(resource_has_no_history(Branch_Descriptor), _)),
+    do_or_die(descriptor_has_history(Descriptor),
+              error(resource_has_no_history(Descriptor), _)),
 
-    check_descriptor_auth(System_DB, Branch_Descriptor, '@schema':'Action/meta_read_access', Auth),
+    check_descriptor_auth(System_DB, Descriptor, '@schema':'Action/meta_read_access', Auth),
 
     do_or_die(
-        open_descriptor(Branch_Descriptor, _Branch_Transaction),
-        error(unresolvable_absolute_descriptor(Branch_Descriptor),_)),
+        open_descriptor(Descriptor, _Branch_Transaction),
+        error(unresolvable_absolute_descriptor(Descriptor),_)),
 
-    Repository_Descriptor = (Branch_Descriptor.repository_descriptor),
-    branch_head_commit(Repository_Descriptor,
-                       (Branch_Descriptor.branch_name),
-                       Commit_Uri),
+    loggable_commit_uri(Descriptor, Repository_Descriptor, Commit_Uri),
 
     commit_uri_to_history_commit_uris(Repository_Descriptor, Commit_Uri, History_Commit_Uris, Options),
 

--- a/src/core/api/api_log.pl
+++ b/src/core/api/api_log.pl
@@ -7,10 +7,20 @@
 :- use_module(core(transaction)).
 :- use_module(library(lists)).
 
+descriptor_type_has_history(branch_descriptor).
+descriptor_type_has_history(commit_descriptor).
+
+descriptor_has_history(Descriptor) :-
+    Type{} :< Descriptor,
+    descriptor_type_has_history(Type).
+
 api_log(System_DB, Auth, Path, Log, Options) :-
     do_or_die(
         resolve_absolute_string_descriptor(Path,Branch_Descriptor),
         error(invalid_absolute_path(Path),_)),
+
+    do_or_die(descriptor_has_history(Branch_Descriptor),
+              error(resource_has_no_history(Branch_Descriptor), _)),
 
     check_descriptor_auth(System_DB, Branch_Descriptor, '@schema':'Action/meta_read_access', Auth),
 

--- a/tests/test/log.js
+++ b/tests/test/log.js
@@ -60,4 +60,25 @@ describe('log', function () {
     // cleanup
     await agent.delete('/api/db/admin/hello')
   })
+
+  it('gets an error from _system', async function () {
+    const response = await agent.get('/api/log/_system').unverified()
+
+    expect(response.status).to.equal(400)
+    expect(result.body['api:error']['@type']).to.equal('api:ResourceHasNoHistory')
+  })
+
+  it('gets an error from somedb/_meta', async function () {
+    const response = await agent.get('/api/log/somedb/_meta').unverified()
+
+    expect(response.status).to.equal(400)
+    expect(result.body['api:error']['@type']).to.equal('api:ResourceHasNoHistory')
+  })
+
+  it('gets an error from somedb/local/_commits', async function () {
+    const response = await agent.get('/api/log/somedb/local/_commits').unverified()
+
+    expect(response.status).to.equal(400)
+    expect(result.body['api:error']['@type']).to.equal('api:ResourceHasNoHistory')
+  })
 })

--- a/tests/test/log.js
+++ b/tests/test/log.js
@@ -35,6 +35,33 @@ describe('log', function () {
     await agent.delete('/api/db/admin/hello')
   })
 
+  it('gets a log from changes by commit', async function () {
+    await agent.post('/api/db/admin/hello').send({ label: 'Hello' })
+
+    const id = util.randomString()
+    const schema = { '@type': 'Class', '@id': id }
+    await document.insert(agent, { schema })
+    const instance1 = { '@type': id, '@id': `terminusdb:///data/${id}/0` }
+    const result1 = await document.insert(agent, { instance: instance1 })
+
+    const version1 = result1.headers['terminusdb-data-version'].split('branch:')[1]
+    const instance2 = { '@type': id, '@id': `terminusdb:///data/${id}/1` }
+
+    const result2 = await document.insert(agent, { instance: instance2 })
+    const version2 = result2.headers['terminusdb-data-version'].split('branch:')[1]
+
+    const logRequest = await agent.get(`/api/log/admin/hello/local/commit/${version2}`)
+    const log = logRequest.body
+
+    expect(log).to.have.lengthOf(3)
+    expect(log[0].author).to.equal('default_author')
+    expect(log[0].identifier).to.equal(version2)
+    expect(log[1].identifier).to.equal(version1)
+
+    // cleanup
+    await agent.delete('/api/db/admin/hello')
+  })
+
   it('gets a log with count', async function () {
     await agent.post('/api/db/admin/hello').send({ label: 'Hello' })
 
@@ -62,23 +89,23 @@ describe('log', function () {
   })
 
   it('gets an error from _system', async function () {
-    const response = await agent.get('/api/log/_system').unverified()
+    const response = await agent.get('/api/log/_system')
 
     expect(response.status).to.equal(400)
-    expect(result.body['api:error']['@type']).to.equal('api:ResourceHasNoHistory')
+    expect(response.body['api:error']['@type']).to.equal('api:ResourceHasNoHistory')
   })
 
   it('gets an error from somedb/_meta', async function () {
-    const response = await agent.get('/api/log/somedb/_meta').unverified()
+    const response = await agent.get('/api/log/someorg/somedb/_meta')
 
     expect(response.status).to.equal(400)
-    expect(result.body['api:error']['@type']).to.equal('api:ResourceHasNoHistory')
+    expect(response.body['api:error']['@type']).to.equal('api:ResourceHasNoHistory')
   })
 
   it('gets an error from somedb/local/_commits', async function () {
-    const response = await agent.get('/api/log/somedb/local/_commits').unverified()
+    const response = await agent.get('/api/log/someorg/somedb/local/_commits')
 
     expect(response.status).to.equal(400)
-    expect(result.body['api:error']['@type']).to.equal('api:ResourceHasNoHistory')
+    expect(response.body['api:error']['@type']).to.equal('api:ResourceHasNoHistory')
   })
 })


### PR DESCRIPTION
This ensures that we only attempt to build a log from things that actually have logs (branch and commit descriptors).