### PR TITLE
Return 204 on doc delete (and disable chunking for non-gets)

### DIFF
--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -431,7 +431,6 @@ triples_handler(put,Path,Request, System_DB, Auth) :-
 :- http_handler(api(document/Path), cors_handler(Method, document_handler(Path), [add_payload(false)]),
                 [method(Method),
                  prefix,
-                 chunked,
                  time_limit(infinite),
                  methods([head,options,post,delete,get,put])]).
 
@@ -573,7 +572,7 @@ document_handler(delete, Path, Request, System_DB, Auth) :-
 
             write_cors_headers(Request),
             write_data_version_header(New_Data_Version),
-            nl,nl
+            format("Status: 204~n~n")
         )).
 
 document_handler(put, Path, Request, System_DB, Auth) :-
@@ -3320,6 +3319,7 @@ cors_reply_json(Request, JSON, Options) :-
 cors_json_stream_write_headers_(Request, Data_Version, As_List) :-
     write_cors_headers(Request),
     write_data_version_header(Data_Version),
+    format("Transfer-Encoding: chunked~n"),
     (   As_List = true
     ->  % Write the JSON header
         format("Content-type: application/json; charset=UTF-8~n~n")

--- a/tests/lib/api/response.js
+++ b/tests/lib/api/response.js
@@ -246,7 +246,7 @@ module.exports = {
       }
     },
     deleteSuccess: {
-      status: 200,
+      status: 204,
     },
     deleteFailure (errorObject) {
       const result = {


### PR DESCRIPTION
Fixes #1728 .

In addition to returning the correct status code for deletes, this will also only use `Transfer-Encoding: chunked` for the get version of the document api endpoint. We were running into an issue where with this header present, the swipl http logic would insert chunk information even after an empty response. This is probably a swipl bug.

We'll need to verify that this doesn't break the javascript or python client. 