### PR TITLE
Update dashboard version to 0.0.7

### DIFF
--- a/distribution/Makefile.deps
+++ b/distribution/Makefile.deps
@@ -1,6 +1,6 @@
 TUS_VERSION := v0.0.10
 JWT_VERSION := v0.0.5
-DASHBOARD_VERSION := v0.0.6
+DASHBOARD_VERSION := v0.0.7
 DASHBOARD_GITHUB_REPO := terminusdb/terminusdb-dashboard
 
 SWIPL = LANG=C.UTF-8 $(SWIPL_DIR)swipl


### PR DESCRIPTION
Update dashboard to the new version.

Some changes include that the dependencies are updated and that it has proper titles now (it should display TerminusDB Dashboard instead of TerminusX for the local build)