### PR TITLE
Support enums in optionals for graphql queries

### DIFF
--- a/src/rust/terminusdb-community/src/graphql/schema.rs
+++ b/src/rust/terminusdb-community/src/graphql/schema.rs
@@ -693,6 +693,14 @@ impl<'a, C: QueryableContextType + 'a> GraphQLValue for TerminusType<'a, C> {
                                         },
                                         &TerminusType::new(object_id),
                                     ))
+                                } else if let Some(enum_type) = enum_type {
+                                    let enum_uri = instance.id_object_node(object_id).unwrap();
+                                    let enum_value = enum_node_to_value(enum_type, &enum_uri);
+                                    let enum_definition = allframes.frames[enum_type].as_enum_definition();
+                                    let value = juniper::Value::Scalar(DefaultScalarValue::String(
+                                        enum_definition.name_value(&enum_value).to_string(),
+                                    ));
+                                    Some(Ok(value))
                                 } else {
                                     let val = instance.id_object_value(object_id).unwrap();
                                     Some(Ok(value_to_graphql(&val)))

--- a/tests/test/graphql.js
+++ b/tests/test/graphql.js
@@ -103,7 +103,13 @@ describe('GraphQL', function () {
       '@fields': ['name'],
     },
     name: 'xsd:string',
-  }]
+  },
+  {
+    '@id': 'MaybeRocks',
+    '@type': 'Class',
+    rocks_opt: { '@type': 'Optional', '@class': 'Rocks' },
+  },
+  ]
 
   const aristotle = { '@type': 'Person', name: 'Aristotle', age: '61', order: '3', friend: ['Person/Plato'] }
   const plato = { '@type': 'Person', name: 'Plato', age: '80', order: '2', friend: ['Person/Aristotle'] }
@@ -561,6 +567,27 @@ query EverythingQuery {
 
       const result = await client.query({ query: TEST_QUERY })
       expect(result.data.Test).to.deep.equal([])
+    })
+
+    it('graphql optional enum', async function () {
+      const testObj = {
+        '@type': 'MaybeRocks',
+        rocks_opt: 'Big',
+      }
+      await document.insert(agent, { instance: testObj })
+      const TEST_QUERY = gql`
+ query TestRocks {
+    MaybeRocks{
+        rocks_opt
+    }
+}`
+
+      const result = await client.query({ query: TEST_QUERY })
+      expect(result.data.MaybeRocks).to.deep.equal([
+        {
+          rocks_opt: 'Big',
+        },
+      ])
     })
   })
 })


### PR DESCRIPTION
Enums were being retrieved as values in optional fields for graphql, but they're actually nodes. This fixes that.