### PR TITLE
Update arm.yml for latest buildx action due to Github buildx@v2 sunse…

### DIFF
--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build
         uses: docker/build-push-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,11 @@ jobs:
         with:
           filters: |
             change_other_than_docs_alone:
-              - '!(**.md|docs/**|LICENSE)'
+              - '**'
+              - '!**/*.md'
+              - '!docs/**'
+              - '!LICENSE'            
+#origin filter              - '!(**.md|docs/**|LICENSE)'
 
   versions:
     name: Versions


### PR DESCRIPTION
…tting

Upgrading to version 3

See URL for info: https://docs.docker.com/build/ci/github-actions/cache/

Error received:
> ERROR: failed to solve: This legacy service is shutting down, effective April 15, 2025. Migrate to the new service ASAP. For more information: https://gh.io/gha-cache-sunset

<!--
Thanks for taking the time to contribute!

Is this your first pull request? If you don't mind, please read this first.

<https://github.com/terminusdb/terminusdb/blob/main/docs/CONTRIBUTING.md>
-->
