### PR TITLE
Remove benchmark in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,13 +120,6 @@ jobs:
       test_repository: ${{ github.repository }}
       test_ref: ${{ github.sha }}
 
-  benchmark:
-    name: Benchmark
-    if: github.repository == 'terminusdb/terminusdb' && github.ref == 'refs/heads/main'
-    uses: ./.github/workflows/benchmark.yml
-    secrets: inherit
-
-
  # This is required for status checks.
   all_checks_pass_with_build:
     name: All checks pass


### PR DESCRIPTION
It is pretty unstable. We should mature it a bit and then enable it again. But now, it fails too many times in order to make it run reliably.