### PR TITLE
Performance bump with inferred migrations as schema-instance check

### DIFF
--- a/src/config/terminus_config.pl
+++ b/src/config/terminus_config.pl
@@ -35,7 +35,8 @@
               parallelize_enabled/0,
               grpc_label_endpoint/1,
               crypto_password_cost/1,
-              lru_cache_size/1
+              lru_cache_size/1,
+              trust_migrations/0
           ]).
 
 :- use_module(library(pcre)).
@@ -319,3 +320,7 @@ crypto_password_cost(10).
 :- table lru_cache_size/1.
 lru_cache_size(Cache_Size) :-
     getenv_default_number('TERMINUSDB_LRU_CACHE_SIZE', 512, Cache_Size).
+
+:- table trust_migrations/0.
+trust_migrations :-
+    getenv('TERMINUSDB_TRUST_MIGRATIONS', true).

--- a/src/config/terminus_config.pl
+++ b/src/config/terminus_config.pl
@@ -36,9 +36,8 @@
               grpc_label_endpoint/1,
               crypto_password_cost/1,
               lru_cache_size/1,
-              trust_migrations/0,
-              fetch_timeout/1
-          ]).
+              trust_migrations/0
+]).
 
 :- use_module(library(pcre)).
 

--- a/src/core/document.pl
+++ b/src/core/document.pl
@@ -100,7 +100,8 @@
               perform_instance_migration/5,
               perform_instance_migration_on_transaction/4,
               infer_weakening_migration/3,
-              infer_arbitrary_migration/3
+              infer_arbitrary_migration/3,
+              operations_are_weakening/1
           ]).
 
 :- use_module('document/validation').

--- a/src/core/document/migration.pl
+++ b/src/core/document/migration.pl
@@ -2,7 +2,8 @@
               perform_instance_migration/5,
               perform_instance_migration_on_transaction/4,
               infer_weakening_migration/3,
-              infer_arbitrary_migration/3
+              infer_arbitrary_migration/3,
+              operations_are_weakening/1
           ]).
 
 :- use_module(instance).
@@ -1102,6 +1103,14 @@ perform_instance_migration_on_transaction(Before_Transaction, Operations, After_
     ;   Result = metadata{ schema_operations: Op_Count,
                            instance_operations: Count }
     ).
+
+
+operation_is_weakening(create_class(_)).
+operation_is_weakening(create_class_property(_,_,_)).
+operation_is_weakening(upcast_class_property(_,_,_)).
+
+operations_are_weakening(L) :-
+    maplist(operation_is_weakening, L).
 
 :- begin_tests(migration).
 

--- a/src/core/document/validation.pl
+++ b/src/core/document/validation.pl
@@ -45,7 +45,8 @@ needs_schema_instance_validation(Validation_Object) :-
     exists(validation_object_has_layer, Instance_Objects),
     exists(validation_object_changed, Schema_Objects),
     \+ is_schemaless(Validation_Object),
-    \+ (   get_dict(commit_info, Validation_Object, CI),
+    \+ (   config:trust_migrations,
+           get_dict(commit_info, Validation_Object, CI),
            ground(CI),
            % existance of a migration should be proof
            % that we don't need to check


### PR DESCRIPTION
Improves the performance of instance checking by not doing it at all if an inferred migration exists. The reasoning is that the schema migrations fix the instance data appropriately as is, and so any inferred migration is sufficient to avoid a global schema-instance check which is very expensive with large datasets.