### PR TITLE
Add benchmarking on dedicated machine

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -43,12 +43,15 @@ jobs:
 
 
       - name: Add SSH Key
+        env:
+          KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY
         run: |
           mkdir -p ${HOME}/.ssh
           echo "Created SSH DIR"
-          echo "${{ secrets.SSH_KNOWN_HOSTS }}" >> ${HOME}/.ssh/known_hosts
+          echo "$SSH_KNOWN_HOSTS" >> ${HOME}/.ssh/known_hosts
           echo "Add known hosts"
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ${HOME}/.ssh/github_actions
+          echo "$SSH_PRIVATE_KEY" > ${HOME}/.ssh/github_actions
           echo "Add SSH private key"
           chmod 600 ${HOME}/.ssh/github_actions
           echo "Change SSH permissions"
@@ -63,9 +66,12 @@ jobs:
 
 
       - name: Run k6 benchmark
+        env:
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_HOST: ${{ secrets.SSH_HOST }}
         working-directory: tests
         run: |
-          ssh "${{ secrets.SSH_USER }}"@"${{ secrets.SSH_HOST }}" "benchmark $GITHUB_SHA" > "results/k6_benchmark_results/${GITHUB_SHA}.json"
+          ssh "$SSH_USER"@"$SSH_HOST" "benchmark $GITHUB_SHA" > "results/k6_benchmark_results/${GITHUB_SHA}.json"
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -35,9 +35,29 @@ jobs:
       - name: Run benchmarks
         working-directory: tests
         run: |
-          mkdir results
+          mkdir -p results/js_benchmark_results
           npm ci
-          node bench.js --json > "results/${GITHUB_SHA}.json"
+          node bench.js --json > "results/js_benchmark_results/${GITHUB_SHA}.json"
+
+
+      - name: Add SSH Key
+        run: |
+          mkdir -p ${HOME}/.ssh
+          ssh-keyscan "${{ secrets.SSH_HOST }}" >> ${HOME}/.ssh/known_hosts
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ${HOME}/.ssh/github_actions
+          chmod 600 ${HOME}/.ssh/github_actions
+          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+          ssh-add ${HOME}/.ssh/github_actions
+
+      - name: Make k6 benchmark dir
+        working-directory: tests
+        run: mkdir -p results/k6_benchmark_results
+
+
+      - name: Run k6 benchmark
+        working-directory: tests
+        run: |
+          ssh "${{ secrets.SSH_USER }}"@"${{ secrets.SSH_HOST }}" "benchmark $GITHUB_SHA" > "results/k6_benchmark_results/${GITHUB_SHA}.json"
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
@@ -45,5 +65,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./tests/results/
           keep_files: true
-          destination_dir: js_benchmark_results
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,6 +16,7 @@ env:
 jobs:
 
   benchmark:
+    concurrency: benchmark
     name: Run
     runs-on: ubuntu-latest
     env:
@@ -71,6 +72,9 @@ jobs:
         working-directory: tests
         run: mkdir -p results/k6_benchmark_results
 
+      - name: Make k6 benchmark dir
+        working-directory: tests
+        run: mkdir -p results/lego_benchmark_results
 
       - name: Run k6 benchmark
         env:
@@ -78,12 +82,14 @@ jobs:
           SSH_HOST: ${{ secrets.SSH_HOST }}
         working-directory: tests
         run: |
-          ssh "$SSH_USER"@"$SSH_HOST" "benchmark $GITHUB_SHA" > "results/k6_benchmark_results/${GITHUB_SHA}.json"
+          ssh "$SSH_USER"@"$SSH_HOST" "benchmark $GITHUB_SHA all"
+          scp "$SSH_USER"@"$SSH_HOST":"/home/${SSH_USER}/benchmark_data/lego_terminusdb_${GITHUB_SHA}.json results/lego_benchmark_results/
+          scp "$SSH_USER"@"$SSH_HOST":"/home/${SSH_USER}/benchmark_data/k6_output.json results/k6_benchmark_results/${GITHUB_SHA}.json
 
-#      - name: Deploy
-#        uses: peaceiris/actions-gh-pages@v3
-#        with:
-#          github_token: ${{ secrets.GITHUB_TOKEN }}
-#          publish_dir: ./tests/results/
-#          keep_files: true
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./tests/results/
+          keep_files: true
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,6 +11,8 @@ jobs:
   benchmark:
     name: Run
     runs-on: ubuntu-latest
+    env:
+      SSH_AUTH_SOCK: /tmp/ssh_agent.sock
 
     steps:
       - name: Download Docker image

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -39,7 +39,7 @@ jobs:
 #        with:
 #          node-version: ${{ env.NODE_VERSION }}
 #
-#      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 #
 #      - name: Run benchmarks
 #        working-directory: tests

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -55,13 +55,11 @@ jobs:
           echo "Created SSH DIR"
           echo "$SSH_KNOWN_HOSTS" >> ${HOME}/.ssh/known_hosts
           echo "Add known hosts"
-          echo "$SSH_PRIVATE_KEY" > ${HOME}/.ssh/github_actions
-          echo "Add SSH private key"
           chmod 600 ${HOME}/.ssh/github_actions
           echo "Change SSH permissions"
           ssh-agent -a $SSH_AUTH_SOCK > /dev/null
           echo "Started ssh agent"
