### PR TITLE
snap: copy src folder in final snap

### DIFF
--- a/distribution/snap/snapcraft.yaml
+++ b/distribution/snap/snapcraft.yaml
@@ -62,7 +62,8 @@ parts:
       cd /snap/terminusdb/current
       make install-dashboard
       make
-      cp -r terminusdb distribution dashboard "$SNAPCRAFT_PART_INSTALL/"
+      rm -rf src/rust
+      cp -r terminusdb distribution dashboard src "$SNAPCRAFT_PART_INSTALL/"
     build-environment:
       - TERMINUSDB_SERVER_PACK_DIR: /root/stage
       - LANG: C.UTF-8


### PR DESCRIPTION
We rely on some files that are present in the src folder. For instance, the ref.json. We remove the rust folder though because the artifacts are really big and we don't rely on those files at runtime.