### PR TITLE
Revert "Utility image (#1714)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,16 +236,12 @@ jobs:
 
           echo "docker_tags=${TAGS}" >> $GITHUB_ENV
 
-      - name: Create new image manifest and create debug image
+      - name: Create new image manifest
         run: |
           TAGS="${{ env.docker_tags }}"
           for TAG in ${TAGS//,/ }
           do
               docker buildx imagetools create -t $TAG terminusdb/terminusdb-server:dev-amd64-$GITHUB_SHA terminusdb/terminusdb-server:dev-arm64-$GITHUB_SHA
-              # Replace version in Dockerfile with latest pushed version
-              sed -i "s/latest/$TAG/" distribution/Dockerfile.utility
-              sudo docker buildx build . -f distribution/Dockerfile.utility -t terminusdb/terminusdb-utility-image:"$TAG"
-              sudo docker push terminusdb/terminusdb-utility-image:"$TAG"
           done
 
   trigger_enterprise_build:

--- a/distribution/Dockerfile.utility
+++ b/distribution/Dockerfile.utility
@@ -1,4 +1,0 @@
-FROM terminusdb/terminusdb-server:latest
-RUN apt update -y && \
-    apt install curl git less vim make -y
-CMD ["/bin/bash"]


### PR DESCRIPTION
This reverts commit ef0d849ca3601460e83aa938504374507ad3db1f because of the failing CI. I know what is wrong but it is better to get CI up and running quickly before taking more time to fix the issue.

<!--
Thanks for taking the time to contribute!

Is this your first pull request? If you don't mind, please read this first.

<https://github.com/terminusdb/terminusdb/blob/main/docs/CONTRIBUTING.md>
-->
