### PR TITLE
Add HEAD call to check for document permissions and data-version

### DIFF
--- a/src/core/api.pl
+++ b/src/core/api.pl
@@ -117,6 +117,7 @@
               unbundle/4,
 
               % api_document.pl
+              api_can_read_document/6,
               api_insert_documents/8,
               api_delete_documents/8,
               api_delete_document/7,

--- a/src/core/api/api_document.pl
+++ b/src/core/api/api_document.pl
@@ -1,4 +1,5 @@
 :- module(api_document, [
+              api_can_read_document/6,
               api_insert_documents/8,
               api_delete_documents/8,
               api_delete_document/7,
@@ -453,6 +454,11 @@ api_replace_documents(SystemDB, Auth, Path, Stream, Requested_Data_Version, New_
                      ),
                      Meta_Data),
     meta_data_version(Transaction, Meta_Data, New_Data_Version).
+
+api_can_read_document(System_DB, Auth, Path, Graph_Type, Requested_Data_Version, Actual_Data_Version) :-
+    resolve_descriptor_auth(read, System_DB, Auth, Path, Graph_Type, Descriptor),
+    before_read(Descriptor, Requested_Data_Version, Actual_Data_Version, _).
+
 
 :- meta_predicate api_read_document_selector(+,+,+,+,+,+,+,+,+,+,1).
 api_read_document_selector(System_DB, Auth, Path, Graph_Type, _Id, Type, Query, Config, Requested_Data_Version, Actual_Data_Version, Initial_Goal) :-

--- a/src/core/api/api_error.pl
+++ b/src/core/api/api_error.pl
@@ -1377,6 +1377,8 @@ api_error_jsonld_(capability,error(no_capability_for_user_with_scope(User,Scope)
             }.
 api_error_jsonld_(woql, Error, JSON) :-
     api_document_error_jsonld(woql, Error, JSON).
+api_error_jsonld_(access_documents, Error, JSON) :-
+    api_document_error_jsonld(access_documents, Error, JSON).
 api_error_jsonld_(get_documents, Error, JSON) :-
     api_document_error_jsonld(get_documents, Error, JSON).
 api_error_jsonld_(insert_documents, Error, JSON) :-
@@ -1415,6 +1417,7 @@ error_type_(delete_documents, 'api:DeleteDocumentErrorResponse').
 error_type_(delete_organization, 'api:DeleteOrganizationErrorResponse').
 error_type_(fetch, 'api:FetchErrorResponse').
 error_type_(frame, 'api:FrameErrorResponse').
+error_type_(access_documents, 'api:AccessDocumentErrorResponse').
 error_type_(get_documents, 'api:GetDocumentErrorResponse').
 error_type_(insert_documents, 'api:InsertDocumentErrorResponse').
 error_type_(optimize, 'api:OptimizeErrorResponse').
@@ -1488,6 +1491,7 @@ api_error_jsonld(graph,error(graph_already_exists(Descriptor,Graph_Name), _), Ty
                               'api:absolute_descriptor' : Path}
             }.
 
+document_error_type(access_documents, 'api:AccessDocumentErrorResponse').
 document_error_type(get_documents, 'api:GetDocumentErrorResponse').
 document_error_type(insert_documents, 'api:InsertDocumentErrorResponse').
 document_error_type(replace_documents, 'api:ReplaceDocumentErrorResponse').

--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -431,8 +431,29 @@ triples_handler(put,Path,Request, System_DB, Auth) :-
                  prefix,
                  chunked,
                  time_limit(infinite),
-                 methods([options,post,delete,get,put])]).
+                 methods([head,options,post,delete,get,put])]).
 
+
+document_handler(head, Path, Request, System_DB, Auth) :-
+    api_report_errors(
+        access_documents,
+        Request,
+        (   (   http_read_json_semidet(json_dict(JSON), Request)
+            ->  true
+            ;   JSON = json{}),
+
+            (   memberchk(search(Search), Request)
+            ->  true
+            ;   Search = []),
+
+
+            param_value_search_or_json_optional(Search, JSON, graph_type, graph, instance, Graph_Type),
+            read_data_version_header(Request, Requested_Data_Version),
+
+            api_can_read_document(System_DB, Auth, Path, Graph_Type, Requested_Data_Version, Actual_Data_Version),
+            write_data_version_header(Actual_Data_Version),
+            format('Status: 200 OK~n~n', [])
+        )).
 document_handler(get, Path, Request, System_DB, Auth) :-
     api_report_errors(
         get_documents,


### PR DESCRIPTION
As the title already explains, this adds a HEAD call to the document_handler for a more-or-less fast way (50ms on average in my tests) to check for user permissions and whether the user has the correct data-version.

It also returns the most recent data-version if no data-version has been supplied. This makes it easier to for caching systems.