### PR TITLE
Fix missing import for superuser check

### DIFF
--- a/src/core/api/api_indexer.pl
+++ b/src/core/api/api_indexer.pl
@@ -11,6 +11,7 @@
 :- use_module(core(query)).
 :- use_module(core(transaction)).
 :- use_module(core(util)).
+:- use_module(core(account)).
 :- use_module(library(http/json)).
 :- use_module(library(http/http_client)).
 :- use_module(core(api/api_graphql)).


### PR DESCRIPTION
The predicate `is_super_user` was used but the appropriate module wasn't imported.