### PR TITLE
properly detect cycles in unfoldables when collections are involved

### DIFF
--- a/src/core/document/json.pl
+++ b/src/core/document/json.pl
@@ -6527,6 +6527,70 @@ test(oneof_unfoldable,
          _
      ).
 
+bad_unfoldable_col_schema(ColType, Schema) :-
+    format(atom(Schema),
+           '
+{"@type": "@context",
+ "@base": "terminusdb:///base/",
+ "@schema": "terminusdb:///schema#"}
+{"@type": "Class",
+ "@id": "Foo",
+ "@unfoldable": [],
+ "link": {"@type": "~s",
+          "@class": "Foo"}
+}',
+           [ColType]).
+
+test(bad_unfoldable_col,
+     [
+         setup(
+             (   setup_temp_store(State),
+                 test_document_label_descriptor(Desc)
+             )),
+         cleanup(
+             teardown_temp_store(State)
+         ),
+         forall(member(Col, ['Optional', 'Set', 'List', 'Array'])),
+         error(
+             schema_check_failure(
+                 [witness{'@type':property_path_cycle_detected,
+                          class:'terminusdb:///schema#Foo',
+                          path:['terminusdb:///schema#link','terminusdb:///schema#Foo']}]),
+             _)
+     ]) :-
+    write_schema(bad_unfoldable_col_schema(Col),Desc).
+
+bad_unfoldable_card_schema('
+{"@type": "@context",
+ "@base": "terminusdb:///base/",
+ "@schema": "terminusdb:///schema#"}
+{"@type": "Class",
+ "@id": "Foo",
+ "@unfoldable": [],
+ "link": {"@type": "Cardinality",
+          "@class": "Foo",
+          "@minCardinality": "3",
+          "@maxCardinality": "5"}
+}').
+
+test(bad_unfoldable_card,
+     [
+         setup(
+             (   setup_temp_store(State),
+                 test_document_label_descriptor(Desc)
+             )),
+         cleanup(
+             teardown_temp_store(State)
+         ),
+         error(
+             schema_check_failure(
+                 [witness{'@type':property_path_cycle_detected,
+                          class:'terminusdb:///schema#Foo',
+                          path:['terminusdb:///schema#link','terminusdb:///schema#Foo']}]),
+             _)
+     ]) :-
+    write_schema(bad_unfoldable_card_schema,Desc).
+
 test(always_smaller_unfoldable,
      [
          setup(

--- a/src/core/document/schema.pl
+++ b/src/core/document/schema.pl
@@ -478,10 +478,16 @@ is_circular_hasse_diagram(Validation_Object,Witness) :-
                   path : Path
               }.
 
+type_to_reachable_class(_Schema, class(C), C) :- !.
+type_to_reachable_class(Schema, Type, C) :-
+    type_descriptor_inner_type(Type, C),
+    is_schema_simple_class(Schema, C).
+
 reachable_unfoldable(Schema,A,P,B) :-
     distinct(B,
              (   schema_class_subsumed(Schema,A,C),
-                 schema_class_predicate_type(Schema,C,P,class(B)),
+                 schema_class_predicate_type(Schema,C,P,Type),
+                 type_to_reachable_class(Schema, Type, B),
                  schema_is_unfoldable(Schema,B)
              )).
 
@@ -1034,6 +1040,14 @@ schema_type_descriptor(Schema, Type, optional(Class)) :-
     xrdf(Schema, Type, rdf:type, sys:'Optional'),
     !,
     xrdf(Schema, Type, sys:class, Class).
+
+type_descriptor_inner_type(class(C), C).
+type_descriptor_inner_type(set(C), C).
+type_descriptor_inner_type(cardinality(C, _, _), C).
+type_descriptor_inner_type(optional(C), C).
+type_descriptor_inner_type(list(C), C).
+type_descriptor_inner_type(array(C,_), C).
+type_descriptor_inner_type(table(C), C).
 
 key_base(Validation_Object, Context, Type, Base) :-
     database_schema(Validation_Object, Schema),


### PR DESCRIPTION
This ensures the schema checker will reject schemas where collections of unfoldables lead to cycles.