### PR TITLE
Fix mode calculation on skeletons

### DIFF
--- a/src/core/query/definition.pl
+++ b/src/core/query/definition.pl
@@ -994,12 +994,12 @@ cost(false, Cost) =>
 
 :- begin_tests(mode).
 
-test(skeleton_term_mode) :-
+test(list_skeleton_term_mode) :-
     term_mode(sum([v('Person')], v('Count')), Mode),
     Mode = [?, ?].
 
 
-test(skeleton_term_mode) :-
+test(dict_skeleton_term_mode) :-
     term_mode((dict{ asdf : v('Foo') } = dict{ asdf : "bar" }), Mode),
     Mode = [?, +].
 

--- a/src/core/query/definition.pl
+++ b/src/core/query/definition.pl
@@ -151,7 +151,7 @@ definition(
     get{
         name: 'Get',
         fields: [columns, resource, optional(has_header)],
-        mode: [+,+,+],
+        mode: [[?],+,+],
         types: [list(column), resource]
     }).
 
@@ -1014,5 +1014,12 @@ test(list_skeleton_bound_term_mode) :-
 
 test(dict_skeleton_term_mode) :-
     \+ term_mode_correct(dict{ asdf : v('Foo') } = dict{ asdf : "bar" }).
+
+
+test(get_well_moded) :-
+    AST = (get([as('Start date', v('Start date'), 'http://www.w3.org/2001/XMLSchema#dateTime')],
+               resource(remote("https://terminusdb.com/t/data/bike_tutorial.csv"), csv, _{}),
+               true)),
+    term_mode_correct(AST).
 
 :- end_tests(mode).

--- a/src/core/query/reorder.pl
+++ b/src/core/query/reorder.pl
@@ -576,5 +576,27 @@ test(sum) :-
     % No reorder
     Prog = AST.
 
+test(sum_swap) :-
+    AST = (
+        sum([v('Person')],v('Count')),
+        count(t(v('Doc_0'),
+			    rdf:type,
+			    '@schema':'Person'),
+		      v('Person'))
+
+    ),
+    partition(AST,Reads_Unordered,_Writes),
+    optimize_read_order(Reads_Unordered, Reads),
+    xfy_list(',', Prog, Reads),
+
+    % Swap reorder
+    Prog = (
+        count(t(v('Doc_0'),
+			    rdf:type,
+			    '@schema':'Person'),
+		      v('Person')),
+        sum([v('Person')],v('Count'))
+    ).
+
 
 :- end_tests(reorder_query).


### PR DESCRIPTION
An incorrect assumption about modality calculations can cause reordering failures due to the fact that skeletons exist in WOQL (dicts and lists can have deep structure). We do not have a modality concept employing skeletons so we employ a more conservative approach which calculates a non-ground structure as ?. We can explore employing a better skeleton mode later (for instance count([X,Y,Z],Count) does not need its variables bound as it is parametrically polymorphic in the values of the list). 