### PR TITLE
Ok handler no auth

### DIFF
--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -3028,10 +3028,10 @@ cors_handler(Method, Goal, Options, R) :-
             ->  add_payload_to_request(R,Request)
             ;   Request = R),
 
-            open_descriptor(system_descriptor{}, System_Database),
             catch((   (   option(skip_authentication(true), Options)
                       ->  true
-                      ;   authenticate(System_Database, Request, Auth)),
+                      ;   open_descriptor(system_descriptor{}, System_Database),
+                          authenticate(System_Database, Request, Auth)),
                       call_http_handler(Method, Goal, Request, System_Database, Auth)),
 
                   error(authentication_incorrect(Reason),_),

--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -158,7 +158,7 @@ info_handler(get, Request, System_DB, Auth) :-
 
 
 %%%%%%%%%%%%%%%%%%%% Ping Handler %%%%%%%%%%%%%%%%%%%%%%%%%
-:- http_handler(api(ok), cors_handler(Method, ok_handler),
+:- http_handler(api(ok), cors_handler(Method, ok_handler, [skip_authentication(true)]),
                 [method(Method),
                  methods([options,get])]).
 

--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -3028,10 +3028,10 @@ cors_handler(Method, Goal, Options, R) :-
             ->  add_payload_to_request(R,Request)
             ;   Request = R),
 
+            open_descriptor(system_descriptor{}, System_Database),
             catch((   (   option(skip_authentication(true), Options)
                       ->  true
-                      ;   open_descriptor(system_descriptor{}, System_Database),
-                          authenticate(System_Database, Request, Auth)),
+                      ;   authenticate(System_Database, Request, Auth)),
                       call_http_handler(Method, Goal, Request, System_Database, Auth)),
 
                   error(authentication_incorrect(Reason),_),


### PR DESCRIPTION
This PR adds the "skip authentication" option to the `ok_handler` because the ok endpoint doesn't need authentication.