### PR TITLE
Clippy comments

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -331,3 +331,14 @@ jobs:
             -v $(pwd):/app/terminusdb \
             terminusdb/terminusdb-server:local \
             make lint
+
+    clippy:
+      name: Clippy comments
+      runs-on: ubuntu-latest
+
+      steps:
+        - uses: actions/checkout@v2
+        - uses: actions-rs/clippy-check@v1
+          with:
+            token: ${{ secrets.GITHUB_TOKEN }}
+            args: --all-features --manifest-path=src/rust/Cargo.toml

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -332,13 +332,13 @@ jobs:
             terminusdb/terminusdb-server:local \
             make lint
 
-    clippy:
-      name: Clippy comments
-      runs-on: ubuntu-latest
+  clippy:
+    name: Clippy comments
+    runs-on: ubuntu-latest
 
-      steps:
-        - uses: actions/checkout@v2
-        - uses: actions-rs/clippy-check@v1
-          with:
-            token: ${{ secrets.GITHUB_TOKEN }}
-            args: --all-features --manifest-path=src/rust/Cargo.toml
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features --manifest-path=src/rust/Cargo.toml


### PR DESCRIPTION
This PR adds Clippy comments to the Rust code. Useful for finding things in the code that could be improved. Some things are not show-stoppers and may be a matter of taste, therefore it doesn't fail but only annotates the commits.