### PR TITLE
When a clone fails, delete the database

### DIFF
--- a/src/core/api/db_clone.pl
+++ b/src/core/api/db_clone.pl
@@ -29,15 +29,11 @@ clone_cleanup_required(remote_pack_unpexected_failure(_)).
 clone_cleanup_required(error(http_open_error(_), _)).
 clone_cleanup_required(error(remote_connection_failure(_, _), _)).
 
-:- meta_predicate clone_(+,+,+,+,+,+,+,+,+,3,-).
-clone_(System_DB,Auth,Account,DB,Label,Comment,Public,Remote,Source,Fetch_Predicate,Meta_Data) :-
+do_clone_(Auth,Account,DB,Remote,Source, Fetch_Predicate,Meta_Data) :-
+    open_descriptor(system_descriptor{}, System_DB),
+
     % Is this local or over the network
     remote_path(Source, Remote_Path),
-
-    % Create DB
-    create_db_unfinalized(System_DB, Auth, Account, DB, Label, Comment, false, Public, _{'@base' : 'http://example.com/', '@schema' : 'http://example.com#'}, Db_Uri),
-
-    open_descriptor(system_descriptor{}, System_DB2),
 
     resolve_absolute_descriptor([Account,DB,"_meta"], Database_Descriptor),
     create_context(Database_Descriptor, Database_Context),
@@ -57,8 +53,8 @@ clone_(System_DB,Auth,Account,DB,Label,Comment,Public,Remote,Source,Fetch_Predic
 
     % Fetch remote
     (   Remote_Path = db(_Remote_Team,_Remote_DB)
-    ->  local_fetch(System_DB2, Auth, From_Path, _New_Head, _Has_Updated)
-    ;   remote_fetch(System_DB2, Auth, From_Path, Fetch_Predicate, _New_Head, _Has_Updated)
+    ->  local_fetch(System_DB, Auth, From_Path, _New_Head, _Has_Updated)
+    ;   remote_fetch(System_DB, Auth, From_Path, Fetch_Predicate, _New_Head, _Has_Updated)
     ),
 
     resolve_absolute_descriptor([Account,DB,"local","branch","main"], To_Branch_Descriptor),
@@ -67,7 +63,21 @@ clone_(System_DB,Auth,Account,DB,Label,Comment,Public,Remote,Source,Fetch_Predic
     % Fast forward commits from master in remote to master in local
     fast_forward_branch(To_Branch_Descriptor, From_Branch_Descriptor, Applied_Commits),
 
-    finalize_db(Db_Uri),
-
     Meta_Data = _{ applied_commits : Applied_Commits }.
+
+
+:- meta_predicate clone_(+,+,+,+,+,+,+,+,+,3,-).
+clone_(System_DB,Auth,Account,DB,Label,Comment,Public,Remote,Source,Fetch_Predicate,Meta_Data) :-
+    % Create DB
+    create_db_unfinalized(System_DB, Auth, Account, DB, Label, Comment, false, Public, _{'@base' : 'http://example.com/', '@schema' : 'http://example.com#'}, Db_Uri),
+
+    catch_with_backtrace(do_clone_(Auth,Account,DB,Remote,Source,Fetch_Predicate,Meta_Data),
+                         Error,
+                         true),
+
+    (   var(Error)
+    ->  finalize_db(Db_Uri)
+    ;   force_delete_db(Account, DB),
+        throw(Error)).
+
 


### PR DESCRIPTION
The database was being left in an inconsistent state, requiring a force delete. Since we're in a code path where we just created the database, we know it is safe to delete it. This is the more user friendly approach.