### PR TITLE
Issue/2135 double content length, fixes #2135

### DIFF
--- a/distribution/Makefile.deps
+++ b/distribution/Makefile.deps
@@ -1,4 +1,4 @@
-TUS_VERSION := v0.0.14
+TUS_VERSION := v0.0.16
 JWT_VERSION := v1.0.3
 DASHBOARD_VERSION := v6.0.10
 DASHBOARD_GITHUB_REPO := terminusdb/terminusdb-dashboard

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+# TerminusDB Server v11.1.13 Release Notes
+## Bug Fixes
+- Sync with upstreams tus to fix to duplicated Content-Length header
+
 # TerminusDB Server v11.1.12 Release Notes
 ## Enhancements
 - Initial support for building with SWI-Prolog 9.2


### PR DESCRIPTION
Notes:
* TerminusDB tested with push and pull between TerminusDB instances
* Makefile.deps updated with reference to tus 0.0.16 tag (with content-length fix)
* Release notes updated with 11.1.13 version
* TerminusDB was built successfully using command `docker build --no-cache -t terminusdb-content-length`