### PR TITLE
disabled self-hosted ci runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
 
   build:
     name: Docker image
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,10 +17,10 @@ on:
         default: "linux/amd64"
       runner:
         type: string
-        default: "self-hosted"
+        default: "ubuntu-latest"
       mocha_jobs:
         type: string
-        default: "4"
+        default: "1"
       mocha_parallel:
         type: boolean
         default: true


### PR DESCRIPTION
pretty much #1945 but we're keeping the buildjet arm runners.