### PR TITLE
Fix set property inheritance in doc retrieval

### DIFF
--- a/src/rust/terminusdb-community/src/schema.rs
+++ b/src/rust/terminusdb-community/src/schema.rs
@@ -121,7 +121,7 @@ impl<'a, L: Layer> SchemaQueryContext<'a, L> {
         }
         let rdf_type_id = rdf_type_id.unwrap();
 
-        let inheritance_graph = self.get_inheritance_graph();
+        let inheritance_graph = self.get_reverse_inheritance_graph();
         itertools::Either::Right(
             self.layer
                 .triples_o(sys_set_id)


### PR DESCRIPTION
we accidentally walked the inheritance graph in the wrong direction.