### PR TITLE
Fix memory leak by abolishing tables on each request

### DIFF
--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -3184,6 +3184,7 @@ cors_handler(Method, Goal, Options, R) :-
                                    'api:message' : 'Incorrect authentication information'
                                   },
                                  [width(0), status(401)]))))),
+    abolish_private_tables,
     !.
 cors_handler(_Method, Goal, _Options, R) :-
     write_cors_headers(R),


### PR DESCRIPTION
This fixes a memory leak where simple document gets would not get the private tables in SWI Prolog wiped.