### PR TITLE
SSL for TerminusDB with Traefik and Let’s Encrypt

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,51 @@
+DOMAIN=localhost
+
+LETSENCRYPT_EMAIL=admin@localhost
+
+# WARNING! Note that you should leave `CERT_RESOLVER` variable empty if you test your deployment locally. The password is `admin` and you might want to change it before deploying to production.
+CERT_RESOLVER=
+
+# Traefik dashboard basic auth login:
+TRAEFIK_USER=admin
+
+# Generate hash of traefik dashboard basic auth password with:
+# $ htpasswd -nBC 10 admin
+# 
+# Or use online version: https://www.web2generators.com/apache-tools/htpasswd-generator
+# 
+# The output has the following format: `username`:`password_hash`. The username doesn't have to be `admin`, feel free to change it (in the first line).
+# 
+# You can paste the username into the `TRAEFIK_USER` environment variable. The other part, `hashedPassword`, should be assigned to `TRAEFIK_PASSWORD_HASH`. Now you have your own `username`:`password` pair.
+# 
+TRAEFIK_PASSWORD_HASH=$2y$10$zi5n43jq9S63gBqSJwHTH.nCai2vB0SW/ABPGg2jSGmJBVRo0A.ni
+
+
+# ## Deploying on a Public Server With Real Domain
+# 
+# Let's say you have a domain `example.com` and it's DNS records point to your production server. Just repeat the local deployment steps, but don't forget to update `DOMAIN`, `LETSENCRYPT_EMAIL` and `CERT_RESOLVER` environment variables. In case of `example.com`, your `.env` file should have the following lines:
+# 
+# ```bash
+# DOMAIN=example.com
+# LETSENCRYPT_EMAIL=your@email.com
+# CERT_RESOLVER=letsencrypt
+# ```
+# 
+# Setting correct email is important because it allows Let’s Encrypt to contact you in case there are any present and future issues with your certificates.
+# 
+# That's it! Let me know if something was unclear to you or if you find any errors.
+# 
+# 
+# ## Test Your Deployment
+# 
+# ```bash
+# curl --insecure https://<DOMAIN>/
+# ```
+# 
+# You can also test it in the browser:
+# 
+# https://<DOMAIN>/
+# 
+# https://traefik.<DOMAIN>/
+# 
+# 
+# This `docker-compose.yml` and `.env` config was forked from: https://github.com/bubelov/traefik-letsencrypt-compose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
-version: "3"
 
 services:
   terminusdb-server:
     image: terminusdb/terminusdb-server:latest
     container_name: terminusdb-server
     pull_policy: always
-    hostname: terminusdb-server
+    # hostname: terminusdb-server
+    hostname: ${DOMAIN}
     tty: true
     ports:
       - 6364:6363
@@ -14,12 +14,19 @@ services:
       - TERMINUSDB_SERVER_PORT=6363
       # DISABLE THESE ENV VARIABLES WHEN RUNNING TERMINUSDB IN PRODUCTION
       # OR PUT AN AUTHENTICATION GATEWAY IN FRONT OF TERMINUSDB
-      - TERMINUSDB_INSECURE_USER_HEADER=X-User-Forward
-      - TERMINUSDB_INSECURE_USER_HEADER_ENABLED=true
+      # - TERMINUSDB_INSECURE_USER_HEADER=X-User-Forward
+      # - TERMINUSDB_INSECURE_USER_HEADER_ENABLED=true
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.terminusdb-server.rule=Host(`${DOMAIN}`)
+      - traefik.http.routers.terminusdb-server.entrypoints=https
+      - traefik.http.routers.terminusdb-server.tls.certresolver=letsencrypt
+      - traefik.http.services.terminusdb-server.loadbalancer.server.port=6363
     volumes:
       # For the use of a local dashboard
       #      - ./dashboard:/app/terminusdb/dashboard
       - ./storage:/app/terminusdb/storage
