### PR TITLE
package-lock: fix deprecation warning by updating

### DIFF
--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -1195,13 +1195,13 @@
       }
     },
     "node_modules/eslint-plugin-mocha": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.0.4.tgz",
-      "integrity": "sha512-8wzAeepVY027oBHz/TmBmUr7vhVqoC1KTFeDybFLhbaWKx+aQ7fJJVuUsqcUy+L+G+XvgQBJY+cbAf7hl5DF7Q==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.1.0.tgz",
+      "integrity": "sha512-xLqqWUF17llsogVOC+8C6/jvQ+4IoOREbN7ZCHuOHuD6cT5cDD4h7f2LgsZuzMAiwswWE21tO7ExaknHVDrSkw==",
       "dev": true,
       "dependencies": {
         "eslint-utils": "^3.0.0",
-        "ramda": "^0.28.0"
+        "rambda": "^7.1.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -3198,15 +3198,11 @@
         }
       ]
     },
-    "node_modules/ramda": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-      "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
+    "node_modules/rambda": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/rambda/-/rambda-7.4.0.tgz",
+      "integrity": "sha512-A9hihu7dUTLOUCM+I8E61V4kRXnN4DwYeK0DwCBydC1MqNI1PidyAtbtpsJlBBzK4icSctEcCQ1bGcLpBuETUQ==",
+      "dev": true
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -4948,13 +4944,13 @@
       }
     },
     "eslint-plugin-mocha": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.0.4.tgz",
-      "integrity": "sha512-8wzAeepVY027oBHz/TmBmUr7vhVqoC1KTFeDybFLhbaWKx+aQ7fJJVuUsqcUy+L+G+XvgQBJY+cbAf7hl5DF7Q==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.1.0.tgz",
+      "integrity": "sha512-xLqqWUF17llsogVOC+8C6/jvQ+4IoOREbN7ZCHuOHuD6cT5cDD4h7f2LgsZuzMAiwswWE21tO7ExaknHVDrSkw==",
       "dev": true,
       "requires": {
         "eslint-utils": "^3.0.0",
-        "ramda": "^0.28.0"
+        "rambda": "^7.1.0"
       },
       "dependencies": {
         "eslint-utils": {
@@ -6330,10 +6326,10 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
     },
-    "ramda": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
+    "rambda": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/rambda/-/rambda-7.4.0.tgz",
+      "integrity": "sha512-A9hihu7dUTLOUCM+I8E61V4kRXnN4DwYeK0DwCBydC1MqNI1PidyAtbtpsJlBBzK4icSctEcCQ1bGcLpBuETUQ==",
       "dev": true
     },
     "randombytes": {


### PR DESCRIPTION
eslint-mocha had to be upgraded in order to fix a deprecation warning.