### PR TITLE
Fixing sys unit with Option

### DIFF
--- a/src/core/document/inference.pl
+++ b/src/core/document/inference.pl
@@ -606,6 +606,11 @@ get_dict('@ref', Value, Ref) =>
 check_value_type(Database,Prefixes,Value,Type,Annotated,Captures),
 is_dict(Value) =>
     infer_type(Database, Prefixes, Type, Value, _, Annotated, Captures).
+check_value_type(_Database,_Prefixes,Value,Type,Annotated,Captures),
+Type = 'http://terminusdb.com/schema/sys#Unit',
+is_list(Value) =>
+    no_captures(Captures),
+    Annotated = success([]).
 check_value_type(_Database,_Prefixes,Value,Type,_Annotated,_Captures),
 is_list(Value) =>
     throw(error(schema_check_failure([witness{ '@type' : unexpected_list,

--- a/src/core/document/json.pl
+++ b/src/core/document/json.pl
@@ -11675,6 +11675,11 @@ schema_class_with_unit_property('
   "@id": "Foo",
   "field": "sys:Unit"
 }
+
+{ "@type" : "Class",
+  "@id" : "Bar",
+  "unit_option" : { "@type" : "Optional", "@class" : "sys:Unit"}
+}
 ').
 
 test(class_with_unit_property,
@@ -11738,6 +11743,41 @@ test(class_with_unit_property_missing_field,
                                           _{'@type': "Foo"},
                                           _Id)
                          ).
+
+test(class_with_optional_unit_property,
+     [setup((setup_temp_store(State),
+             test_document_label_descriptor(Desc)
+            )),
+      cleanup(teardown_temp_store(State))
+     ]) :-
+
+    write_schema(schema_class_with_unit_property,Desc),
+
+    with_test_transaction(Desc,
+                          C,
+                          insert_document(C,
+                                          _{'@type': "Bar",
+                                            'unit_option': []},
+                                          Id)
+                         ),
+
+    get_document(Desc, Id, Document),
+
+    _{'@type': 'Bar',
+      'unit_option': []} :< Document,
+
+    with_test_transaction(Desc,
+                          C2,
+                          insert_document(C2,
+                                          _{'@type': "Bar"},
+                                          Id2)
+                         ),
+
+    get_document(Desc, Id2, Document2),
+
+    get_dict('@type', Document2, 'Bar'),
+    \+ get_dict('unit_option', Document2, _).
+
 
 schema_class_with_oneof_unit_property('
 { "@base": "terminusdb:///data/",


### PR DESCRIPTION
One case was not covered in value checking in the inference.  `sys:Unit` optionals (which are silly because they are isomorphic with bool) are now possible.