### PR TITLE
Clean up container after tests (#2178)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Remove old TerminusDB container if exists
         run: |
-          docker rm -f terminusdb || true
+          docker rm -f terminusdb-${{ github.run_id }} || true
         
       - name: Run server
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -126,7 +126,7 @@ jobs:
           docker load < ${{ inputs.image_artifact }}.tar.gz
           docker run --platform ${{ inputs.image_platform }} \
             --volume "${PWD}/tests:/app/terminusdb/tests" \
-            --name=terminusdb \
+            --name=terminusdb-${{ github.run_id }} \
             --detach \
             --net=host \
             terminusdb/terminusdb-server:local
@@ -143,7 +143,7 @@ jobs:
       - name: Run tests
         working-directory: tests
         env:
-          TERMINUSDB_DOCKER_CONTAINER: terminusdb
+          TERMINUSDB_DOCKER_CONTAINER: terminusdb-${{ github.run_id }}
           MOCHA_JOBS: ${{ inputs.mocha_jobs }}
           MOCHA_PARALLEL: ${{ inputs.mocha_parallel }}
         run: |
@@ -151,8 +151,8 @@ jobs:
 
       - name: Clean up detached container
         run: |
-          docker stop terminusdb
-          docker rm -f terminusdb
+          docker stop terminusdb-${{ github.run_id }}
+          docker rm -f terminusdb-${{ github.run_id }}
 
   # integration_tests_non_parallel:
   #   name: Integration tests (non-parallel)

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -149,6 +149,10 @@ jobs:
         run: |
           npm install-ci-test
 
+      - name: Clean up detached container
+        run: |
+          docker stop terminusdb
+          docker rm -f terminusdb
 
   # integration_tests_non_parallel:
   #   name: Integration tests (non-parallel)


### PR DESCRIPTION
The integration tests currently do not clean up the container it detaches. This makes sure the container is cleaned up again.