### PR TITLE
Remove built-in server welcome message

### DIFF
--- a/src/server/main.pl
+++ b/src/server/main.pl
@@ -64,7 +64,7 @@ terminus_server(Argv,Wait) :-
     server_port(Port),
     worker_amount(Workers),
     load_jwt_conditionally,
-    HTTPOptions = [port(Port), workers(Workers)],
+    HTTPOptions = [port(Port), workers(Workers), silent(true)],
     foreach(pre_server_startup_hook(Port),true),
     catch(http_server(http_dispatch, HTTPOptions),
           E,


### PR DESCRIPTION
This message is not needed as we already print our own welcome message, including on which port it is running.

It is also printed regardless of whether you are setting the log format to JSON which is very annoying as you get JSON parsing errors that way. Removing that green welcome message solves the problem and I do think that our own welcome message is clear enough.