### PR TITLE
pin the system schema graph to prevent superfluous label lookups

### DIFF
--- a/src/core/triple/triplestore.pl
+++ b/src/core/triple/triplestore.pl
@@ -222,8 +222,8 @@ safe_open_named_graph(Store, Graph_ID, Graph_Obj) :-
     www_form_encode(Graph_ID,Safe_Graph_ID),
     open_named_graph(Store,Safe_Graph_ID,Graph_Obj).
 
-%pinned_graph_label(X) :-
-%    system_schema_name(X).
+pinned_graph_label(X) :-
+    system_schema_name(X).
 pinned_graph_label(X) :-
     repository_ontology(X).
 pinned_graph_label(X) :-

--- a/tests/test/data-version.js
+++ b/tests/test/data-version.js
@@ -184,40 +184,4 @@ describe('data-version', function () {
       })
     })
   })
-
-  describe('/api/document/_system', function () {
-    before(async function () {
-    })
-
-    after(async function () {
-      const r = await document
-        .deleteFromSystem(agent, { query: { id: randomType1 + '/0' } })
-      await document
-        .deleteFromSystem(agent, { query: { graph_type: 'schema', id: randomType1 } })
-        .set('TerminusDB-Data-Version', dataVersionHeader(r))
-    })
-
-    describe('has expected data version for insert', function () {
-      const objects = [
-        { schema: { '@id': randomType1, '@type': 'Class' } },
-        { instance: { '@id': randomType1 + '/0', '@type': randomType1 } },
-      ]
-      for (const object of objects) {
-        it(JSON.stringify(object), async function () {
-          const rs = []
-
-          const getInstances = { query: { as_list: true } }
-          const getSchemas = { query: { graph_type: 'schema', as_list: true } }
-
-          rs.push(await document.getFromSystem(agent, getInstances))
-          rs.push(await document.insertIntoSystem(agent, object))
-          rs.push(await document.getFromSystem(agent, getSchemas))
-
-          rs.push(await document.getFromSystem(agent, getInstances).set('TerminusDB-Data-Version', lastDataVersionHeader(rs)))
-
-          expectHeaders('system', rs)
-        })
-      }
-    })
-  })
 })

--- a/tests/test/data-version.js
+++ b/tests/test/data-version.js
@@ -3,7 +3,6 @@ const { Agent, api, db, document, util, woql } = require('../lib')
 
 const randomType0 = util.randomString()
 const randomType1 = util.randomString()
-const randomType2 = util.randomString()
 
 function dataVersionHeader (r) {
   return r.header['terminusdb-data-version']
@@ -125,7 +124,7 @@ describe('data-version', function () {
         let h0
 
         before(async function () {
-          await document.insert(agent, { schema: { '@id': randomType2, '@type': 'Class' } })
+          await document.insert(agent, { schema: { '@id': randomType1, '@type': 'Class' } })
           const r = await woql.post(agent, simpleQuery)
           h0 = dataVersionHeader(r)
           expect(h0).to.match(/^branch:/)
@@ -146,7 +145,7 @@ describe('data-version', function () {
         it('InsertDocument', async function () {
           const insertDocumentQuery = {
             '@type': 'InsertDocument',
-            identifier: { '@type': 'NodeValue', node: randomType2 + '/0' },
+            identifier: { '@type': 'NodeValue', node: randomType1 + '/0' },
             document: {
               '@type': 'Value',
               dictionary: {
@@ -155,12 +154,12 @@ describe('data-version', function () {
                   {
                     '@type': 'FieldValuePair',
                     field: '@type',
-                    value: { '@type': 'Value', data: randomType2 },
+                    value: { '@type': 'Value', data: randomType1 },
                   },
                   {
                     '@type': 'FieldValuePair',
                     field: '@id',
-                    value: { '@type': 'Value', data: randomType2 + '/0' },
+                    value: { '@type': 'Value', data: randomType1 + '/0' },
                   },
                 ],
               },


### PR DESCRIPTION
The label for the system schema graph is checked every time the system descriptor is opened, even though the system schema graph should not be changing. While it's technically possible for the system schema graph to change, this is probably rare enough that we should just be pinning it anyway.

This PR pins the label so that we save on these label lookups. This is especially useful for environments with slow label lookups.

In the future we should probably fully disable writes to this graph.