-          ssh-add ${HOME}/.ssh/github_actions
+          ssh-add - <<< "${SSH_PRIVATE_KEY}"
           echo "Add SSH key"
 
       - name: Make k6 benchmark dir

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -46,19 +46,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install libssl1.1
 
-      - name: Add SSH Key
-        env:
-          SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
-          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-        run: |
-          mkdir -p ${HOME}/.ssh
-          echo "Created SSH DIR"
-          echo "$SSH_KNOWN_HOSTS" >> ${HOME}/.ssh/known_hosts
-          echo "Add known hosts"
-          eval $(ssh-agent -s)
-          echo "Started ssh agent"
-          ssh-add - <<< "${{ secrets.SSH_PRIVATE_KEY }}"
-          echo "Add SSH key"
+
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          known_hosts: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Make k6 benchmark dir
         working-directory: tests

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -45,11 +45,17 @@ jobs:
       - name: Add SSH Key
         run: |
           mkdir -p ${HOME}/.ssh
+          echo "Created SSH DIR"
           ssh-keyscan "${{ secrets.SSH_HOST }}" >> ${HOME}/.ssh/known_hosts
+          echo "Add known hosts"
           echo "${{ secrets.SSH_PRIVATE_KEY }}" > ${HOME}/.ssh/github_actions
+          echo "Add SSH private key"
           chmod 600 ${HOME}/.ssh/github_actions
+          echo "Change SSH permissions"
           ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+          echo "Started ssh agent"
           ssh-add ${HOME}/.ssh/github_actions
+          echo "Add SSH key"
 
       - name: Make k6 benchmark dir
         working-directory: tests

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -41,6 +41,10 @@ jobs:
 #          npm ci
 #          node bench.js --json > "results/js_benchmark_results/${GITHUB_SHA}.json"
 
+      - name: Install libssl1.1
+        run: |
+          sudo apt-get update
+          sudo apt-get install libssl1.1
 
       - name: Add SSH Key
         env:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -55,9 +55,9 @@ jobs:
           echo "Created SSH DIR"
           echo "$SSH_KNOWN_HOSTS" >> ${HOME}/.ssh/known_hosts
           echo "Add known hosts"
-          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+          eval $(ssh-agent -s)
           echo "Started ssh agent"
-          ssh-add - <<< "${SSH_PRIVATE_KEY}\n"
+          ssh-add - <<< "${SSH_PRIVATE_KEY}"
           echo "Add SSH key"
 
       - name: Make k6 benchmark dir

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,6 +2,13 @@ name: Benchmark
 
 on:
   workflow_call:
+    secrets:
+      SSH_KNOWN_HOSTS:
+        required: true
+      SSH_PRIVATE_KEY:
+        required: true
+      SSH_HOST:
+        required: true
 
 env:
   NODE_VERSION: '16'
@@ -46,12 +53,19 @@ jobs:
           sudo apt-get update
           sudo apt-get install libssl1.1
 
-
-      - name: Install SSH key
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
+      - name: Add SSH Key
+        env:
+          SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        run: |
+          mkdir -p ${HOME}/.ssh
+          echo "Created SSH DIR"
+          echo "$SSH_KNOWN_HOSTS" >> ${HOME}/.ssh/known_hosts
+          echo "Add known hosts"
+          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+          echo "Started ssh agent"
+          ssh-add - <<< "${SSH_PRIVATE_KEY}"
+          echo "Add SSH key"
 
       - name: Make k6 benchmark dir
         working-directory: tests

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -51,7 +51,7 @@ jobs:
         uses: shimataro/ssh-key-action@v2
         with:
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          known_hosts: ${{ secrets.SSH_PRIVATE_KEY }}
+          known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
 
       - name: Make k6 benchmark dir
         working-directory: tests

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,31 +15,31 @@ jobs:
       SSH_AUTH_SOCK: /tmp/ssh_agent.sock
 
     steps:
-      - name: Download Docker image
-        uses: actions/download-artifact@v2
-        with:
-          name: terminusdb-server-docker-image
-
-      - name: Run server
-        run: |
-          docker load < terminusdb-server-docker-image.tar.gz
-          docker run \
-            --detach \
-            --net=host \
-            terminusdb/terminusdb-server:local
-
-      - uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - uses: actions/checkout@v2
-
-      - name: Run benchmarks
-        working-directory: tests
-        run: |
-          mkdir -p results/js_benchmark_results
-          npm ci
-          node bench.js --json > "results/js_benchmark_results/${GITHUB_SHA}.json"
+#      - name: Download Docker image
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: terminusdb-server-docker-image
+#
+#      - name: Run server
+#        run: |
+#          docker load < terminusdb-server-docker-image.tar.gz
+#          docker run \
+#            --detach \
+#            --net=host \
+#            terminusdb/terminusdb-server:local
+#
+#      - uses: actions/setup-node@v2
+#        with:
+#          node-version: ${{ env.NODE_VERSION }}
+#
+#      - uses: actions/checkout@v2
+#
+#      - name: Run benchmarks
+#        working-directory: tests
+#        run: |
+#          mkdir -p results/js_benchmark_results
+#          npm ci
+#          node bench.js --json > "results/js_benchmark_results/${GITHUB_SHA}.json"
 
 
       - name: Add SSH Key
