### PR TITLE
change lazy doc logic to have the attr unify hook unify on head

### DIFF
--- a/src/core/util/lazy_docs.pl
+++ b/src/core/util/lazy_docs.pl
@@ -8,23 +8,23 @@ stream_to_lazy_docs(Stream, List) :-
     do_or_die(
         ground(Stream),
         error(instantiation_error, _)),
-    put_attr(List, 'util/lazy_docs', lazy_input(Stream, _)).
+    put_attr(List, 'util/lazy_docs', lazy_input(Stream, peek(_))).
 
-attr_unify_hook(State, Value) :-
-    State = lazy_input(Stream, Peek),
+attr_unify_hook(lazy_input(Stream, Peek_State), Value) :-
+    Peek_State = peek(Peek),
     (   var(Peek)
     ->  json_read_dict(Stream, Term, [default_tag(json), end_of_file(eof)]),
         (   Term = eof
-        ->  nb_setarg(2, State, []),
+        ->  nb_setarg(1, Peek_State, []),
             Value = []
         ;   is_list(Term)
         ->  stream_to_lazy_docs(Stream, Rest),
             append(Term,Rest,Result),
-            nb_linkarg(2, State, Result),
+            nb_linkarg(1, Peek_State, Result),
             Value = Result
         ;   stream_to_lazy_docs(Stream, Rest),
             Result = [Term|Rest],
-            nb_linkarg(2, State, Result),
+            nb_linkarg(1, Peek_State, Result),
             Value = Result
         )
     ;   Value = Peek


### PR DESCRIPTION
I think it is better if hooks are able to unify on head, because this allows swipl to use indexing and hooks will be called quite often for anything that has attributes, not just our lazy doc lists.

So this will prevent our unify hook for lazy doc lists from being called on everything else.