### PR TITLE
simple lru caching for graphql context

### DIFF
--- a/src/core/api/api_graphql.pl
+++ b/src/core/api/api_graphql.pl
@@ -61,5 +61,8 @@ handle_graphql_request(System_DB, Auth, Method, Path_Atom, Input_Stream, Respons
         Meta_DB = none
     ),
     assert_read_access(System_DB, Auth, Desc, type_filter{types:[instance,schema]}),
-    all_class_frames(Transaction, Frames, [compress_ids(true),expand_abstract(true),simple(true)]),
-    '$graphql':handle_request(Method, Frames, System_DB, Meta_DB, Commit_DB, Transaction, Auth, Content_Length, Input_Stream, Response).
+    (   '$graphql':get_cached_graphql_context(Transaction, Graphql_Context)
+    ->  true
+    ;   all_class_frames(Transaction, Frames, [compress_ids(true),expand_abstract(true),simple(true)]),
+        '$graphql':get_graphql_context(Transaction, Frames, Graphql_Context)),
+    '$graphql':handle_request(Method, Graphql_Context, System_DB, Meta_DB, Commit_DB, Transaction, Auth, Content_Length, Input_Stream, Response).

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -47,6 +47,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,6 +870,10 @@ name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -1173,6 +1183,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "718e8fae447df0c7e1ba7f5189829e63fd536945c8988d61444c19039f16b670"
 dependencies = [
  "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "lru"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eedb2bdbad7e0634f83989bf596f497b070130daaa398ab22d84c39e266deec5"
+dependencies = [
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -2007,7 +2026,7 @@ dependencies = [
  "hex",
  "itertools",
  "lazy_static",
- "lru",
+ "lru 0.10.1",
  "num-derive",
  "num-traits",
  "rand 0.8.5",
@@ -2036,6 +2055,7 @@ dependencies = [
  "lazy-init",
  "lazy_static",
  "lcs",
+ "lru 0.11.0",
  "nom",
  "ordered-float",
  "rand 0.8.5",

--- a/src/rust/terminusdb-community/Cargo.toml
+++ b/src/rust/terminusdb-community/Cargo.toml
@@ -32,3 +32,4 @@ nom = "7.1"
 chrono = { version="0.4", features=["serde"]}
 handlebars = "4.3"
 thiserror = "1.0"
+lru = "0.11"

--- a/src/rust/terminusdb-community/src/graphql/schema.rs
+++ b/src/rust/terminusdb-community/src/graphql/schema.rs
@@ -238,6 +238,7 @@ impl<'a, C: QueryableContextType + 'a> GraphQLType for TerminusTypeCollection<'a
 }
 
 #[derive(Clone)]
+#[clone_blob("terminus_type_collection_info", defaults)]
 pub struct TerminusTypeCollectionInfo {
     pub allframes: Arc<AllFrames>,
 }


### PR DESCRIPTION
Adding an LRU cache to graphql to keep the most recent 10 terminusdb schema compiles in memory, speeding up repeated graphql queries, especially when the schema is pretty big.