@@ -73,10 +73,10 @@ jobs:
         run: |
           ssh "$SSH_USER"@"$SSH_HOST" "benchmark $GITHUB_SHA" > "results/k6_benchmark_results/${GITHUB_SHA}.json"
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./tests/results/
-          keep_files: true
+#      - name: Deploy
+#        uses: peaceiris/actions-gh-pages@v3
+#        with:
+#          github_token: ${{ secrets.GITHUB_TOKEN }}
+#          publish_dir: ./tests/results/
+#          keep_files: true
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -57,7 +57,7 @@ jobs:
           echo "Add known hosts"
           eval $(ssh-agent -s)
           echo "Started ssh agent"
-          ssh-add - <<< "${SSH_PRIVATE_KEY}"
+          ssh-add - <<< "${{ secrets.SSH_PRIVATE_KEY }}"
           echo "Add SSH key"
 
       - name: Make k6 benchmark dir

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -35,6 +35,15 @@ jobs:
       - name: Run benchmarks
         working-directory: tests
         run: |
+          mkdir results
           npm ci
-          npm run bench
+          node bench.js --json > "results/${GITHUB_SHA}.json"
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./tests/results/
+          keep_files: true
+          destination_dir: js_benchmark_results
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Add SSH Key
         env:
-          KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
+          SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
         run: |
           mkdir -p ${HOME}/.ssh

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Add SSH Key
         env:
           KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
-          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
         run: |
           mkdir -p ${HOME}/.ssh
           echo "Created SSH DIR"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,31 +23,7 @@ jobs:
       SSH_AUTH_SOCK: /tmp/ssh_agent.sock
 
     steps:
-#      - name: Download Docker image
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: terminusdb-server-docker-image
-#
-#      - name: Run server
-#        run: |
-#          docker load < terminusdb-server-docker-image.tar.gz
-#          docker run \
-#            --detach \
-#            --net=host \
-#            terminusdb/terminusdb-server:local
-#
-#      - uses: actions/setup-node@v2
-#        with:
-#          node-version: ${{ env.NODE_VERSION }}
-#
       - uses: actions/checkout@v2
-#
-#      - name: Run benchmarks
-#        working-directory: tests
-#        run: |
-#          mkdir -p results/js_benchmark_results
-#          npm ci
-#          node bench.js --json > "results/js_benchmark_results/${GITHUB_SHA}.json"
 
       - name: Install libssl1.1
         run: |
@@ -68,13 +44,12 @@ jobs:
           ssh-add - <<< "${SSH_PRIVATE_KEY}"
           echo "Add SSH key"
 
-      - name: Make k6 benchmark dir
+      - name: Make benchmark dirs
         working-directory: tests
-        run: mkdir -p results/k6_benchmark_results
-
-      - name: Make k6 benchmark dir
-        working-directory: tests
-        run: mkdir -p results/lego_benchmark_results
+        run: |
+          mkdir -p results/k6_benchmark_results
+          mkdir results/lego_benchmark_results
+          mkdir results/js_benchmark_results
 
       - name: Run k6 benchmark
         env:
@@ -85,6 +60,7 @@ jobs:
           ssh "$SSH_USER"@"$SSH_HOST" "benchmark $GITHUB_SHA all"
           scp "$SSH_USER"@"$SSH_HOST":"/home/${SSH_USER}/benchmark_data/lego_terminusdb_${GITHUB_SHA}.json" results/lego_benchmark_results/
           scp "$SSH_USER"@"$SSH_HOST":"/home/${SSH_USER}/benchmark_data/k6_output.json" "results/k6_benchmark_results/${GITHUB_SHA}.json"
+          scp "$SSH_USER"@"$SSH_HOST":"/home/${SSH_USER}/benchmark_data/js_benchmark_terminusdb_${GITHUB_SHA}.json" "results/js_benchmark_results/${GITHUB_SHA}.json"
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
@@ -92,4 +68,3 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./tests/results/
           keep_files: true
-

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -57,7 +57,7 @@ jobs:
           echo "Add known hosts"
           ssh-agent -a $SSH_AUTH_SOCK > /dev/null
           echo "Started ssh agent"
-          ssh-add - <<< "${SSH_PRIVATE_KEY}"
+          ssh-add - <<< "${SSH_PRIVATE_KEY}\n"
           echo "Add SSH key"
 
       - name: Make k6 benchmark dir

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -55,8 +55,6 @@ jobs:
           echo "Created SSH DIR"
           echo "$SSH_KNOWN_HOSTS" >> ${HOME}/.ssh/known_hosts
           echo "Add known hosts"
-          chmod 600 ${HOME}/.ssh/github_actions
-          echo "Change SSH permissions"
           ssh-agent -a $SSH_AUTH_SOCK > /dev/null
           echo "Started ssh agent"
           ssh-add - <<< "${SSH_PRIVATE_KEY}"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,7 +10,7 @@ jobs:
 
   benchmark:
     name: Run
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       SSH_AUTH_SOCK: /tmp/ssh_agent.sock
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,7 +10,7 @@ jobs:
 
   benchmark:
     name: Run
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       SSH_AUTH_SOCK: /tmp/ssh_agent.sock
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -83,8 +83,8 @@ jobs:
         working-directory: tests
         run: |
           ssh "$SSH_USER"@"$SSH_HOST" "benchmark $GITHUB_SHA all"
