### PR TITLE
Try docker build on custom runner from buildjet

### DIFF
--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   arm64_docker:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-2vcpu-ubuntu-2204-arm
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
An hour for building a Docker image is just sad. On a real arm64 server it only takes 11m.

Example: https://github.com/terminusdb/terminusdb/actions/runs/3444496724