### PR TITLE
Update to new homebrew path for swipl

### DIFF
--- a/.github/install-swi-prolog.sh
+++ b/.github/install-swi-prolog.sh
@@ -33,7 +33,7 @@ do_install() {
     homebrew)
       # Install swipl from Homebrew: https://www.swi-prolog.org/build/macos.html
       brew install swi-prolog
-      [ "$(which swipl)" = "/usr/local/bin/swipl" ] || die "swipl command not found"
+      [ "$(which swipl)" = "/opt/homebrew/bin/swipl" ] || die "swipl command not found"
       ;;
     *)
       die "Unexpected release: '$release'"


### PR DESCRIPTION
There is a new homebrew path for swipl that make the macos build fail. This sets the correct path for the swi-prolog installation.