-          scp "$SSH_USER"@"$SSH_HOST":"/home/${SSH_USER}/benchmark_data/lego_terminusdb_${GITHUB_SHA}.json results/lego_benchmark_results/
-          scp "$SSH_USER"@"$SSH_HOST":"/home/${SSH_USER}/benchmark_data/k6_output.json results/k6_benchmark_results/${GITHUB_SHA}.json
+          scp "$SSH_USER"@"$SSH_HOST":"/home/${SSH_USER}/benchmark_data/lego_terminusdb_${GITHUB_SHA}.json" results/lego_benchmark_results/
+          scp "$SSH_USER"@"$SSH_HOST":"/home/${SSH_USER}/benchmark_data/k6_output.json" "results/k6_benchmark_results/${GITHUB_SHA}.json"
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           mkdir -p ${HOME}/.ssh
           echo "Created SSH DIR"
-          ssh-keyscan "${{ secrets.SSH_HOST }}" >> ${HOME}/.ssh/known_hosts
+          echo "${{ secrets.SSH_KNOWN_HOSTS }}" >> ${HOME}/.ssh/known_hosts
           echo "Add known hosts"
           echo "${{ secrets.SSH_PRIVATE_KEY }}" > ${HOME}/.ssh/github_actions
           echo "Add SSH private key"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,18 +92,18 @@ jobs:
             src/config/terminus_config.pl
             distribution/snap/snapcraft.yaml
 
-  build:
-    name: Build
-    needs: versions
-    uses: ./.github/workflows/build.yml
-
-  check:
-    name: Check
-    needs: build
-    uses: ./.github/workflows/check.yml
-    with:
-      test_repository: ${{ github.repository }}
-      test_ref: ${{ github.sha }}
+#  build:
+#    name: Build
+#    needs: versions
+#    uses: ./.github/workflows/build.yml
+#
+#  check:
+#    name: Check
+#    needs: build
+#    uses: ./.github/workflows/check.yml
+#    with:
+#      test_repository: ${{ github.repository }}
+#      test_ref: ${{ github.sha }}
 
   benchmark:
     name: Benchmark

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
     name: Benchmark
 #    needs: build
     uses: ./.github/workflows/benchmark.yml
+    secrets: inherit
 
 
   # This is required for status checks.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,162 +112,162 @@ jobs:
 
 
   # This is required for status checks.
