### PR TITLE
ci: add major tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,9 @@ jobs:
           # Tag and push the latest image when a version tag is pushed
           # We also make sure that rc and beta are not pushed to the latest tag!
           if [ $(echo "$GITHUB_REF" | grep "refs/tags/v" | grep -v "rc" | grep -v "beta") ]; then
-            TAGS="${TAGS},${LATEST_IMAGE}"
+            # Get the major tag, for instance v11 if the version is v11.0.4
+            VERSION_MAJOR=$(echo "$VERSION" | cut -d '.' -f 1)
+            TAGS="${TAGS},${LATEST_IMAGE},terminusdb/terminusdb-server:${VERSION_MAJOR}"
           fi
 
           echo "docker_tags=${TAGS}" >> $GITHUB_ENV


### PR DESCRIPTION
If a new release is tagged, we also push a major tag now without containing the full version. For instance, when someone pushes a new tag called v11.0.4, it will update the v11 tag with this new image.

The reason for this is that it is easier for users to track minor releases this way.