### PR TITLE
Revert "Remove default insecure headers from docker-compose config"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,10 @@ services:
     env_file: .env
     environment:
       - TERMINUSDB_SERVER_PORT=6363
+      # DISABLE THESE ENV VARIABLES WHEN RUNNING TERMINUSDB IN PRODUCTION
+      # OR PUT AN AUTHENTICATION GATEWAY IN FRONT OF TERMINUSDB
+      - TERMINUSDB_INSECURE_USER_HEADER=X-User-Forward
+      - TERMINUSDB_INSECURE_USER_HEADER_ENABLED=true
     volumes:
       # For the use of a local dashboard
       #      - ./dashboard:/app/terminusdb/dashboard


### PR DESCRIPTION
Reverts terminusdb/terminusdb#2039

vectorlink currently relies on this config. Changing this back for now, but will restore when vectorlink is fixed.