-  all_checks_pass_with_build:
-    name: All checks pass
-    runs-on: ubuntu-latest
-    needs: check
-    steps:
-      - run: echo "Celebrate! 🥳"
-
-  docs:
-    name: Update docs
-    runs-on: ubuntu-latest
-    needs: all_checks_pass_with_build
-    if: github.event_name == 'push'
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Download Docker image
-        uses: actions/download-artifact@v2
-        with:
-          name: terminusdb-server-docker-image
-
-      - name: Generate man page
-        run: |
-          sudo apt-get install --no-install-recommends ronn
-          ronn --version
-          docker load < terminusdb-server-docker-image.tar.gz
-          export HELP="$(docker run --rm terminusdb/terminusdb-server:local /app/terminusdb/terminusdb help -m)"
-          envsubst < docs/terminusdb.1.ronn.template > docs/terminusdb.1.ronn
-          ronn --roff docs/terminusdb.1.ronn
-
-      - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: Update man page
-          file_pattern: docs/terminusdb.1.*
-
-  # This is required for status checks.
-  all_checks_pass_without_build:
-    name: All checks pass
-    runs-on: ubuntu-latest
-    needs: is_build_required
-    if: >
-      needs.is_build_required.outputs.build_required == 'false' &&
-      needs.is_build_required.outputs.push_docker_required == 'false'
-    steps:
-      - run: echo "Nothing to be done. 😌"
-
-  push_docker:
-    name: Push Docker image
-    runs-on: ubuntu-latest
-    needs:
-      - is_build_required
-      - all_checks_pass_with_build
-    if: needs.is_build_required.outputs.push_docker_required == 'true'
-
-    steps:
-      - name: Download Docker image
-        uses: actions/download-artifact@v2
-        with:
-          name: terminusdb-server-docker-image
-
-      - name: Push image to Docker Container Registry
-        run: |
-          echo '${{ secrets.DOCKER_PASS }}' | docker login -u terminusdb --password-stdin
-
-          # Strip git ref prefix from version
-          VERSION=$(echo "$GITHUB_REF" | sed -e 's,.*/\(.*\),\1,')
-
-          # Use Docker `dev` tag convention for main branch
-          [ "$VERSION" == "main" ] && VERSION=dev
-
-          docker load < terminusdb-server-docker-image.tar.gz
-
-          # Image identifiers
-          LOCAL_IMAGE=terminusdb/terminusdb-server:local
-          VERSION_IMAGE=terminusdb/terminusdb-server:$VERSION
-          DEV_COMMIT_IMAGE=terminusdb/terminusdb-server:$VERSION-$GITHUB_SHA
-          LATEST_IMAGE=terminusdb/terminusdb-server:latest
-
-          # Tag and push the version image
-          docker tag $LOCAL_IMAGE $VERSION_IMAGE
-          docker push $VERSION_IMAGE
-
-          # Tag and push the dev-commit image. This is removed later.
-          if [ "$VERSION" == "dev" ]; then
-            docker tag $LOCAL_IMAGE $DEV_COMMIT_IMAGE
-            docker push $DEV_COMMIT_IMAGE
-          fi
-
-          # Tag and push the latest image when a version tag is pushed
-          if [ $(echo "$GITHUB_REF" | grep "refs/tags/v") ]; then
-             docker tag $LOCAL_IMAGE $LATEST_IMAGE
-             docker push $LATEST_IMAGE
-          fi
-
-  trigger_enterprise_build:
-    name: Trigger enterprise build
-    runs-on: ubuntu-latest
-    needs: push_docker
-    if: |
-      github.repository == 'terminusdb/terminusdb' &&
-      github.event_name == 'push' &&
-      github.ref == 'refs/heads/main'
-
-    steps:
-      - name: Run
-        run: |
-          curl https://api.github.com/repos/${{ secrets.ENTERPRISE_REPO_OWNER }}/${{ secrets.ENTERPRISE_REPO }}/dispatches \
-            -X POST \
-            -H 'Accept: application/vnd.github.everest-preview+json' \
-            -u rrooij:${{ secrets.PAT }} -d '{ "event_type": "Trigger from community", "client_payload": {"commit": "${{ github.sha }}" } }'
-
-  trigger_snap:
-    name: Trigger snap build
-    if: >-
-      github.repository == 'terminusdb/terminusdb' &&
-      github.event_name == 'push' &&
-      startsWith(github.ref, 'refs/tags/v')
-    needs:
-      - is_build_required
-      - all_checks_pass_with_build
-    uses: ./.github/workflows/snap.yml
-
-  release_snap:
-    name: Release the build snap
-    needs: trigger_snap
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Download Snap image
-        uses: actions/download-artifact@v3
-        with:
-          name: terminusdb-snap
-          path: download_snap/
-      - name: Determine exact snap path
-        id: snap_path_step
-        run: echo "::set-output name=snap_path::$(find download_snap -name '*.snap')"
-      - uses: snapcore/action-publish@v1
-        env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
-        with:
-          snap: ${{ steps.snap_path_step.outputs.snap_path }}
-          release: stable
-
-  trigger_docs_update:
-    name: Trigger docs update
-    runs-on: ubuntu-latest
-    needs: push_docker
-    if: >-
-      github.repository == 'terminusdb/terminusdb' &&
-      github.event_name == 'push' &&
-      startsWith(github.ref, 'refs/tags/v')
-
-    steps:
-      - uses: peter-evans/repository-dispatch@v2
-        with:
-          token: ${{ secrets.PAT }}
-          repository: terminusdb/terminusdb-docs
-          event-type: update-from-terminusdb
-          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
+#  all_checks_pass_with_build:
+#    name: All checks pass
+#    runs-on: ubuntu-latest
+#    needs: check
+#    steps:
+#      - run: echo "Celebrate! 🥳"
+#
+#  docs:
+#    name: Update docs
+#    runs-on: ubuntu-latest
+#    needs: all_checks_pass_with_build
+#    if: github.event_name == 'push'
+#    steps:
+#      - uses: actions/checkout@v2
+#
+#      - name: Download Docker image
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: terminusdb-server-docker-image
+#
+#      - name: Generate man page
+#        run: |
+#          sudo apt-get install --no-install-recommends ronn
+#          ronn --version
+#          docker load < terminusdb-server-docker-image.tar.gz
+#          export HELP="$(docker run --rm terminusdb/terminusdb-server:local /app/terminusdb/terminusdb help -m)"
+#          envsubst < docs/terminusdb.1.ronn.template > docs/terminusdb.1.ronn
+#          ronn --roff docs/terminusdb.1.ronn
+#
+#      - name: Commit changes
+#        uses: stefanzweifel/git-auto-commit-action@v4
+#        with:
+#          commit_message: Update man page
+#          file_pattern: docs/terminusdb.1.*
+#
+#  # This is required for status checks.
+#  all_checks_pass_without_build:
+#    name: All checks pass
+#    runs-on: ubuntu-latest
+#    needs: is_build_required
+#    if: >
+#      needs.is_build_required.outputs.build_required == 'false' &&
+#      needs.is_build_required.outputs.push_docker_required == 'false'
+#    steps:
+#      - run: echo "Nothing to be done. 😌"
+#
+#  push_docker:
+#    name: Push Docker image
+#    runs-on: ubuntu-latest
+#    needs:
+#      - is_build_required
+#      - all_checks_pass_with_build
+#    if: needs.is_build_required.outputs.push_docker_required == 'true'
+#
+#    steps:
+#      - name: Download Docker image
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: terminusdb-server-docker-image
+#
+#      - name: Push image to Docker Container Registry
+#        run: |
+#          echo '${{ secrets.DOCKER_PASS }}' | docker login -u terminusdb --password-stdin
+#
+#          # Strip git ref prefix from version
+#          VERSION=$(echo "$GITHUB_REF" | sed -e 's,.*/\(.*\),\1,')
+#
+#          # Use Docker `dev` tag convention for main branch
+#          [ "$VERSION" == "main" ] && VERSION=dev
+#
+#          docker load < terminusdb-server-docker-image.tar.gz
+#
+#          # Image identifiers
+#          LOCAL_IMAGE=terminusdb/terminusdb-server:local
+#          VERSION_IMAGE=terminusdb/terminusdb-server:$VERSION
+#          DEV_COMMIT_IMAGE=terminusdb/terminusdb-server:$VERSION-$GITHUB_SHA
+#          LATEST_IMAGE=terminusdb/terminusdb-server:latest
+#
+#          # Tag and push the version image
+#          docker tag $LOCAL_IMAGE $VERSION_IMAGE
+#          docker push $VERSION_IMAGE
+#
+#          # Tag and push the dev-commit image. This is removed later.
+#          if [ "$VERSION" == "dev" ]; then
+#            docker tag $LOCAL_IMAGE $DEV_COMMIT_IMAGE
+#            docker push $DEV_COMMIT_IMAGE
+#          fi
+#
+#          # Tag and push the latest image when a version tag is pushed
+#          if [ $(echo "$GITHUB_REF" | grep "refs/tags/v") ]; then
+#             docker tag $LOCAL_IMAGE $LATEST_IMAGE
+#             docker push $LATEST_IMAGE
+#          fi
+#
+#  trigger_enterprise_build:
+#    name: Trigger enterprise build
+#    runs-on: ubuntu-latest
+#    needs: push_docker
+#    if: |
+#      github.repository == 'terminusdb/terminusdb' &&
+#      github.event_name == 'push' &&
+#      github.ref == 'refs/heads/main'
+#
+#    steps:
+#      - name: Run
+#        run: |
+#          curl https://api.github.com/repos/${{ secrets.ENTERPRISE_REPO_OWNER }}/${{ secrets.ENTERPRISE_REPO }}/dispatches \
+#            -X POST \
+#            -H 'Accept: application/vnd.github.everest-preview+json' \
+#            -u rrooij:${{ secrets.PAT }} -d '{ "event_type": "Trigger from community", "client_payload": {"commit": "${{ github.sha }}" } }'
+#
+#  trigger_snap:
+#    name: Trigger snap build
+#    if: >-
+#      github.repository == 'terminusdb/terminusdb' &&
+#      github.event_name == 'push' &&
+#      startsWith(github.ref, 'refs/tags/v')
+#    needs:
+#      - is_build_required
+#      - all_checks_pass_with_build
+#    uses: ./.github/workflows/snap.yml
+#
+#  release_snap:
+#    name: Release the build snap
+#    needs: trigger_snap
+#    runs-on: ubuntu-latest
+#
+#    steps:
+#      - name: Download Snap image
+#        uses: actions/download-artifact@v3
+#        with:
+#          name: terminusdb-snap
+#          path: download_snap/
+#      - name: Determine exact snap path
+#        id: snap_path_step
+#        run: echo "::set-output name=snap_path::$(find download_snap -name '*.snap')"
+#      - uses: snapcore/action-publish@v1
+#        env:
+#          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
+#        with:
+#          snap: ${{ steps.snap_path_step.outputs.snap_path }}
+#          release: stable
+#
+#  trigger_docs_update:
+#    name: Trigger docs update
+#    runs-on: ubuntu-latest
+#    needs: push_docker
+#    if: >-
+#      github.repository == 'terminusdb/terminusdb' &&
+#      github.event_name == 'push' &&
+#      startsWith(github.ref, 'refs/tags/v')
+#
+#    steps:
+#      - uses: peter-evans/repository-dispatch@v2
+#        with:
+#          token: ${{ secrets.PAT }}
+#          repository: terminusdb/terminusdb-docs
+#          event-type: update-from-terminusdb
+#          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
 
   benchmark:
     name: Benchmark
