### PR TITLE
Gyear behaviour patch

### DIFF
--- a/src/core/query/json_woql.pl
+++ b/src/core/query/json_woql.pl
@@ -1494,7 +1494,7 @@ test(gyear_int, []) :-
                                       "@type": "xsd:gYear"}}}',
     atom_json_dict(JSON_Atom, JSON, []),
     json_woql(JSON,WOQL),
-    WOQL = (v('X')=gyear(2004,0.0)^^'http://www.w3.org/2001/XMLSchema#gYear').
+    WOQL = (v('X')=gyear(2004,0)^^'http://www.w3.org/2001/XMLSchema#gYear').
 
 test(gyear_month, []) :-
     JSON_Atom= '{"@type": "Equals",

--- a/src/core/triple/casting.pl
+++ b/src/core/triple/casting.pl
@@ -919,8 +919,25 @@ test(positive_decimal_round_trip, []) :-
     ].
 
 test(gyear_to_string, []) :-
-    typecast(gyear(1990,0.0)^^'http://www.w3.org/2001/XMLSchema#gYear',
+    typecast(gyear(1990,0)^^'http://www.w3.org/2001/XMLSchema#gYear',
              'http://www.w3.org/2001/XMLSchema#string', [], "1990"^^'http://www.w3.org/2001/XMLSchema#string').
+
+test(string_to_gyear, []) :-
+    typecast("1990"^^'http://www.w3.org/2001/XMLSchema#string',
+             'http://www.w3.org/2001/XMLSchema#gYear', [],
+             gyear(1990,0)^^'http://www.w3.org/2001/XMLSchema#gYear').
+
+test(integer_to_gyear, []) :-
+    typecast(1990^^'http://www.w3.org/2001/XMLSchema#integer',
+             'http://www.w3.org/2001/XMLSchema#gYear', [],
+             gyear(1990,0)^^'http://www.w3.org/2001/XMLSchema#gYear').
+
+test(float_cast, []) :-
+    typecast("0.5679"^^'http://www.w3.org/2001/XMLSchema#string',
+             'http://www.w3.org/2001/XMLSchema#decimal',
+             [],
+             0.5679^^'http://www.w3.org/2001/XMLSchema#decimal').
+
 
 test(float_cast, []) :-
     typecast("0.5679"^^'http://www.w3.org/2001/XMLSchema#string',

--- a/src/core/triple/casting.pl
+++ b/src/core/triple/casting.pl
@@ -345,7 +345,7 @@ typecast_switch('http://www.w3.org/2001/XMLSchema#gYear', 'http://www.w3.org/200
 typecast_switch('http://www.w3.org/2001/XMLSchema#gYear', 'http://www.w3.org/2001/XMLSchema#decimal', Val, _, Cast^^'http://www.w3.org/2001/XMLSchema#gYear') :-
     !,
     (   integer(Val)
-    ->  Cast = gyear(Val,0.0)
+    ->  Cast = gyear(Val,0)
     ;   throw(error(casting_error(Val,'http://www.w3.org/2001/XMLSchema#gYear'),_))).
 %%% xsd:gYear => xsd:string
 typecast_switch('http://www.w3.org/2001/XMLSchema#string', 'http://www.w3.org/2001/XMLSchema#gYear', Val, _, S^^'http://www.w3.org/2001/XMLSchema#string') :-


### PR DESCRIPTION
This fixes a very serious bug in the interpretation of gYear from integer objects. Previously it would always crash with a type_error. 
