### PR TITLE
Graphiql no fixed host

### DIFF
--- a/src/rust/terminusdb-community/src/graphql/mod.rs
+++ b/src/rust/terminusdb-community/src/graphql/mod.rs
@@ -1,9 +1,9 @@
 use juniper::{
-    http::{graphiql::graphiql_source, GraphQLRequest},
+    http::{GraphQLRequest},
     EmptyMutation, EmptySubscription, RootNode,
 };
 
-use std::io::{Read, Write};
+use std::io::{Read};
 use std::sync::Arc;
 use swipl::prelude::*;
 
@@ -55,23 +55,8 @@ predicates! {
             Err(_) => return context.raise_exception(&term!{context: error(json_serialize_error, _)}?),
         }
     }
-
-    #[module("$graphql")]
-    semidet fn graphiql(context, path_term, output_term, port_term) {
-        let port: u64 = port_term.get_ex()?;
-        let path: String = path_term.get_ex()?;
-        let full_url: String = format!("http://localhost:{}/api/graphql/{}", port, path);
-        let source = graphiql_source(&full_url, None);
-
-        let mut stream: WritablePrologStream = output_term.get_ex()?;
-        context.try_or_die_generic(write!(stream, "Status: 200\n\n"))?;
-        context.try_or_die_generic(stream.write_all(source.as_bytes()))?;
-
-        Ok(())
-    }
 }
 
 pub fn register() {
     register_handle_request();
-    register_graphiql();
 }

--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -2970,9 +2970,8 @@ http:location(graphiql,root(graphiql),[]).
                  methods([options,get])]).
 
 graphiql_handler(_Method, Path_Atom, _Request, _System_DB, _Auth) :-
-    server_port(Port),
     atom_string(Path_Atom, Path),
-    format(string(Full_Path), "http://localhost:~d/api/graphql/~s", [Port, Path]),
+    format(string(Full_Path), "/api/graphql/~s", [Path]),
     graphiql_template(Template),
     format(string(Result), Template, [Full_Path]),
     throw(http_reply(bytes('text/html', Result))).


### PR DESCRIPTION
The graphiql endpoint always assumed `terminusdb` to be accessible on localhost. Mostly because the `graphiql` endpoint is intended as a tool for developers. However, there are certainly cases where you would like to access it under different domains.

Therefore I removed the host and port from the path as it now assumes that if you visit for instance:

`http://some-site.xyz:9090/graphiql/admin/test` that your terminusdb server is also on `http://some-site.xyz:9090`