-    needs: build
+#    needs: build
     uses: ./.github/workflows/benchmark.yml
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,183 +92,183 @@ jobs:
             src/config/terminus_config.pl
             distribution/snap/snapcraft.yaml
 
-#  build:
-#    name: Build
-#    needs: versions
-#    uses: ./.github/workflows/build.yml
-#
-#  check:
-#    name: Check
-#    needs: build
-#    uses: ./.github/workflows/check.yml
-#    with:
-#      test_repository: ${{ github.repository }}
-#      test_ref: ${{ github.sha }}
+  build:
+    name: Build
+    needs: versions
+    uses: ./.github/workflows/build.yml
+
+  check:
+    name: Check
+    needs: build
+    uses: ./.github/workflows/check.yml
+    with:
+      test_repository: ${{ github.repository }}
+      test_ref: ${{ github.sha }}
 
   benchmark:
     name: Benchmark
-#    needs: build
+    if: github.repository == 'terminusdb/terminusdb' && github.ref == 'refs/heads/main'
     uses: ./.github/workflows/benchmark.yml
     secrets: inherit
 
 
+ # This is required for status checks.
+  all_checks_pass_with_build:
+    name: All checks pass
+    runs-on: ubuntu-latest
+    needs: check
+    steps:
+      - run: echo "Celebrate! 🥳"
+
+  docs:
+    name: Update docs
+    runs-on: ubuntu-latest
+    needs: all_checks_pass_with_build
+    if: github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download Docker image
+        uses: actions/download-artifact@v2
+        with:
+          name: terminusdb-server-docker-image
+
+      - name: Generate man page
+        run: |
+          sudo apt-get install --no-install-recommends ronn
+          ronn --version
+          docker load < terminusdb-server-docker-image.tar.gz
+          export HELP="$(docker run --rm terminusdb/terminusdb-server:local /app/terminusdb/terminusdb help -m)"
+          envsubst < docs/terminusdb.1.ronn.template > docs/terminusdb.1.ronn
+          ronn --roff docs/terminusdb.1.ronn
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Update man page
+          file_pattern: docs/terminusdb.1.*
+
   # This is required for status checks.
