### PR TITLE
Nukes choice objects properly

### DIFF
--- a/src/core/document/json.pl
+++ b/src/core/document/json.pl
@@ -8011,6 +8011,30 @@ test(double_choice_error,
                                            message: "foo" },
                         Document, _).
 
+test(delete_choice, [
+          setup(
+             (   setup_temp_store(State),
+                 test_document_label_descriptor(Desc),
+                 write_schema(schema2,Desc)
+             )),
+         cleanup(
+             teardown_temp_store(State)
+         )
+     ]) :-
+    with_test_transaction(
+        Desc,
+        C,
+        delete_schema_document(C, 'EnumChoice')
+    ),
+    \+
+        ask(Desc,
+            (
+                t(Id, rdf:type, sys:'Choice', schema),
+                t(Id, a, sys:'Unit', schema),
+                t(Id, b, sys:'Unit', schema),
+                t(Id, c, sys:'Unit', schema),
+                t(Id, d, sys:'Unit', schema))).
+
 test(double_choice_triples,[]) :-
     Document = json{'@id':'http://s/DoubleChoice',
                     '@type':'http://terminusdb.com/schema/sys#Class',

--- a/src/core/document/schema.pl
+++ b/src/core/document/schema.pl
@@ -701,10 +701,6 @@ is_documentation(Type) :-
                  sys:'DocumentationLabelComment'], List),
     memberchk(Type, List).
 
-is_choice_type(Type) :-
-    prefix_list([sys:'Lexical', sys:'Hash', sys:'ValueHash', sys:'Random'], List),
-    memberchk(Type, List).
-
 refute_class_key(Validation_Object,Class,Witness) :-
     database_schema(Validation_Object,Schema),
     xrdf_added(Schema, Class, sys:key, Key_Obj),

--- a/src/core/document/schema.pl
+++ b/src/core/document/schema.pl
@@ -594,7 +594,8 @@ type_family_constructor(Type) :-
             sys:'Array',
             sys:'Table',
             sys:'Cardinality',
-            sys:'Optional'
+            sys:'Optional',
+            sys:'Choice'
         ],
         List),
     memberchk(Type,List).
@@ -698,6 +699,10 @@ is_key(Type) :-
 is_documentation(Type) :-
     prefix_list([sys:'SchemaDocumentation', sys:'PropertyDocumentation', sys:'Documentation',
                  sys:'DocumentationLabelComment'], List),
+    memberchk(Type, List).
+
+is_choice_type(Type) :-
+    prefix_list([sys:'Lexical', sys:'Hash', sys:'ValueHash', sys:'Random'], List),
     memberchk(Type, List).
 
 refute_class_key(Validation_Object,Class,Witness) :-


### PR DESCRIPTION
Cascading delete on choice properties in the schema was not properly working as choice was not deemed a type which needed to be transitively explored.