### PR TITLE
Fix captures in full replace

### DIFF
--- a/src/core/document/json.pl
+++ b/src/core/document/json.pl
@@ -2892,7 +2892,7 @@ insert_document_unsafe(Transaction, Prefixes, Document, true, Captures, Id, Capt
     ;   insert_json_object(Transaction, Document, Id)
     ).
 insert_document_unsafe(Transaction, Prefixes, Document, false, Captures_In, Id, Captures_Out) :-
-    json_elaborate(Transaction, Document, Prefixes, Captures_In, Elaborated, _Dependencies, Captures_Out),
+    json_elaborate(Transaction, Document, Prefixes, Captures_In, Elaborated, Dependencies, Captures_Out),
     % Are we trying to insert a subdocument?
     do_or_die(
         get_dict('@type', Elaborated, Type),
@@ -2904,7 +2904,8 @@ insert_document_unsafe(Transaction, Prefixes, Document, false, Captures_In, Id, 
     do_or_die(
         get_dict('@id', Elaborated, Id),
         error(missing_field('@id', Elaborated), _)),
-    insert_document_expanded(Transaction, Elaborated, Id).
+    when(ground(Dependencies),
+         insert_document_expanded(Transaction, Elaborated, Id)).
 
 insert_document_expanded(Transaction, Elaborated, ID) :-
     get_dict('@id', Elaborated, ID),

--- a/tests/test/document-full-replace.js
+++ b/tests/test/document-full-replace.js
@@ -4,12 +4,12 @@ const { Agent, api, db, document, util } = require('../lib')
 describe('document-full-replace', function () {
   let agent
 
-  before(async function () {
+  beforeEach(async function () {
     agent = new Agent().auth()
     await db.create(agent)
   })
 
-  after(async function () {
+  afterEach(async function () {
     await db.delete(agent)
   })
 

--- a/tests/test/document-full-replace.js
+++ b/tests/test/document-full-replace.js
@@ -40,6 +40,29 @@ describe('document-full-replace', function () {
     await document.insert(agent, option)
   })
 
+    it('handles captures correctly in a full instance replace', async function() {
+        let classId = util.randomString()
+        const schema = { '@type': 'Class', '@id': classId, 'other': classId }
+        await document.insert(agent, { schema })
+        const option = {
+            instance: [
+                { '@type': schema['@id'], '@capture': 'Ref_A', 'other': {'@ref': 'Ref_B'} },
+                { '@type': schema['@id'], '@capture': 'Ref_B', 'other': {'@ref': 'Ref_A'} },
+            ],
+            fullReplace: true,
+        }
+        await document.insert(agent, option)
+
+        let result = await document.get(agent, {query: {as_list: true}})
+        let documents = result.body
+        let id1 = documents[0]['@id']
+        let id2 = documents[1]['@id']
+        let other1 = documents[0]['other']
+        let other2 = documents[1]['other']
+        expect(id1).to.equal(other2)
+        expect(id2).to.equal(other1)
+    })
+
   describe('fails insert schema with duplicate @id (#1063)', function () {
     for (const fullReplace of [false, true]) {
       it(`full_replace=${fullReplace}`, async function () {

--- a/tests/test/document-full-replace.js
+++ b/tests/test/document-full-replace.js
@@ -40,28 +40,28 @@ describe('document-full-replace', function () {
     await document.insert(agent, option)
   })
 
-    it('handles captures correctly in a full instance replace', async function() {
-        let classId = util.randomString()
-        const schema = { '@type': 'Class', '@id': classId, 'other': classId }
-        await document.insert(agent, { schema })
-        const option = {
-            instance: [
-                { '@type': schema['@id'], '@capture': 'Ref_A', 'other': {'@ref': 'Ref_B'} },
-                { '@type': schema['@id'], '@capture': 'Ref_B', 'other': {'@ref': 'Ref_A'} },
-            ],
-            fullReplace: true,
-        }
-        await document.insert(agent, option)
+  it('handles captures correctly in a full instance replace', async function () {
+    const classId = util.randomString()
+    const schema = { '@type': 'Class', '@id': classId, other: classId }
+    await document.insert(agent, { schema })
+    const option = {
+      instance: [
+        { '@type': schema['@id'], '@capture': 'Ref_A', other: { '@ref': 'Ref_B' } },
+        { '@type': schema['@id'], '@capture': 'Ref_B', other: { '@ref': 'Ref_A' } },
+      ],
+      fullReplace: true,
+    }
+    await document.insert(agent, option)
 
-        let result = await document.get(agent, {query: {as_list: true}})
-        let documents = result.body
-        let id1 = documents[0]['@id']
-        let id2 = documents[1]['@id']
-        let other1 = documents[0]['other']
-        let other2 = documents[1]['other']
-        expect(id1).to.equal(other2)
-        expect(id2).to.equal(other1)
-    })
+    const result = await document.get(agent, { query: { as_list: true } })
+    const documents = result.body
+    const id1 = documents[0]['@id']
+    const id2 = documents[1]['@id']
+    const other1 = documents[0].other
+    const other2 = documents[1].other
+    expect(id1).to.equal(other2)
+    expect(id2).to.equal(other1)
+  })
 
   describe('fails insert schema with duplicate @id (#1063)', function () {
     for (const fullReplace of [false, true]) {


### PR DESCRIPTION
When doing a full replace on instance data, the insert logic was not properly suspending inserts until all captures were known, causing the code to attempt to insert unbound triple data. This led to an ugly stack trace.

Fixes #1398.