### PR TITLE
Use custom runners for CI

### DIFF
--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -54,3 +54,4 @@ jobs:
       test_ref: ${{ github.sha }}
       image_artifact: terminusdb-server-docker-image-arm64
       image_platform: linux/arm64
+      runner: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
 
   build:
     name: Docker image
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -52,7 +52,7 @@ jobs:
 
   python_client:
     name: Python client tests
-    runs-on: ${{ inputs.runner }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Set up Docker Buildx

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -52,7 +52,7 @@ jobs:
 
   python_client:
     name: Python client tests
-    runs-on: ${{ inputs.runner }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Set up Docker Buildx
@@ -95,7 +95,7 @@ jobs:
 
   integration_tests_basic:
     name: Integration tests (basic)
-    runs-on: ${{ inputs.runner }}
+    runs-on: self-hosted
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,6 +15,9 @@ on:
       image_platform:
         type: string
         default: "linux/amd64"
+      runner:
+        type: string
+        default: "self-hosted"
 
 env:
   NODE_VERSION: '16'
@@ -23,7 +26,7 @@ jobs:
 
   unit:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
 
     steps:
       - name: Set up Docker Buildx
@@ -49,7 +52,7 @@ jobs:
 
   python_client:
     name: Python client tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
 
     steps:
       - name: Set up Docker Buildx
@@ -92,7 +95,7 @@ jobs:
 
   integration_tests_basic:
     name: Integration tests (basic)
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
 
     steps:
       - uses: actions/checkout@v3
@@ -143,7 +146,7 @@ jobs:
 
   integration_tests_non_parallel:
     name: Integration tests (non-parallel)
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
 
     steps:
       - uses: actions/checkout@v3
@@ -194,7 +197,7 @@ jobs:
 
   integration_tests_header:
     name: Integration tests (header)
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
 
     steps:
       - uses: actions/checkout@v3
@@ -247,7 +250,7 @@ jobs:
 
   integration_tests_jwt:
     name: Integration tests (JWT)
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -52,7 +52,7 @@ jobs:
 
   python_client:
     name: Python client tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
 
     steps:
       - name: Set up Docker Buildx
@@ -95,7 +95,7 @@ jobs:
 
   integration_tests_basic:
     name: Integration tests (basic)
-    runs-on: self-hosted
+    runs-on: ${{ inputs.runner }}
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Use custom runners for our CI. Unfortunately, since we don't execute test files in parallel, it is not a big improvement but still cuts of a few minutes. In the future, we should aim to reduce shared state in tests in order to get them run in parallel.