### PR TITLE
limit the default password hash cost to 10 for less roundtrips

### DIFF
--- a/src/config/terminus_config.pl
+++ b/src/config/terminus_config.pl
@@ -31,7 +31,8 @@
               pinned_databases/1,
               plugin_path/1,
               dashboard_enabled/0,
-              parallelize_enabled/0
+              parallelize_enabled/0,
+              crypto_password_cost/1
           ]).
 
 :- use_module(library(pcre)).
@@ -292,3 +293,5 @@ pinned_databases([]).
 :- table parallelize_enabled.
 parallelize_enabled :-
     getenv_default('TERMINUSDB_PARALLELIZE_ENABLED', true, true).
+
+crypto_password_cost(10).

--- a/src/core/account.pl
+++ b/src/core/account.pl
@@ -37,7 +37,8 @@
               add_organization/2,
               add_organization/3,
               add_organization_transaction/3,
-              add_user_organization_transaction/4
+              add_user_organization_transaction/4,
+              generate_password_hash/2
 
           ]).
 

--- a/src/core/api/api_access_control.pl
+++ b/src/core/api/api_access_control.pl
@@ -527,7 +527,7 @@ api_add_user(SystemDB,Auth,User,Id) :-
 
     get_dict(name, User, Name),
     (   get_dict(password, User, Password)
-    ->  crypto_password_hash(Password, Hash)
+    ->  generate_password_hash(Password, Hash)
     ;   Hash = null
     ),
     New_User =
@@ -656,7 +656,7 @@ api_update_user_password(System_DB, Auth, UserName, Password) :-
         ;   get_dict('@id', User, Auth)),
         error(access_not_authorised(Auth,'Action/manage_capabilities','SystemDatabase'), _)),
 
-    crypto_password_hash(Password, Hash),
+    generate_password_hash(Password, Hash),
     put_dict(_{ key_hash : Hash}, User, New_User),
 
     create_context(System_DB, commit_info{author: "admin", message: "API: Update User Password"},

--- a/src/core/api/api_init.pl
+++ b/src/core/api/api_init.pl
@@ -13,6 +13,7 @@
 :- use_module(core(document)).
 :- use_module(core(query), [expand/2, default_prefixes/1]).
 :- use_module(core(transaction), [open_descriptor/2]).
+:- use_module(core(account), [generate_password_hash/2]).
 
 :- use_module(config(terminus_config)).
 
@@ -23,7 +24,6 @@
 :- use_module(library(yall)).
 :- use_module(library(plunit)).
 :- use_module(library(filesex)).
-:- use_module(library(crypto)).
 :- use_module(library(git), [git_hash/2]).
 
 /**
@@ -179,7 +179,7 @@ initialize_system_instance(Store, Schema_Layer, Key, Force) :-
     open_descriptor(Descriptor, Transaction_Object),
 
     template_system_instance(Template_Instance_String),
-    crypto_password_hash(Key,Hash, [cost(15)]),
+    generate_password_hash(Key,Hash),
     format(string(Instance_String), Template_Instance_String, [Hash]),
     open_string(Instance_String, Instance_Stream),
     create_graph_from_json(Store,Instance_Name,Instance_Stream,


### PR DESCRIPTION
It turns out that password hashing is taking up a significant amount of time in TerminusDB due to the hash function being set to cycle 2^17 times, leading to hash costs in excess of 100ms. This is completely unacceptable for an API.

This PR limits the cost to 10, which means 1024 cycles. IMO there's little need for any cycling so I'm open to lowering this even more. At this point though it looks like costs for single requests fall into the noise.