### PR TITLE
Fix clone timeouts by polling remote server

### DIFF
--- a/src/config/terminus_config.pl
+++ b/src/config/terminus_config.pl
@@ -35,7 +35,8 @@
               parallelize_enabled/0,
               grpc_label_endpoint/1,
               crypto_password_cost/1,
-              lru_cache_size/1
+              lru_cache_size/1,
+              fetch_timeout/1
           ]).
 
 :- use_module(library(pcre)).
@@ -140,6 +141,13 @@ tmp_path(Value) :-
 :- table file_upload_storage_path/1 as shared.
 file_upload_storage_path(Path) :-
     getenv('TERMINUSDB_FILE_STORAGE_PATH', Path).
+
+:- table fetch_timeout/1 as shared.
+fetch_timeout(Timeout) :-
+    (   getenv('TERMINUSDB_FETCH_TIMEOUT', TimeOutEnv)
+    ->  atom_number(TimeOutEnv, Timeout)
+    ;   Timeout = inf
+    ).
 
 server(Server) :-
     server_protocol(Protocol),

--- a/src/core/api.pl
+++ b/src/core/api.pl
@@ -35,7 +35,10 @@
               unpack/1,
               pack/5,
               pack_from_context/3,
+              pack_in_background/5,
               layer_layerids/2,
+              check_pack_status/2,
+              try_open_pack/3,
 
               % db_fetch.pl
               remote_fetch/6,

--- a/src/core/api/db_fetch.pl
+++ b/src/core/api/db_fetch.pl
@@ -69,10 +69,34 @@ remote_pack_url(URL, Pack_URL) :-
     append(Pre, ["api", "pack", Organization, Database], All_Parts),
     merge_separator_split(Pack_URL,'/',All_Parts).
 
+get_fetch_payload(URL, Resource_Id, Payload) :-
+    get_fetch_payload(URL, Resource_Id, 0, Payload).
+
+get_fetch_payload(URL, Resource_Id, Count, Payload) :-
+    uri_encoded(query_value, Resource_Id, Encoded_Resource_Id),
+    atomic_list_concat([URL, '?', 'resource_id=', Encoded_Resource_Id], Resource_URL),
+    http_get(Resource_URL, _, [status_code(Status_Code), method(head)]),
+    (   Status_Code = 200
+    ->  http_get(Resource_URL, Data, [status(Status_Code), size(Length)]),
+        (   Length = 0
+        ->  Payload = none
+        ;   Status_Code = 200
+        ->  Payload = some(Data)
+        ;   throw(error(existence_error(url, Resource_URL)))
+        )
+    ;   fetch_timeout(Timeout),
+        Timeout < Count
+    ->  throw(error(time_limit_exceeded, _))
+    ;   sleep(5),
+        New_Count is Count + 5,
+        get_fetch_payload(URL, Resource_Id, New_Count, Payload)
+    ).
+
+
 authorized_fetch(Authorization, URL, Repository_Head_Option, Payload_Option) :-
     (   some(Repository_Head) = Repository_Head_Option
-    ->  Document = _{ repository_head: Repository_Head }
-    ;   Document = _{}),
+    ->  Document = _{ repository_head: Repository_Head, resource_id: true }
+    ;   Document = _{ resource_id: true }),
 
     remote_pack_url(URL,Pack_URL),
     terminusdb_version(Version),
@@ -87,7 +111,15 @@ authorized_fetch(Authorization, URL, Repository_Head_Option, Payload_Option) :-
         throw(error(http_open_error(Err), _))
     ),
 
