### PR TITLE
docker-compose: remove CR team name env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,6 @@ services:
       - USER_KEY=${TERMINUSDB_USER_KEY}
       - USER_NAME=${TERMINUSDB_USER_NAME}
       - OPENAI_SERVER_URL=http://vectorlink:8080
-      - CR_TEAM_NAME=terminusCR
 
       # There are multiple ways to configure TerminusDB security through
       # environment variables. Several reasonable options are included below.


### PR DESCRIPTION
Remove the ENV variable for CR team because it is confusing and we have a default now