### PR TITLE
Use custom way of generating tmp files

### DIFF
--- a/src/config/terminus_config.pl
+++ b/src/config/terminus_config.pl
@@ -130,9 +130,7 @@ registry_path(Value) :-
     getenv_default('TERMINUSDB_SERVER_REGISTRY_PATH', Path, Value).
 
 tmp_path(Value) :-
-    user:file_search_path(terminus_home, Dir),
-    atom_concat(Dir,'/tmp',TmpPathRelative),
-    getenv_default('TERMINUSDB_SERVER_TMP_PATH', TmpPathRelative, Value).
+    getenv_default('TERMINUSDB_SERVER_TMP_PATH', '/tmp', Value).
 
 :- table file_upload_storage_path/1 as shared.
 file_upload_storage_path(Path) :-

--- a/src/core/util/test_utils.pl
+++ b/src/core/util/test_utils.pl
@@ -67,6 +67,7 @@
 
 :- use_module(utils).
 :- use_module(file_utils).
+:- use_module(config(terminus_config)).
 
 :- use_module(core(triple)).
 :- use_module(core(transaction)).
@@ -179,10 +180,10 @@ admin_pass(Pass) :-
     ;   Pass='root').
 
 setup_unattached_store(Store-Dir) :-
-    tmp_file(temporary_terminus_store, TmpName),
+    tmp_path(Folder),
     random_string(RandomString),
-    atomic_list_concat([TmpName, RandomString], Dir),
-    make_directory(Dir),
+    atomic_list_concat([Folder, '/temporary_terminus_store/', RandomString], Dir),
+    make_directory_path(Dir),
     open_directory_store(Dir, Store),
     initialize_database_with_store('root', Store).
 


### PR DESCRIPTION
tmp_file generates wrong results sometimes and make the unit tests randomly fail. I know assume the default tmp directory to be /tmp which can be overridden using the ENV variable TERMINUSDB_SERVER_TMP_PATH.