### PR TITLE
Fix compression of @base in document interface

### DIFF
--- a/src/rust/terminusdb-community/src/prefix.rs
+++ b/src/rust/terminusdb-community/src/prefix.rs
@@ -87,7 +87,7 @@ impl PrefixContracter {
 
         items.push(Prefix::JSON);
 
-        items.sort_by(|p1, p2| p1.expansion().cmp(p2.expansion()));
+        items.sort_by(|p1, p2| (p1.expansion(), p2).cmp(&(p2.expansion(), p1)));
         items.dedup();
         items.reverse();
 


### PR DESCRIPTION
If there was a prefix used which compressed with the same URL as `@base`, then this prefix was used preferentially. This has been changed so that the `@base` prefix is used preferentially. 