### PR TITLE
Simplify docker-compose

### DIFF
--- a/distribution/docker-compose/bootstrap_storage.yaml
+++ b/distribution/docker-compose/bootstrap_storage.yaml
@@ -1,0 +1,10 @@
+version: "3"
+
+services:
+  terminusdb-server:
+    volumes:
+      - terminusdb_storage:/app/terminusdb/storage
+volumes:
+  terminusdb_storage:
+    external: true
+    name: terminusdb_storage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     tty: true
     ports:
       - 6363:6363
+    env_file: .env
     environment:
       - TERMINUSDB_SERVER_PORT=6363
       # DISABLE THESE ENV VARIABLES WHEN RUNNING TERMINUSDB IN PRODUCTION
@@ -21,24 +22,22 @@ services:
       - ./storage:/app/terminusdb/storage
   vectorlink:
     image: terminusdb/vectorlink:v0.0.8
+    env_file: .env
     environment:
       - TERMINUSDB_CONTENT_ENDPOINT=http://terminusdb-server:6363/api/index
       - TERMINUSDB_USER_FORWARD_HEADER=X-User-Forward
-      - BUFFER_AMOUNT=120000
     volumes:
       - ./vector_storage:/app/storage
-    command: ["./terminusdb-semantic-indexer", "serve", "--directory", "/app/storage", "--size", "${BUFFER_AMOUNT:-120000}"]
+    command: ["./terminusdb-semantic-indexer", "serve", "--directory", "/app/storage"]
   change-request-api:
     image: terminusdb/terminusdb-change-request-api:v0.0.7
+    env_file: .env
     ports:
       - 3035:3035
     environment:
       - SERVER_ENDPOINT=http://terminusdb-server:6363
       - USE_CHANGE_REQUEST=${USE_CHANGE_REQUEST:-true}
       # Add your OpenAI key in a .env file
-      - OPENAI_KEY=${OPENAI_KEY}
-      - USER_KEY=${TERMINUSDB_USER_KEY}
-      - USER_NAME=${TERMINUSDB_USER_NAME}
       - OPENAI_SERVER_URL=http://vectorlink:8080
 
       # There are multiple ways to configure TerminusDB security through


### PR DESCRIPTION
We don't need to repeat all the environment variables anymore but they can all be declared globally in the .env file

I also added a new bootstrap_storage override yaml which can be run using:

`docker compose -f docker-compose.yml -f distribution/docker-compose/bootstrap_storage.yaml`

<!--
Thanks for taking the time to contribute!

Is this your first pull request? If you don't mind, please read this first.

<https://github.com/terminusdb/terminusdb/blob/main/docs/CONTRIBUTING.md>
-->
