### PR TITLE
Graphql id deep match

### DIFF
--- a/src/rust/terminusdb-community/src/graphql/filter.rs
+++ b/src/rust/terminusdb-community/src/graphql/filter.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use juniper::{
     DefaultScalarValue, FromInputValue, GraphQLInputObject, GraphQLType, GraphQLValue, InputValue,
-    Registry,
+    Registry, ID,
 };
 
 use crate::value::{base_type_kind, BaseTypeKind};
@@ -150,6 +150,8 @@ impl GraphQLType for FilterInputObject {
 
                 args.push(registry.arg::<Option<GeneratedEnum>>("_restriction", &type_info));
             }
+
+            args.push(registry.arg::<Option<ID>>("_id", &()));
 
             args.push(registry.arg::<Option<Vec<FilterInputObject>>>(
                 "_and",

--- a/src/rust/terminusdb-community/src/graphql/filter.rs
+++ b/src/rust/terminusdb-community/src/graphql/filter.rs
@@ -152,6 +152,7 @@ impl GraphQLType for FilterInputObject {
             }
 
             args.push(registry.arg::<Option<ID>>("_id", &()));
+            args.push(registry.arg::<Option<Vec<ID>>>("_ids", &()));
 
             args.push(registry.arg::<Option<Vec<FilterInputObject>>>(
                 "_and",

--- a/src/rust/terminusdb-community/src/graphql/query.rs
+++ b/src/rust/terminusdb-community/src/graphql/query.rs
@@ -403,7 +403,13 @@ fn compile_edges_to_filter(
                 .expect("restriction value in filter was not a string");
             restriction = Some(expected.value);
         } else if field_name == "_id" {
-            ids.push(spanning_input_value.item.as_string_value().expect("id to match on should have been a stringy value").to_owned());
+            ids.push(
+                spanning_input_value
+                    .item
+                    .as_string_value()
+                    .expect("id to match on should have been a stringy value")
+                    .to_owned(),
+            );
         } else {
             let field = class_definition.resolve_field(field_name);
             let prefixes = &all_frames.context;
@@ -662,9 +668,7 @@ fn compile_query<'a, C: QueryableContextType>(
     let mut iter = iter;
     if !filter.ids.is_empty() {
         let resolved_ids: Vec<_> = filter.ids.iter().flat_map(|s| g.subject_id(s)).collect();
-        iter = ClonableIterator::new(iter.filter(move |id| {
-            resolved_ids.contains(id)
-        }));
+        iter = ClonableIterator::new(iter.filter(move |id| resolved_ids.contains(id)));
     }
     if let Some(restriction_name) = filter.restriction.clone() {
         iter = ClonableIterator::new(iter.filter(move |id| {

--- a/src/rust/terminusdb-community/src/graphql/query.rs
+++ b/src/rust/terminusdb-community/src/graphql/query.rs
@@ -7,6 +7,7 @@ use swipl::prelude::QueryableContextType;
 use terminusdb_store_prolog::terminus_store::structure::{Decimal, TdbDataType, TypedDictEntry};
 
 use crate::path::iterator::{CachedClonableIterator, ClonableIterator};
+use crate::path::{Path, Pred};
 use crate::terminus_store::store::sync::SyncStoreLayer;
 
 use crate::value::{base_type_kind, value_to_bigint, value_to_string, BaseTypeKind};
@@ -23,10 +24,10 @@ use super::schema::{
     TerminusOrderBy, TerminusOrdering,
 };
 
-use crate::path::compile::path_to_class;
+use crate::path::compile::{compile_path, path_to_class};
 
 use std::cmp::*;
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 use std::rc::Rc;
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
@@ -53,7 +54,7 @@ enum TextOperation {
     AnyOfTerms(Vec<String>),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 enum CollectionOperation {
     SomeHave,
     AllHave,
@@ -80,7 +81,7 @@ enum FilterType {
     Enum { op: EnumOperation, value: String },
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum FilterValue {
     Required(FilterObjectType),
     // Optional(OptionalOperation),
@@ -808,6 +809,99 @@ fn compile_query<'a, C: QueryableContextType>(
     iter
 }
 
+fn generate_iterator_from_filter<'a>(
+    g: &'a SyncStoreLayer,
+    class_name: &'a str,
+    all_frames: &AllFrames,
+    filter_opt: Option<&FilterObject>,
+    includes_children: bool,
+) -> Option<ClonableIterator<'a, u64>> {
+    if filter_opt.is_none() {
+        return None;
+    }
+
+    let filter = filter_opt.unwrap();
+    let mut iter = None;
+    let mut visit_next: VecDeque<(Vec<&str>, &FilterObject)> = VecDeque::new();
+    visit_next.push_back((vec![], filter));
+    while let Some(mut next) = visit_next.pop_front() {
+        if !next.1.ids.is_empty() {
+            // amazing we found something.
+            let ids: Vec<_> = next.1.ids.iter().flat_map(|id| g.subject_id(id)).collect();
+            let id_iter = ClonableIterator::new(ids.into_iter());
+            next.0.reverse();
+            let components: Vec<_> = next
+                .0
+                .into_iter()
+                .map(|component| Path::Negative(Pred::Named(component.to_string())))
+                .collect();
+            let path = Some(Path::Seq(components));
+            iter = Some(compile_path(
+                g,
+                all_frames.context.clone(),
+                path.unwrap(),
+                id_iter,
+            ));
+            break;
+        } else {
+            // nothing here :( push children.
+            for e in next.1.edges.iter() {
+                let mut path = next.0.clone();
+                path.push(&e.0);
+                match &e.1 {
+                    FilterValue::Required(FilterObjectType::Node(next_f, _)) => {
+                        visit_next.push_back((path, &next_f))
+                    }
+                    FilterValue::Collection(
+                        CollectionOperation::SomeHave,
+                        FilterObjectType::Node(next_f, _),
+                    ) => visit_next.push_back((path, &next_f)),
+                    FilterValue::And(next_fs) => {
+                        for next_f in next_fs.iter() {
+                            visit_next.push_back((path.clone(), next_f));
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    if let Some(iter) = iter {
+        // we have collected a path leading up to this point. Let's filter it down to the expected type.
+        let expanded_type_name = all_frames.fully_qualified_class_name(class_name);
+        if includes_children {
+            let correct_types: Vec<_> = all_frames
+                .subsumed(class_name)
+                .into_iter()
+                .map(|c| all_frames.fully_qualified_class_name(&c))
+                .flat_map(|id| g.subject_id(&id))
+                .collect();
+            let rdf_type_id = g.predicate_id(RDF_TYPE);
+            if rdf_type_id.is_none() {
+                // no types means nothing can be retrieved
+                return None;
+            }
+            let rdf_type_id = rdf_type_id.unwrap();
+            Some(ClonableIterator::new(iter.filter(move |id| {
+                match g.single_triple_sp(*id, rdf_type_id) {
+                    Some(t) => correct_types.contains(&t.object),
+                    None => false,
+                }
+            })))
+        } else {
+            Some(predicate_value_filter(
+                g,
+                RDF_TYPE,
+                &ObjectType::Node(expanded_type_name),
+                iter,
+            ))
+        }
+    } else {
+        // no path was found. we default to None
+        None
+    }
+}
+
 fn generate_initial_iterator<'a>(
     g: &'a SyncStoreLayer,
     class_name: &'a str,
@@ -819,18 +913,33 @@ fn generate_initial_iterator<'a>(
     match zero_iter {
         None => {
             // If we have a filter here, we probably need to use it.
-            let subsuming = if includes_children {
-                all_frames.subsumed(class_name)
-            } else {
-                vec![class_name.to_string()]
-            };
-            let mut iter = ClonableIterator::new(std::iter::empty());
-            for super_class in subsuming {
-                let super_class = all_frames.fully_qualified_class_name(&super_class);
-                let next = predicate_value_iter(g, RDF_TYPE, &ObjectType::Node(super_class));
-                iter = ClonableIterator::new(iter.chain(next))
+            match generate_iterator_from_filter(
+                g,
+                class_name,
+                all_frames,
+                filter_opt.as_ref(),
+                includes_children,
+            ) {
+                Some(zi) => (filter_opt, zi),
+                None => {
+                    let subsuming = if includes_children {
+                        all_frames.subsumed(class_name)
+                    } else {
+                        vec![class_name.to_string()]
+                    };
+                    let mut iter = ClonableIterator::new(std::iter::empty());
+                    for sub_class in subsuming {
+                        let sub_class_expanded = all_frames.fully_qualified_class_name(&sub_class);
+                        let next = predicate_value_iter(
+                            g,
+                            RDF_TYPE,
+                            &ObjectType::Node(sub_class_expanded),
+                        );
+                        iter = ClonableIterator::new(iter.chain(next))
+                    }
+                    (filter_opt, iter)
+                }
             }
-            (filter_opt, iter)
         }
         Some(zi) => (filter_opt, zi),
     }

--- a/src/rust/terminusdb-community/src/path/compile.rs
+++ b/src/rust/terminusdb-community/src/path/compile.rs
@@ -49,6 +49,58 @@ fn compile_path<'a>(
                 .map(move |sub_path| compile_path(g, prefixes.clone(), sub_path, branch.clone()));
             ClonableIterator::new(result.flatten())
         }
+        Path::Branch(vec) => {
+            let branch = iter.clone();
+            let result = vec
+                .into_iter()
+                .map(move |sub_path| compile_path(g, prefixes.clone(), sub_path, branch.clone()));
+            ClonableIterator::new(
+                std::iter::once_with(move || {
+                    let mut sets: Vec<_> =
+                        result.map(|iter| iter.collect::<HashSet<_>>()).collect();
+                    match sets.pop() {
+                        None => ClonableIterator::new(std::iter::empty()),
+                        Some(initial) => {
+                            let final_set = sets.into_iter().fold(initial, |prev, s| {
+                                prev.intersection(&s).copied().collect::<HashSet<_>>()
+                            });
+                            let final_list: Vec<_> = final_set.into_iter().collect();
+                            ClonableIterator::new(final_list.into_iter())
+                        }
+                    }
+                })
+                .flatten(),
+            )
+        }
+        Path::Collide(mut vec) => {
+            let first = vec.pop();
+            if first.is_none() {
+                return ClonableIterator::new(std::iter::empty());
+            }
+            let first = first.unwrap();
+            let mut iter = compile_path(g, prefixes.clone(), first, iter);
+            for path in vec {
+                let reversed = path.reverse();
+                let prefixes = prefixes.clone();
+                // annoyingly this compiles the path over and over
+                // again. It would have been better if we could have
+                // fed our initial iterator directly into
+                // compile_path. Unfortunately, this results in an
+                // iterator where we don't know what destination
+                // resulted from what origin.
+                iter = ClonableIterator::new(iter.filter(move |v| {
+                    compile_path(
+                        g,
+                        prefixes.clone(),
+                        reversed.clone(),
+                        ClonableIterator::new(std::iter::once(*v)),
+                    )
+                    .next()
+                    .is_some()
+                }));
+            }
+            iter
+        }
         Path::Positive(p) => match p {
             Pred::Any => ClonableIterator::new(iter.flat_map(move |object| {
                 CachedClonableIterator::new(g.triples_s(object).map(|t| t.object))

--- a/src/rust/terminusdb-community/src/path/compile.rs
+++ b/src/rust/terminusdb-community/src/path/compile.rs
@@ -29,7 +29,7 @@ pub fn path_to_class<'a, 'b>(
     )
 }
 
-fn compile_path<'a>(
+pub fn compile_path<'a>(
     g: &'a SyncStoreLayer,
     prefixes: Prefixes,
     path: Path,

--- a/src/rust/terminusdb-community/src/path/parse.rs
+++ b/src/rust/terminusdb-community/src/path/parse.rs
@@ -32,6 +32,29 @@ pub enum Path {
     Plus(Rc<Path>),
     Star(Rc<Path>),
     Times(Rc<Path>, usize, usize),
+    Branch(Vec<Path>),
+    Collide(Vec<Path>),
+}
+
+impl Path {
+    pub fn reverse(&self) -> Path {
+        match self {
+            Path::Positive(pred) => Path::Negative(pred.clone()),
+            Path::Negative(pred) => Path::Positive(pred.clone()),
+            Path::Seq(vec) => {
+                let mut result: Vec<_> = vec.iter().map(|v| v.reverse()).collect();
+                result.reverse();
+
+                Path::Seq(result)
+            }
+            Path::Plus(path) => Path::Plus(Rc::new(path.reverse())),
+            Path::Star(path) => Path::Star(Rc::new(path.reverse())),
+            Path::Times(path, m, n) => Path::Times(Rc::new(path.reverse()), *m, *n),
+            Path::Choice(vec) => Path::Choice(vec.iter().map(|p| p.reverse()).collect()),
+            Path::Branch(vec) => Path::Collide(vec.iter().map(|p| p.reverse()).collect()),
+            Path::Collide(vec) => Path::Branch(vec.iter().map(|p| p.reverse()).collect()),
+        }
+    }
 }
 
 fn is_property_char(c: char) -> bool {


### PR DESCRIPTION
This PR introduces a way to match on a node id through the filter object.

So far it's only been possible to match on id directly as part of the graphql operator looking up an object from a collection. It was not possible to match on the id of one of its children.

This introduces the syntax for it, and internally makes use of path queries to come up with a candidate iterator that should be more efficient than going through all types and checking.