### PR TITLE
Fix slow db query that improves /api/db speed

### DIFF
--- a/src/core/account/capabilities.pl
+++ b/src/core/account/capabilities.pl
@@ -511,12 +511,12 @@ user_accessible_database(DB, User_ID, Org, Name, Database) :-
     ->  atom_string(Name, Name_S)
     ;   true),
     ask(DB,
-        (   t(Database_ID, name, Name_S^^xsd:string),
+        (   t(User_ID, capability, Capability_ID),
+            path(Capability_ID, (star(p(scope)),p(database)), Database_ID),
             isa(Database_ID, 'UserDatabase'),
+            t(Database_ID, name, Name_S^^xsd:string),
             t(Org_Id, database, Database_ID),
             t(Org_Id, name, Org_S^^xsd:string),
-            t(User_ID, capability, Capability_ID),
-            path(Capability_ID, (star(p(scope)),p(database)), Database_ID),
             get_document(Database_ID, Database)
         )),
     (   var(Org)


### PR DESCRIPTION
Getting the list of DB's for a particular user was very slow because an inefficient query. This query is now reordered to make it faster. Measurements show that the performance increased about ~9 times.