### PR TITLE
retrieve array indexes using the correct type

### DIFF
--- a/src/rust/terminusdb-community/src/doc.rs
+++ b/src/rust/terminusdb-community/src/doc.rs
@@ -513,7 +513,7 @@ impl<'a, L: Layer> Iterator for ArrayIterator<'a, L> {
                 for index_id in self.sys_index_ids {
                     if let Some(index_triple) = self.layer.single_triple_sp(t.object, *index_id) {
                         let index_value = self.layer.id_object_value(index_triple.object).unwrap();
-                        let index = value_to_usize(&index_value);
+                        let index = value_to_array_index(&index_value);
                         indexes.push(index);
                     } else {
                         // no more indexes to come

--- a/src/rust/terminusdb-community/src/value.rs
+++ b/src/rust/terminusdb-community/src/value.rs
@@ -360,6 +360,6 @@ impl FromInputValue for ScalarInputValue {
     }
 }
 
-pub fn value_to_usize(tde: &TypedDictEntry) -> usize {
-    tde.as_val::<u32, u32>() as usize
+pub fn value_to_array_index(tde: &TypedDictEntry) -> usize {
+    tde.as_val::<NonNegativeInteger, Integer>().try_into().expect("couldn't cast array element index to a usize")
 }


### PR DESCRIPTION
The document interface was retrieving array indexes as u32, but they are actually stored as NonNegativeIntegers (despite actually being usize). This fixes the retrieval so arrays work properly in the doc interface.