### PR TITLE
Remove TERMINUSDB_LOG_PATH ENV variable

### DIFF
--- a/src/cli/main.pl
+++ b/src/cli/main.pl
@@ -2341,10 +2341,8 @@ initialise_hup :-
 :- initialise_hup.
 
 initialise_log_settings :-
-    (   getenv('TERMINUSDB_LOG_PATH', Log_Path)
-    ->  set_setting(http:logfile, Log_Path)
-    ;   get_time(Time),
-        asserta(http_log:log_stream(user_error, Time))).
+    get_time(Time),
+    asserta(http_log:log_stream(user_error, Time)).
 
 :- multifile prolog:message//1.
 

--- a/src/interactive.pl
+++ b/src/interactive.pl
@@ -26,10 +26,8 @@ initialise_hup :-
 
 
 initialise_log_settings :-
-    (   getenv('TERMINUSDB_LOG_PATH', Log_Path)
-    ->  set_setting(http:logfile, Log_Path)
-    ;   get_time(Time),
-        asserta(http_log:log_stream(user_error, Time))).
+    get_time(Time),
+    asserta(http_log:log_stream(user_error, Time)).
 
 :-multifile prolog:message//1.
 

--- a/src/start.pl
+++ b/src/start.pl
@@ -27,10 +27,8 @@ initialise_hup :-
 
 
 initialise_log_settings :-
-    (   getenv('TERMINUSDB_LOG_PATH', Log_Path)
-    ->  set_setting(http:logfile, Log_Path)
-    ;   get_time(Time),
-        asserta(http_log:log_stream(user_error, Time))).
+    get_time(Time),
+    asserta(http_log:log_stream(user_error, Time)).
 
 :-multifile prolog:message//1.
 


### PR DESCRIPTION
It does not serve a purpose since it does not actually work. And even when I got it to work by loading the http_log module it would only log the HTTP requests and not do any other sort of logging by TerminusDB.

Fixes #1572 