### PR TITLE
Reorder with metavariable propagation and relax unification mode.

### DIFF
--- a/src/core/query/definition.pl
+++ b/src/core/query/definition.pl
@@ -1043,7 +1043,8 @@ test(list_skeleton_bound_term_mode) :-
     term_mode_correct(sum([mv('Person')], v('Count'))).
 
 test(dict_skeleton_term_mode) :-
-    \+ term_mode_correct(dict{ asdf : v('Foo') } = dict{ asdf : "bar" }).
+    % Now creates a binding - should be ok
+    term_mode_correct(dict{ asdf : v('Foo') } = dict{ asdf : "bar" }).
 
 
 test(get_well_moded) :-

--- a/src/core/query/reorder.pl
+++ b/src/core/query/reorder.pl
@@ -8,7 +8,7 @@
 :- use_module(partition, [partition/3]).
 :- use_module(woql_compile, [mode_for_compound/2]).
 :- use_module(definition, [mode/2, definition/1, cost/2, is_var/1, non_var/1,
-                           term_vars/2, metasub/3]).
+                           term_vars/2, metasub/3, unmodable/1]).
 
 :- use_module(library(lists)).
 :- use_module(library(apply)).
@@ -160,7 +160,7 @@ optimize_read_order(Read, Ordered) :-
     optimize_conjuncts(Read, Ordered_Bound),
     die_if(
         (   xfy_list(',', Prog, Ordered_Bound),
-            cost(Prog, inf)),
+            unmodable(Prog)),
         error(query_has_no_viable_mode, _)),
     undummy_bind(Ordered_Bound, Ordered).
 
@@ -435,6 +435,7 @@ test(select_not, []) :-
     partition(Term,Reads_Unordered,_Writes),
     optimize_read_order(Reads_Unordered, Reads),
     xfy_list(',', Prog, Reads),
+
     Prog = select(
                [v(document)],
 			   ( member(v(doc_id),[doc1,doc2]),
@@ -529,7 +530,7 @@ test(reorder_once, []) :-
 test(unmodable, [error(query_has_no_viable_mode, _)]) :-
     Term = (
         t(a, b, v(var)),
-        v(var) = v(unbound)
+        v(var) < v(unbound)
     ),
     partition(Term,Reads_Unordered,_Writes),
     optimize_read_order(Reads_Unordered, _Reads).

--- a/src/core/query/reorder.pl
+++ b/src/core/query/reorder.pl
@@ -7,7 +7,8 @@
 :- use_module(core(util)).
 :- use_module(partition, [partition/3]).
 :- use_module(woql_compile, [mode_for_compound/2]).
-:- use_module(definition, [mode/2, definition/1, cost/2, is_var/1, non_var/1, term_vars/2]).
+:- use_module(definition, [mode/2, definition/1, cost/2, is_var/1, non_var/1,
+                           term_vars/2, metasub/3]).
 
 :- use_module(library(lists)).
 :- use_module(library(apply)).
@@ -63,23 +64,6 @@ sort_definedness(Terms, Sorted) :-
 order_conjuncts(Terms, Sorted) :-
     sort_definedness(Terms, Def_Sort),
     sort_bound(Def_Sort, Sorted).
-
-metasub(v(X), Vars, XO),
-memberchk(X, Vars) =>
-    XO = mv(X).
-metasub(select(Vars,_Query), Vars, _Result) =>
-    throw(error(unimplemented)).
-metasub(Dict, Vars, Result),
-is_dict(Dict) =>
-    dict_pairs(Dict, Functor, Pairs),
-    maplist({Vars}/[P-V,P-V2]>>metasub(V,Vars,V2), Pairs, New_Pairs),
-    dict_create(Result, Functor, New_Pairs).
-metasub(Term, Vars, Result) =>
-    Term =.. [F|Args],
-    maplist({Vars}/[Arg,New]>>metasub(Arg, Vars, New),
-            Args,
-            New_Args),
-    Result =.. [F|New_Args].
 
 metaunsub(mv(X), XO) =>
     XO = v(X).

--- a/tests/test/woql-auth.js
+++ b/tests/test/woql-auth.js
@@ -324,7 +324,7 @@ describe('woql-auth', function () {
 
     it('fails when we try to use an unmodable query', async function () {
       const query = {
-        '@type': 'Equals',
+        '@type': 'Less',
         left: {
           '@type': 'Value',
           variable: 'x',


### PR DESCRIPTION
This adds propagation of metavariables during cost calculation to ensure we get meaningful costs, and also relaxes the mode of the equality/unification operator to ? ?.