### PR TITLE
ci: don't depend on external infra

### DIFF
--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   arm64_docker:
-    runs-on: buildjet-2vcpu-ubuntu-2204-arm
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
 
   build:
     name: Docker image
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,7 +20,7 @@ on:
         default: "ubuntu-latest"
       mocha_jobs:
         type: string
-        default: "4"
+        default: "2"
       mocha_parallel:
         type: boolean
         default: true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,7 +20,7 @@ on:
         default: "ubuntu-latest"
       mocha_jobs:
         type: string
-        default: "2"
+        default: "1"
       mocha_parallel:
         type: boolean
         default: true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,7 +17,7 @@ on:
         default: "linux/amd64"
       runner:
         type: string
-        default: "self-hosted"
+        default: "ubuntu-latest"
       mocha_jobs:
         type: string
         default: "4"


### PR DESCRIPTION
It is better for the community if it is only depending on GitHub infra instead of custom AWS infrastructure or BuildJet machines.