### PR TITLE
Remove default insecure headers from docker-compose config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,10 +12,6 @@ services:
     env_file: .env
     environment:
       - TERMINUSDB_SERVER_PORT=6363
-      # DISABLE THESE ENV VARIABLES WHEN RUNNING TERMINUSDB IN PRODUCTION
-      # OR PUT AN AUTHENTICATION GATEWAY IN FRONT OF TERMINUSDB
-      - TERMINUSDB_INSECURE_USER_HEADER=X-User-Forward
-      - TERMINUSDB_INSECURE_USER_HEADER_ENABLED=true
     volumes:
       # For the use of a local dashboard
       #      - ./dashboard:/app/terminusdb/dashboard


### PR DESCRIPTION
For some reason, the default docker-compose.yml we recommend came with insecure user forward headers configured. This does not appear to be necessary for a working local dashboard, but does introduce a security risk if people try to use the default docker-compose in a production environment.

Although the comments in docker-compose.yml do point this out, and warn users to remove these headers in production scenarios, people unfortunately don't always read carefully before deploying things. It is better to default to a safer configuration.

This PR removes the headers from docker-compose.yml.