### PR TITLE
table the check_db predicate to prevent superfluous disk accesses

### DIFF
--- a/src/core/triple/check_db.pl
+++ b/src/core/triple/check_db.pl
@@ -35,10 +35,12 @@ database_version(2).
  *
  * Reports the version associated with the current backing store
  */
+:- table get_db_version/1.
 get_db_version(Version) :-
     db_path(Path),
     get_db_version(Path, Version).
 
+:- table get_db_version/2.
 get_db_version(Path, Version) :-
     storage_version_path(Path, Version_File),
     (   exists_file(Version_File)


### PR DESCRIPTION
Every call to `api/info` would be opening a store version file to check the store version.
I think we can assume that this version won't be updating while the server is running. Since we're calling this endpoint on each client initialization it's probably good to cache the result instead.