### PR TITLE
Correction of the environment-variable in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,10 @@ services:
       # OR PUT AN AUTHENTICATION GATEWAY IN FRONT OF TERMINUSDB
       - TERMINUSDB_INSECURE_USER_HEADER=X-User-Forward
       - TERMINUSDB_INSECURE_USER_HEADER_ENABLED=true
+
+      # Admin-Password should be changed before exposing to the internet:
+      # (it's recommended to use the .env)
+      # -TERMINUSDB_ADMIN_PASS=root
     volumes:
       # For the use of a local dashboard
       #      - ./dashboard:/app/terminusdb/dashboard
@@ -48,7 +52,7 @@ services:
 
       # TerminusDB should be set up behind a TLS-terminating reverse
       # proxy with admin authentication provided by password.
-      # - TERMINUSDB_ADMIN_PASS=root  #  Change before exposing to the internet.
+      # - USER_KEY=root  #  Change before exposing to the internet.
 
       # The storage path of terminusdb databases is /app/terminusdb/storage in case
       # you want to persist storage somewhere else.


### PR DESCRIPTION
As described in https://github.com/terminusdb/terminusdb/issues/1939#issuecomment-1675959894 change-request-api uses the environment-variable "USER_KEY" instead of "TERMINUSDB_ADMIN_PASS". The changes should help new users with the correct configuration.

<!--
Thanks for taking the time to contribute!

Is this your first pull request? If you don't mind, please read this first.

<https://github.com/terminusdb/terminusdb/blob/main/docs/CONTRIBUTING.md>
-->
