### PR TITLE
Alter docker-compose to let the cr api act as proxy middleware

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     hostname: terminusdb-server
     tty: true
     ports:
-      - 6363:6363
+      - 6364:6363
     env_file: .env
     environment:
       - TERMINUSDB_SERVER_PORT=6363
@@ -30,10 +30,10 @@ services:
       - ./vector_storage:/app/storage
     command: ["./terminusdb-semantic-indexer", "serve", "--directory", "/app/storage"]
   change-request-api:
-    image: terminusdb/terminusdb-change-request-api:v0.0.7
+    image: terminusdb/terminusdb-change-request-api:v0.0.8
     env_file: .env
     ports:
-      - 3035:3035
+      - 6363:3035
     environment:
       - SERVER_ENDPOINT=http://terminusdb-server:6363
       - USE_CHANGE_REQUEST=${USE_CHANGE_REQUEST:-true}


### PR DESCRIPTION
the docker-compose was serving up two ports, with dashboard using one to retrieve its static files and the other to do actual api calls. This changes the situation so that everything uses a single port, namely the CR API, which now also properly proxies API calls to terminusdb for anything it doesn't recognize.