### PR TITLE
server: add JSON formatted welcome message

### DIFF
--- a/src/server/main.pl
+++ b/src/server/main.pl
@@ -20,6 +20,7 @@
                                        jwt_jwks_endpoint/1,
                                        server/1,
                                        server_port/1,
+                                       log_format/1,
                                        worker_amount/1,
                                        is_enterprise/0,
                                        terminusdb_version/1]).

--- a/src/server/main.pl
+++ b/src/server/main.pl
@@ -120,7 +120,7 @@ loading_page -->
 print_welcome_banner(Version, Enterprise, Argv, _, _, Server) :-
     log_format(json),
     format(user_error, '{"message": "Welcome to TerminusDB ~s! You can view your server in a browser at ~s",\c
-                          "version": "~s", "args": "~w"}~n',
+                          "version": "~s", "args": "~w", "severity": "INFO"}~n',
           [Enterprise, Server, Version, Argv]).
 print_welcome_banner(Version, Enterprise, Argv, StrTime, Now, Server) :-
     format(user_error,'~N% TerminusDB server started at ~w (utime ~w) args ~w~n',

--- a/src/server/main.pl
+++ b/src/server/main.pl
@@ -120,6 +120,7 @@ loading_page -->
 
 print_welcome_banner(Version, Enterprise, Argv, _, _, Server) :-
     log_format(json),
+    !,
     format(user_error, '{"message": "Welcome to TerminusDB ~s! You can view your server in a browser at ~s",\c
                           "version": "~s", "args": "~w", "severity": "INFO"}~n',
           [Enterprise, Server, Version, Argv]).

--- a/src/server/main.pl
+++ b/src/server/main.pl
@@ -116,15 +116,24 @@ loading_page -->
         p('TerminusDB is still synchronizing backing store')
     ]).
 
+
+print_welcome_banner(Version, Enterprise, Argv, _, _, Server) :-
+    log_format(json),
+    format(user_error, '{"message": "Welcome to TerminusDB ~s! You can view your server in a browser at ~s",\c
+                          "version": "~s", "args": "~w"}~n',
+          [Enterprise, Server, Version, Argv]).
+print_welcome_banner(Version, Enterprise, Argv, StrTime, Now, Server) :-
+    format(user_error,'~N% TerminusDB server started at ~w (utime ~w) args ~w~n',
+           [StrTime, Now, Argv]),
+    format(user_error,'% Welcome to TerminusDB\'s~w terminusdb-server, version ~s!~n',[Enterprise, Version]),
+    format(user_error,'% You can view your server in a browser at \'~s\'~n~n',[Server]).
+
 welcome_banner(Server,Argv) :-
     % Test utils currently reads this so watch out if you change it!
     get_time(Now),
     terminusdb_version(Version),
     format_time(string(StrTime), '%A, %b %d, %H:%M:%S %Z', Now, posix),
-    format(user_error,'~N% TerminusDB server started at ~w (utime ~w) args ~w~n',
-           [StrTime, Now, Argv]),
     (   is_enterprise
     ->  Enterprise = ' Enterprise'
     ;   Enterprise = ''),
-    format(user_error,'% Welcome to TerminusDB\'s~w terminusdb-server, version ~s!~n',[Enterprise, Version]),
-    format(user_error,'% You can view your server in a browser at \'~s\'~n~n',[Server]).
+    print_welcome_banner(Version, Enterprise, Argv, StrTime, Now, Server).


### PR DESCRIPTION
If the LOG_FORMAT ENV variable is set to json, it will print a JSON welcome message instead of the normal text welcome message.

This is better because it is awkward if the logs are streamed to a JSON parser but it does not always contain valid JSON.

The welcome message in this particular commit looks like this:

```
{
  "message": "Welcome to TerminusDB ! You can view your server in a browser at http://localhost:6363",
  "version": "10.1.11",
  "args": "[serve,help(false),interactive(false),memory(_250)]"
}
```