### PR TITLE
remove nonvar check on first argument in is_instance_class

### DIFF
--- a/src/core/document/instance.pl
+++ b/src/core/document/instance.pl
@@ -78,7 +78,6 @@ is_instance(Validation_Object, X, C) :-
     is_instance_class(Validation_Object, X, C).
 
 is_instance_class(Validation_Object, X, C) :-
-    nonvar(X),
     ground(C),
     !,
     database_instance(Validation_Object, Instance),


### PR DESCRIPTION
`is_instance_class` was using the effective path only in case the first argument was nonvar and the second ground (which pretty much means both have to be ground). It should actually work just fine with the first argument being a var, preventing a fallthrough to the much slower second clause, which for an unbound first argument will have to walk the entire database.

This PR just removes the nonvar check.