### PR TITLE
Fix reorder of not and get document

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2297,6 +2297,10 @@ components:
           description: WOQL Query
         "commit_info":
           $ref: "#/components/schemas/CommitInfo"
+        "optimize":
+          type: boolean
+          description: Allow reordering of queries
+          default: true
         "all_witnesses":
           type: boolean
           description: Check for all errors

--- a/docs/terminusdb.1.ronn
+++ b/docs/terminusdb.1.ronn
@@ -103,6 +103,9 @@ Query a database.
   * `-a`, `--author`=[value]:
   author to place on the commit
 
+  * `-o`, `--optimize`=[value]:
+  allow query reordering
+
   * `-j`, `--json`=[value]:
   return results as a json object
 

--- a/src/cli/main.pl
+++ b/src/cli/main.pl
@@ -164,7 +164,7 @@ opt_spec(query,'terminusdb query DB_SPEC QUERY OPTIONS',
            shortflags([o]),
            longflags([optimize]),
            default(true),
-           help('allow query reordering')]
+           help('allow query reordering')],
           [opt(json),
            type(boolean),
            longflags([json]),

--- a/src/cli/main.pl
+++ b/src/cli/main.pl
@@ -159,6 +159,12 @@ opt_spec(query,'terminusdb query DB_SPEC QUERY OPTIONS',
            shortflags([a]),
            default('admin'),
            help('author to place on the commit')],
+          [opt(optimize),
+           type(boolean),
+           shortflags([o]),
+           longflags([optimize]),
+           default(true),
+           help('allow query reordering')]
           [opt(json),
            type(boolean),
            longflags([json]),
@@ -1595,12 +1601,18 @@ run_command(query,[Path,Query],Opts) :-
 
     option(author(Author), Opts),
     option(message(Message), Opts),
+    option(optimize(Optimize), Opts),
 
     Commit_Info = commit_info{author : Author, message : Message},
 
     api_report_errors(
         woql,
-        (   woql_query_json(System_DB, Auth, some(Path), atom_query(Query), Commit_Info, [], _All_Witnesses, no_data_version, _New_Data_Version, Context, Response),
+        (   Options = _{ commit_info: Commit_Info,
+                         files: [],
+                         optimize: Optimize,
+                         data_version: no_data_version,
+                         all_witnesses: false },
+            woql_query_json(System_DB, Auth, some(Path), atom_query(Query), Context, _New_Data_Version, Response, Options),
             (   option(json(true), Opts)
             ->  json_write_dict(current_output, Response, [])
             ;   get_dict(prefixes, Context, Context_Prefixes),

--- a/src/core/api.pl
+++ b/src/core/api.pl
@@ -67,7 +67,7 @@
               api_filled_frame/5,
 
               % api_woql.pl
-              woql_query_json/11,
+              woql_query_json/8,
 
               % api_squash.pl
               api_squash/6,

--- a/src/core/api/api_woql.pl
+++ b/src/core/api/api_woql.pl
@@ -4,6 +4,8 @@
 :- use_module(core(transaction)).
 :- use_module(core(account)).
 
+:- use_module(library(option)).
+
 woql_query_json(System_DB, Auth, Path_Option, Query, Context, New_Data_Version, JSON, Options) :-
 
     option(commit_info(Commit_Info), Options),

--- a/src/core/api/api_woql.pl
+++ b/src/core/api/api_woql.pl
@@ -1,10 +1,15 @@
-:- module(api_woql, [woql_query_json/11]).
+:- module(api_woql, [woql_query_json/8]).
 :- use_module(core(util)).
 :- use_module(core(query)).
 :- use_module(core(transaction)).
 :- use_module(core(account)).
 
-woql_query_json(System_DB, Auth, Path_Option, Query, Commit_Info, Files, All_Witnesses, Requested_Data_Version, New_Data_Version, Context, JSON) :-
+woql_query_json(System_DB, Auth, Path_Option, Query, Context, New_Data_Version, JSON, Options) :-
+
+    option(commit_info(Commit_Info), Options),
+    option(all_witnesses(All_Witnesses), Options),
+    option(files(Files), Options),
+    option(data_version(Requested_Data_Version), Options),
 
     % No descriptor to work with until the query sets one up
     (   some(Path) = Path_Option
@@ -31,7 +36,7 @@ woql_query_json(System_DB, Auth, Path_Option, Query, Commit_Info, Files, All_Wit
     ->  atom_woql(Atom_Query, AST)
     ;   throw(error(unexpected_query_type(Query), _))
     ),
-    run_context_ast_jsonld_response(Context, AST, Requested_Data_Version, New_Data_Version, JSON).
+    run_context_ast_jsonld_response(Context, AST, Requested_Data_Version, New_Data_Version, JSON, Options).
 
 bind_vars([],_).
 bind_vars([Name=Var|Tail],AST) :-

--- a/src/core/document/json.pl
+++ b/src/core/document/json.pl
@@ -84,7 +84,7 @@
 :- use_module(library(apply)).
 :- use_module(library(yall)).
 :- use_module(library(apply_macros)).
-
+% assorted libs
 :- use_module(library(terminus_store)).
 :- use_module(library(http/json)).
 :- use_module(library(lists)).

--- a/src/core/query.pl
+++ b/src/core/query.pl
@@ -51,7 +51,7 @@
               json_value_cast_type/3,
 
               % query_response.pl
-              run_context_ast_jsonld_response/5,
+              run_context_ast_jsonld_response/6,
               pretty_print_query_response/3,
 
               % resolve_query_resource.pl
@@ -73,8 +73,8 @@
               % woql_compile.pl
               lookup/3,
               lookup_backwards/3,
-              compile_query/3,
               compile_query/4,
+              compile_query/5,
               empty_context/1,
               empty_context/2,
               filter_transaction_object_read_write_objects/3,

--- a/src/core/query.pl
+++ b/src/core/query.pl
@@ -51,6 +51,7 @@
               json_value_cast_type/3,
 
               % query_response.pl
+              run_context_ast_jsonld_response/5,
               run_context_ast_jsonld_response/6,
               pretty_print_query_response/3,
 

--- a/src/core/query/ask.pl
+++ b/src/core/query/ask.pl
@@ -345,7 +345,7 @@ ask(Askable, Pre_Term, Options) :-
  * Ask a woql query and get back the resulting context.
  */
 ask_ast(Context, Ast, Output_Context) :-
-    compile_query(Ast,Prog, Context, Output_Context),
+    compile_query(Ast,Prog, Context, Output_Context, _{optimize: true}),
     debug(terminus(sdk),'Program: ~q~n', [Prog]),
 
     woql_compile:Prog.

--- a/src/core/query/query_response.pl
+++ b/src/core/query/query_response.pl
@@ -1,5 +1,6 @@
 :- module(query_response,[
-              run_context_ast_jsonld_response/5,
+              run_context_ast_jsonld_response/6,
+              run_context_ast_jsonld_response/7,
               pretty_print_query_response/3
           ]).
 
@@ -16,12 +17,16 @@
 :- use_module(library(lists)).
 :- use_module(library(yall)).
 
+run_context_ast_jsonld_response(Context, AST, Requested_Data_Version, New_Data_Version, Binding_JSON) :-
+    Options = _{},
+    run_context_ast_jsonld_response(Context, AST, Requested_Data_Version, New_Data_Version, Binding_JSON, Options).
+
 /** <module> Query Response
  *
  * Code to generate bindings for query response in JSON-LD
  */
-run_context_ast_jsonld_response(Context, AST, Requested_Data_Version, New_Data_Version, Binding_JSON) :-
-    compile_query(AST,Prog,Context,Output_Context),
+run_context_ast_jsonld_response(Context, AST, Requested_Data_Version, New_Data_Version, Binding_JSON, Options) :-
+    compile_query(AST,Prog,Context,Output_Context,Options),
     do_or_die(
         query_default_collection(Output_Context, Transaction),
         error(query_default_collection_failed_unexpectedly(Output_Context), _)),

--- a/src/core/query/query_response.pl
+++ b/src/core/query/query_response.pl
@@ -1,6 +1,6 @@
 :- module(query_response,[
+              run_context_ast_jsonld_response/5,
               run_context_ast_jsonld_response/6,
-              run_context_ast_jsonld_response/7,
               pretty_print_query_response/3
           ]).
 

--- a/src/core/query/woql_compile.pl
+++ b/src/core/query/woql_compile.pl
@@ -1,8 +1,8 @@
 :- module(woql_compile,[
               lookup/3,
               lookup_backwards/3,
-              compile_query/3,
               compile_query/4,
+              compile_query/5,
               empty_context/1,
               empty_context/2,
               filter_transaction_object_read_write_objects/3,

--- a/src/core/query/woql_compile.pl
+++ b/src/core/query/woql_compile.pl
@@ -4815,8 +4815,7 @@ test(quad_compilation, [
     Commit_Info = commit_info{author: "a", message: "m"},
     create_context(Descriptor, Commit_Info, Context),
     Ctx_In = (Context.put(authorization, Auth)),
-
-    compile_query(Term, _Prog, Ctx_In, _Ctx_Out).
+    compile_query(Term, _Prog, Ctx_In, _Ctx_Out, options{}).
 
 :- use_module(core(document)).
 test(document_path, [

--- a/src/core/query/woql_compile.pl
+++ b/src/core/query/woql_compile.pl
@@ -4740,6 +4740,7 @@ test(less_than, [
                     some("TERMINUSQA/test"),
                     json_query(Query),
                     _,
+                    _,
                     JSON,
                     Options),
     [_] = (JSON.bindings).
@@ -4796,6 +4797,7 @@ test(using_resource_works, [
                     Auth,
                     some("TERMINUSQA/test"),
                     json_query(Query),
+                    _,
                     _,
                     _JSON,
                     Options).

--- a/src/core/query/woql_compile.pl
+++ b/src/core/query/woql_compile.pl
@@ -402,12 +402,15 @@ var_compare(Op, Left, Right) :-
 /*
  * compile_query(+Term:any,-Prog:any,-Ctx_Out:context) is det.
  */
-compile_query(Term, Prog, Ctx_Out) :-
+compile_query(Term, Prog, Ctx_Out, Options) :-
     empty_context(Ctx_In),
-    compile_query(Term,Prog,Ctx_In,Ctx_Out).
+    compile_query(Term,Prog,Ctx_In,Ctx_Out,Options).
 
-compile_query(Term, Prog, Ctx_In, Ctx_Out) :-
-    (   safe_guard_removal(Term, Optimized),
+compile_query(Term, Prog, Ctx_In, Ctx_Out, Options) :-
+    (   (   option(optimize(true), Options)
+        ->  safe_guard_removal(Term, Optimized)
+        ;   Term = Optimized
+        ),
         assert_pre_flight_access(Ctx_In, Term),
         do_or_die(compile_wf(Optimized, Pre_Prog, Ctx_In, Ctx_Out),
                   error(woql_syntax_error(badly_formed_ast(Term)),_)),
@@ -4726,17 +4729,19 @@ test(less_than, [
 
     Commit_Info = commit_info{author: "TERMINUSQA", message: "less than"},
 
+    Options = _{
+                  commit_info: Commit_Info,
+                  all_witnesses: false,
+                  files: [],
+                  data_version: no_data_version
+              },
     woql_query_json(system_descriptor{},
                     Auth,
                     some("TERMINUSQA/test"),
                     json_query(Query),
-                    Commit_Info,
-                    [],
-                    false,
-                    no_data_version,
                     _,
-                    _,
-                    JSON),
+                    JSON,
+                    Options),
     [_] = (JSON.bindings).
 
 
@@ -4780,17 +4785,20 @@ test(using_resource_works, [
 
     Commit_Info = commit_info{author: "TERMINUSQA", message: "less than"},
 
+    Options = _{
+                  commit_info: Commit_Info,
+                  all_witnesses: false,
+                  files: [],
+                  data_version: no_data_version
+              },
+
     woql_query_json(system_descriptor{},
                     Auth,
                     some("TERMINUSQA/test"),
                     json_query(Query),
-                    Commit_Info,
-                    [],
-                    false,
-                    no_data_version,
                     _,
-                    _,
-                    _JSON).
+                    _JSON,
+                    Options).
 
 test(quad_compilation, [
          setup((setup_temp_store(State),

--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -751,10 +751,18 @@ woql_handler_helper(Request, System_DB, Auth, Path_Option) :-
             param_value_json_required(JSON, query, object, Query),
             param_value_json_optional(JSON, commit_info, object, commit_info{}, Commit_Info),
             param_value_json_optional(JSON, all_witnesses, boolean, false, All_Witnesses),
+            param_value_json_optional(JSON, optimize, boolean, true, Optimize),
 
             read_data_version_header(Request, Requested_Data_Version),
 
-            woql_query_json(System_DB, Auth, Path_Option, json_query(Query), Commit_Info, Files, All_Witnesses, Requested_Data_Version, New_Data_Version, _Context, Response),
+            Options = _{
+                          files: Files,
+                          all_witnesses: All_Witnesses,
+                          data_version: Requested_Data_Version,
+                          commit_info: Commit_Info,
+                          optimize: Optimize
+                      },
+            woql_query_json(System_DB, Auth, Path_Option, json_query(Query), _Context, New_Data_Version, Response, Options),
 
             write_cors_headers(Request),
             write_data_version_header(New_Data_Version),


### PR DESCRIPTION
This PR fixes the ordering of nots such that they are delayed effectively until bindings can be obtained. It also moves get document late in the query order as it is a relatively expensive search operation even when its id argument is bound.

This PR does not yet move query order optimisation into a feature which can be turned on / off, which is why it is in draft.