-    (   Status = 200
+    (   Status = 401
+    ->  throw(error(remote_connection_failure(Status, Payload), _))
+    ;   Status = 403
+    ->  throw(error(remote_connection_failure(Status, Payload), _))
+    ;   is_dict(Payload)
+    ->  do_or_die(_{ resource_id: Resource_ID } :< Payload,
+                  error(missing_parameter(resource_id), _)),
+        get_fetch_payload(Pack_URL, Resource_ID, Payload_Option)
+    ;   Status = 200
     ->  Payload_Option = some(Payload)
     ;   Status = 204
     ->  Payload_Option = none

--- a/src/core/api/db_fetch.pl
+++ b/src/core/api/db_fetch.pl
@@ -11,6 +11,7 @@
 :- use_module(core(transaction)).
 :- use_module(db_pack).
 :- use_module(library(ssl)).
+:- use_module(library(uri)).
 :- use_module(library(http/http_client)).
 :- use_module(library(plunit)).
 :- use_module(library(lists)).
@@ -84,7 +85,7 @@ get_fetch_payload(URL, Resource_Id, Count, Payload) :-
         ->  Payload = some(Data)
         ;   throw(error(existence_error(url, Resource_URL)))
         )
-    ;   fetch_timeout(Timeout),
+    ;   config:fetch_timeout(Timeout),
         Timeout < Count
     ->  throw(error(time_limit_exceeded, _))
     ;   sleep(5),

--- a/src/core/api/db_pack.pl
+++ b/src/core/api/db_pack.pl
@@ -1,5 +1,8 @@
 :- module(db_pack, [
               payload_repository_head_and_pack/3,
+              pack_in_background/5,
+              check_pack_status/2,
+              try_open_pack/3,
               repository_head_layerid/2,
               pack/5,
               pack_from_context/3,
@@ -13,9 +16,12 @@
 :- use_module(core(transaction)).
 :- use_module(core(triple)).
 :- use_module(core(account)).
+:- use_module(core(document), [idgen_random/2]).
 
 :- use_module(library(lists)).
+:- use_module(library(uri)).
 :- use_module(library(apply)).
+:- use_module(library(shell), [mv/2]).
 :- use_module(library(plunit)).
 
 payload_repository_head_and_pack(Data, Head, Pack) :-
@@ -40,6 +46,58 @@ repository_context__previous_head_option__current_repository_head__pack(Reposito
         storage(Store),
         pack_export(Store,Layer_Ids,Pack),
         Pack_Option = some(Pack)).
+
+get_pack_storage_path(FilePath) :-
+    (   config:file_upload_storage_path(FilePath)
+    ->  true
+    ;   config:tmp_path(FilePath)
+    ).
+
+pack_partial_filename(Random, Part_Filename) :-
+    get_pack_storage_path(FilePath),
+    atomic_list_concat([FilePath, '/', Random, '.part'], Part_Filename).
+
+pack_processed_filename(Random, Processed_Filename) :-
+    get_pack_storage_path(FilePath),
+    atomic_list_concat([FilePath, '/', Random], Processed_Filename).
+
+pack_in_background(System_DB, Auth, Path, Repo_Head_Option, Resource_ID) :-
+    idgen_random(Path, Unsafe_Random),
+    uri_encoded(segment, Unsafe_Random, Random),
+    pack_partial_filename(Random, Part_Filename),
+    pack_processed_filename(Random, Processed_Filename),
+    open(Part_Filename, write, FileStream),
+    thread_create(
+        (    pack(System_DB, Auth, Path, Repo_Head_Option, Payload_Option),
+             (   Payload_Option = some(Payload)
+             ->  write(FileStream, Payload)
+             ;   true
+             ),
+             close(FileStream),
+             mv(Part_Filename, Processed_Filename)
+        ), _, [detached(true)]),
+    Resource_ID = Random.
+
+check_pack_status(Resource_Id, Status) :-
+    pack_processed_filename(Resource_Id, Processed_Filename),
+    pack_partial_filename(Resource_Id, Partial_Filename),
+
+    (   exists_file(Partial_Filename)
+    ->  Status = busy
+    ;   exists_file(Processed_Filename)
+    ->  Status = complete
+    ;   Status = unknown
+    ).
+
+try_open_pack(Resource_Id, Size, Stream) :-
+    pack_processed_filename(Resource_Id, Processed_Filename),
+    catch(
+        (    open(Processed_Filename, read, Stream),
+             size_file(Processed_Filename, Size)
+        ),
+        error(existence_error(source_sink, _), _),
+        fail
+    ).
 
 pack(System_DB, Auth, Path, Repo_Head_Option, Payload_Option) :-
     atomic_list_concat([Path, '/local/_commits'], Repository_Path),


### PR DESCRIPTION
Instead of waiting for the pack to be finished, we now poll the remote server for when the pack is finished and then fetch the pack.

We use a 5 second interval between the polls, which is long but might be better to save resources.