-#  all_checks_pass_with_build:
-#    name: All checks pass
-#    runs-on: ubuntu-latest
-#    needs: check
-#    steps:
-#      - run: echo "Celebrate! 🥳"
-#
-#  docs:
-#    name: Update docs
-#    runs-on: ubuntu-latest
-#    needs: all_checks_pass_with_build
-#    if: github.event_name == 'push'
-#    steps:
-#      - uses: actions/checkout@v2
-#
-#      - name: Download Docker image
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: terminusdb-server-docker-image
-#
-#      - name: Generate man page
-#        run: |
-#          sudo apt-get install --no-install-recommends ronn
-#          ronn --version
-#          docker load < terminusdb-server-docker-image.tar.gz
-#          export HELP="$(docker run --rm terminusdb/terminusdb-server:local /app/terminusdb/terminusdb help -m)"
-#          envsubst < docs/terminusdb.1.ronn.template > docs/terminusdb.1.ronn
-#          ronn --roff docs/terminusdb.1.ronn
-#
-#      - name: Commit changes
-#        uses: stefanzweifel/git-auto-commit-action@v4
-#        with:
-#          commit_message: Update man page
-#          file_pattern: docs/terminusdb.1.*
-#
-#  # This is required for status checks.
-#  all_checks_pass_without_build:
-#    name: All checks pass
-#    runs-on: ubuntu-latest
-#    needs: is_build_required
-#    if: >
-#      needs.is_build_required.outputs.build_required == 'false' &&
-#      needs.is_build_required.outputs.push_docker_required == 'false'
-#    steps:
-#      - run: echo "Nothing to be done. 😌"
-#
-#  push_docker:
-#    name: Push Docker image
-#    runs-on: ubuntu-latest
-#    needs:
-#      - is_build_required
-#      - all_checks_pass_with_build
-#    if: needs.is_build_required.outputs.push_docker_required == 'true'
-#
-#    steps:
-#      - name: Download Docker image
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: terminusdb-server-docker-image
-#
-#      - name: Push image to Docker Container Registry
-#        run: |
-#          echo '${{ secrets.DOCKER_PASS }}' | docker login -u terminusdb --password-stdin
-#
-#          # Strip git ref prefix from version
-#          VERSION=$(echo "$GITHUB_REF" | sed -e 's,.*/\(.*\),\1,')
-#
-#          # Use Docker `dev` tag convention for main branch
-#          [ "$VERSION" == "main" ] && VERSION=dev
-#
-#          docker load < terminusdb-server-docker-image.tar.gz
-#
-#          # Image identifiers
-#          LOCAL_IMAGE=terminusdb/terminusdb-server:local
-#          VERSION_IMAGE=terminusdb/terminusdb-server:$VERSION
-#          DEV_COMMIT_IMAGE=terminusdb/terminusdb-server:$VERSION-$GITHUB_SHA
-#          LATEST_IMAGE=terminusdb/terminusdb-server:latest
-#
-#          # Tag and push the version image
-#          docker tag $LOCAL_IMAGE $VERSION_IMAGE
-#          docker push $VERSION_IMAGE
-#
-#          # Tag and push the dev-commit image. This is removed later.
-#          if [ "$VERSION" == "dev" ]; then
-#            docker tag $LOCAL_IMAGE $DEV_COMMIT_IMAGE
-#            docker push $DEV_COMMIT_IMAGE
-#          fi
-#
-#          # Tag and push the latest image when a version tag is pushed
-#          if [ $(echo "$GITHUB_REF" | grep "refs/tags/v") ]; then
-#             docker tag $LOCAL_IMAGE $LATEST_IMAGE
-#             docker push $LATEST_IMAGE
-#          fi
-#
-#  trigger_enterprise_build:
-#    name: Trigger enterprise build
-#    runs-on: ubuntu-latest
-#    needs: push_docker
-#    if: |
-#      github.repository == 'terminusdb/terminusdb' &&
-#      github.event_name == 'push' &&
-#      github.ref == 'refs/heads/main'
-#
-#    steps:
-#      - name: Run
-#        run: |
-#          curl https://api.github.com/repos/${{ secrets.ENTERPRISE_REPO_OWNER }}/${{ secrets.ENTERPRISE_REPO }}/dispatches \
-#            -X POST \
-#            -H 'Accept: application/vnd.github.everest-preview+json' \
-#            -u rrooij:${{ secrets.PAT }} -d '{ "event_type": "Trigger from community", "client_payload": {"commit": "${{ github.sha }}" } }'
-#
-#  trigger_snap:
-#    name: Trigger snap build
-#    if: >-
-#      github.repository == 'terminusdb/terminusdb' &&
-#      github.event_name == 'push' &&
-#      startsWith(github.ref, 'refs/tags/v')
-#    needs:
-#      - is_build_required
-#      - all_checks_pass_with_build
-#    uses: ./.github/workflows/snap.yml
-#
-#  release_snap:
-#    name: Release the build snap
-#    needs: trigger_snap
-#    runs-on: ubuntu-latest
-#
-#    steps:
-#      - name: Download Snap image
-#        uses: actions/download-artifact@v3
-#        with:
-#          name: terminusdb-snap
-#          path: download_snap/
-#      - name: Determine exact snap path
-#        id: snap_path_step
-#        run: echo "::set-output name=snap_path::$(find download_snap -name '*.snap')"
-#      - uses: snapcore/action-publish@v1
-#        env:
-#          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
-#        with:
-#          snap: ${{ steps.snap_path_step.outputs.snap_path }}
-#          release: stable
-#
-#  trigger_docs_update:
-#    name: Trigger docs update
-#    runs-on: ubuntu-latest
-#    needs: push_docker
-#    if: >-
-#      github.repository == 'terminusdb/terminusdb' &&
-#      github.event_name == 'push' &&
-#      startsWith(github.ref, 'refs/tags/v')
-#
-#    steps:
-#      - uses: peter-evans/repository-dispatch@v2
-#        with:
-#          token: ${{ secrets.PAT }}
-#          repository: terminusdb/terminusdb-docs
-#          event-type: update-from-terminusdb
-#          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
+  all_checks_pass_without_build:
+    name: All checks pass
+    runs-on: ubuntu-latest
+    needs: is_build_required
+    if: >
+      needs.is_build_required.outputs.build_required == 'false' &&
+      needs.is_build_required.outputs.push_docker_required == 'false'
+    steps:
+      - run: echo "Nothing to be done. 😌"
+
+  push_docker:
+    name: Push Docker image
+    runs-on: ubuntu-latest
+    needs:
+      - is_build_required
+      - all_checks_pass_with_build
+    if: needs.is_build_required.outputs.push_docker_required == 'true'
+
+    steps:
+      - name: Download Docker image
+        uses: actions/download-artifact@v2
+        with:
+          name: terminusdb-server-docker-image
+
+      - name: Push image to Docker Container Registry
+        run: |
+          echo '${{ secrets.DOCKER_PASS }}' | docker login -u terminusdb --password-stdin
+
+          # Strip git ref prefix from version
+          VERSION=$(echo "$GITHUB_REF" | sed -e 's,.*/\(.*\),\1,')
+
+          # Use Docker `dev` tag convention for main branch
+          [ "$VERSION" == "main" ] && VERSION=dev
+
+          docker load < terminusdb-server-docker-image.tar.gz
+
+          # Image identifiers
+          LOCAL_IMAGE=terminusdb/terminusdb-server:local
+          VERSION_IMAGE=terminusdb/terminusdb-server:$VERSION
+          DEV_COMMIT_IMAGE=terminusdb/terminusdb-server:$VERSION-$GITHUB_SHA
+          LATEST_IMAGE=terminusdb/terminusdb-server:latest
+
+          # Tag and push the version image
+          docker tag $LOCAL_IMAGE $VERSION_IMAGE
+          docker push $VERSION_IMAGE
+
+          # Tag and push the dev-commit image. This is removed later.
+          if [ "$VERSION" == "dev" ]; then
+            docker tag $LOCAL_IMAGE $DEV_COMMIT_IMAGE
+            docker push $DEV_COMMIT_IMAGE
+          fi
+
+          # Tag and push the latest image when a version tag is pushed
+          if [ $(echo "$GITHUB_REF" | grep "refs/tags/v") ]; then
+             docker tag $LOCAL_IMAGE $LATEST_IMAGE
+             docker push $LATEST_IMAGE
+          fi
+
+  trigger_enterprise_build:
+    name: Trigger enterprise build
+    runs-on: ubuntu-latest
+    needs: push_docker
+    if: |
+      github.repository == 'terminusdb/terminusdb' &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Run
+        run: |
+          curl https://api.github.com/repos/${{ secrets.ENTERPRISE_REPO_OWNER }}/${{ secrets.ENTERPRISE_REPO }}/dispatches \
+            -X POST \
+            -H 'Accept: application/vnd.github.everest-preview+json' \
+            -u rrooij:${{ secrets.PAT }} -d '{ "event_type": "Trigger from community", "client_payload": {"commit": "${{ github.sha }}" } }'
+
+  trigger_snap:
+    name: Trigger snap build
+    if: >-
+      github.repository == 'terminusdb/terminusdb' &&
+      github.event_name == 'push' &&
+      startsWith(github.ref, 'refs/tags/v')
+    needs:
+      - is_build_required
+      - all_checks_pass_with_build
+    uses: ./.github/workflows/snap.yml
+
+  release_snap:
+    name: Release the build snap
+    needs: trigger_snap
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download Snap image
+        uses: actions/download-artifact@v3
+        with:
+          name: terminusdb-snap
+          path: download_snap/
+      - name: Determine exact snap path
+        id: snap_path_step
+        run: echo "::set-output name=snap_path::$(find download_snap -name '*.snap')"
+      - uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
+        with:
+          snap: ${{ steps.snap_path_step.outputs.snap_path }}
+          release: stable
+
+  trigger_docs_update:
+    name: Trigger docs update
+    runs-on: ubuntu-latest
+    needs: push_docker
+    if: >-
+      github.repository == 'terminusdb/terminusdb' &&
+      github.event_name == 'push' &&
+      startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+      - uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.PAT }}
+          repository: terminusdb/terminusdb-docs
+          event-type: update-from-terminusdb
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
Benchmarks have been enabled to run on a remote machine. The results are published on the `gh-pages` branch as can be seen here with the few test runs I did: https://github.com/terminusdb/terminusdb/tree/gh-pages

The following benchmarks are executed on the remote machine:

- The k6 benchmarks https://github.com/terminusdb-labs/terminusdb-http-perf
- The JS benchmarks in `tests/bench`
- Lego data is ingested from https://github.com/terminusdb-labs/terminus-cms/ which is a relative big JSON. It is measured by using GNU Time

The server runs a relatively simple Go program that executes those benchmarks and saves those on the machine. It is started from GH Actions with SSH and subsequently fetched by using SCP.