### PR TITLE
snapcraft: add m4 as dependency

### DIFF
--- a/distribution/snap/snapcraft.yaml
+++ b/distribution/snap/snapcraft.yaml
@@ -17,7 +17,7 @@ contact: team@terminusdb.com
 issues: https://github.com/terminusdb/terminusdb/issues
 icon: snap/local/terminusdb_icon.png
 confinement: strict
-base: core20
+base: core22
 grade: stable
 package-repositories:
  - type: apt
@@ -45,6 +45,9 @@ parts:
       - curl
       - clang
       - m4
+      - build-essential
+      - file
+      - diffutils
     stage-packages:
       - swi-prolog-nox
     override-build: |

--- a/distribution/snap/snapcraft.yaml
+++ b/distribution/snap/snapcraft.yaml
@@ -44,6 +44,7 @@ parts:
       - swi-prolog-nox
       - curl
       - clang
+      - m4
     stage-packages:
       - swi-prolog-nox
     override-build: |


### PR DESCRIPTION
It was missing m4 as a dependency for the build of the GMP rust crates.
