### PR TITLE
Block sends of documents to print beyond a multiple of thread count

### DIFF
--- a/src/rust/terminusdb-community/src/doc.rs
+++ b/src/rust/terminusdb-community/src/doc.rs
@@ -827,7 +827,8 @@ fn par_print_documents_of_types<C: QueryableContextType, L: Layer + 'static>(
     let count: Option<u64> = attempt_opt(count_term.get())?;
     let as_list: bool = as_list_term.get_ex()?;
 
-    let (sender, receiver) = mpsc::channel();
+    let channel_size = rayon::current_num_threads() * 2;
+    let (sender, receiver) = mpsc::sync_channel(channel_size);
 
     // cloning here cause we need to use the doc context from two places.
     // Since we are dealing with an arc, the clone is cheap.


### PR DESCRIPTION
We were seeing that while parallel fetching documents, generating their json struct can easily outperform printing the json. This causes documents to get queued up in a message channel, increasing the memory footprint without improving performance.

This PR switches to a synchronized channel, blocking sends when there's more than a certain amount of documents still in the message queue.