### PR TITLE
vscode project files

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,43 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug terminusdb (REPL)",
+            "program": "swipl",
+            "args": [
+                "-f",
+                "src/interactive.pl"
+            ],
+            "cwd": "${workspaceFolder}",
+            "sourceLanguages": [
+                "rust",
+                "c"
+            ],
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug terminusdb server (REPL)",
+            "program": "swipl",
+            "args": [
+                "-f",
+                "src/interactive.pl",
+                "-g",
+                "terminus_server([], false)"
+            ],
+            "cwd": "${workspaceFolder}",
+            "env": {
+                "TERMINUSDB_SERVER_PORT": "6363"
+            },
+            "sourceLanguages": [
+                "rust",
+                "c"
+            ],
+        },
+    ]
+}

--- a/.vscode/lldb_pre_setup_swipl_path.py
+++ b/.vscode/lldb_pre_setup_swipl_path.py
@@ -1,0 +1,11 @@
+import subprocess
+import lldb
+
+def setup_swipl_path():
+    swipl_path = subprocess.check_output("cargo swipl info -l", shell=True).decode('UTF-8').strip()
+    old_path = lldb.target.GetEnvironment().Get('LD_LIBRARY_PATH')
+    if old_path:
+        new_path = f"{swipl_path}:{old_path}"
+    else:
+        new_path = swipl_path
+    lldb.debugger.HandleCommand(f'env LD_LIBRARY_PATH="{new_path}"')

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+    "rust-analyzer.linkedProjects": [
+        "src/rust/Cargo.toml"
+    ],
+    "lldb.launch.preRunCommands": [
+        "script sys.path.append('${workspaceFolder}/.vscode/')",
+        "script import lldb_pre_setup_swipl_path",
+        "script lldb_pre_setup_swipl_path.setup_swipl_path()"
+    ],
+    "terminal.integrated.profiles.linux": {
+        "bash-swipl": {
+            "path": "bash",
+            "icon": "terminal-bash",
+            "args": [
+                "--init-file",
+                "${workspaceRoot}/.vscode/setup_shell.sh"
+            ]
+        },
+        test   },
+    "terminal.integrated.defaultProfile.linux": "bash-swipl",
+    "rust-analyzer.runnables.command": "cargo-swipl"
+}

--- a/.vscode/setup_shell.sh
+++ b/.vscode/setup_shell.sh
@@ -1,0 +1,1 @@
+source <(cargo swipl listenv)

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,69 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "make: terminusdb rust module",
+            "type": "shell",
+            "command": "make rust",
+            "group": "build",
+            "problemMatcher": {
+                "base": "$rustc",
+                "fileLocation": [
+                    "relative",
+                    "${workspaceFolder}/src/rust/"
+                ]
+            }
+        },
+        {
+            "label": "make: terminusdb",
+            "type": "shell",
+            "command": "make",
+            "dependsOn": [
+                "make: rust module"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": [
+                "$rustc"
+            ]
+        },
+        {
+            "label": "test: terminusdb rust",
+            "type": "shell",
+            "dependsOn": [
+                "make: rust module"
+            ],
+            "group": {
+                "kind": "test",
+            },
+            "command": "cd src/rust/;cargo swipl test --release",
+        },
+        {
+            "label": "test: terminusdb prolog",
+            "type": "shell",
+            "dependsOn": [
+                "make: rust module"
+            ],
+            "group": {
+                "kind": "test",
+            },
+            "command": "make test"
+        },
+        {
+            "label": "test: terminusdb",
+            "type": "shell",
+            "dependsOn": [
+                "test: terminusdb rust",
+                "test: terminusdb prolog",
+            ],
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            },
+        }
+    ]
+}


### PR DESCRIPTION
This PR introduces vscode project files for those that want to use vscode.

Specifically, this PR introduces a bunch of launch, build and test tasks, and common workspace settings, as well as some scripts needed to set up an environment where the various targets can find the right version of SWI-Prolog.
This setup requires cargo-swipl to be installed.

## launch tasks
- debug terminusdb server in LLDB
- debug a swipl repl through LLDB with terminusdb loaded, but no server started

## build tasks
- build the rust module
- build terminusdb

## test tasks
- run rust unit tests through cargo test
- run the terminusdb prolog tests

## common settings
- discovery of nested rust project
- ensure that lldb can find the swi-prolog library
- ensure that rust-analyzer uses the `cargo-swipl` wrapper to run all cargo commands
- ensure that launched terminals have swi-prolog environments set