+
   vectorlink:
     image: terminusdb/vectorlink:v0.0.8
     env_file: .env
@@ -29,6 +36,7 @@ services:
     volumes:
       - ./vector_storage:/app/storage
     command: ["./terminusdb-semantic-indexer", "serve", "--directory", "/app/storage"]
+
   change-request-api:
     image: terminusdb/terminusdb-change-request-api:v0.0.9
     restart: always
@@ -52,3 +60,49 @@ services:
 
       # The storage path of terminusdb databases is /app/terminusdb/storage in case
       # you want to persist storage somewhere else.
+
+  traefik:
+    image: traefik:2.4.8
+    command:
+      # Try to enable this if something isn't working. 
+      # Chances are, Traefik will tell you why.
+      # Be careful in production as it exposes the traffic you might not want to expose.
+      #--log.level=DEBUG
+
+      - --entrypoints.http.address=:80
+      - --entrypoints.https.address=:443
+
+      - --providers.docker=true
+
+      - --api.dashboard=true
+      - --api.insecure=false
+
+      # LetsEncrypt Staging Server - uncomment when testing
+      # - --certificatesResolvers.letsencrypt.acme.caServer=https://acme-staging-v02.api.letsencrypt.org/directory
+
+      - --certificatesresolvers.letsencrypt.acme.httpchallenge=true
+      - --certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=http
+      - --certificatesresolvers.letsencrypt.acme.email=${LETSENCRYPT_EMAIL}
+      - --certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json
+    labels:
+      # Redirect all HTTP traffic to HTTPS
+      - traefik.http.routers.to-https.rule=HostRegexp(`{host:.+}`)
+      - traefik.http.routers.to-https.entrypoints=http
+      - traefik.http.routers.to-https.middlewares=to-https
+
+      - traefik.http.routers.traefik.rule=Host(`traefik.${DOMAIN}`)
+      - traefik.http.routers.traefik.entrypoints=https
+      - traefik.http.routers.traefik.middlewares=auth
+      - traefik.http.routers.traefik.service=api@internal
+      - traefik.http.routers.traefik.tls=true
+      - traefik.http.routers.traefik.tls.certresolver=${CERT_RESOLVER}
+
+      - traefik.http.middlewares.to-https.redirectscheme.scheme=https
+      - traefik.http.middlewares.auth.basicauth.users=${TRAEFIK_USER}:${TRAEFIK_PASSWORD_HASH}
+    env_file: .env
+    ports:
+      - 80:80
+      - 443:443
+    volumes:
+      - ./data/letsencrypt:/letsencrypt
+      - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,12 @@ services:
 
       # The storage path of terminusdb databases is /app/terminusdb/storage in case
       # you want to persist storage somewhere else.
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.change-request-api.rule=Host(`${DOMAIN}`)
+      - traefik.http.routers.change-request-api.entrypoints=https
+      - traefik.http.routers.change-request-api.tls.certresolver=letsencrypt
+      - traefik.http.services.change-request-api.loadbalancer.server.port=3035
 
   traefik:
     image: traefik:2.4.8

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+version: "3"
 
 services:
   terminusdb-server:


### PR DESCRIPTION
## Done

- [x] terminus-db dashboard
- [x] change-request-api

## To improve

- [ ] enable vectorlink:

```sh
docker logs 9efd97ccffa9
time="2023-12-24T21:12:32Z" level=info msg="Configuration loaded from flags."
time="2023-12-24T21:12:32Z" level=error msg="service \"vectorlink-terminusdb\" error: port is missing" providerName=docker container=vectorlink-terminusdb-a80b620d2d5ef46c35a1035b5c8f64f22628c9420fafe67ceaa8dff89f757224
```


<!--
Thanks for taking the time to contribute!

Is this your first pull request? If you don't mind, please read this first.

<https://github.com/terminusdb/terminusdb/blob/main/docs/CONTRIBUTING.md>
-->
