### PR TITLE
It seems the docker/build-push-action also needs to be updated

### DIFF
--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -18,7 +18,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: .
           tags: terminusdb/terminusdb-server:local


### PR DESCRIPTION
https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/#decommissioned-cache-service-brownouts

and the linked page:

https://docs.docker.com/build/cache/backends/gha/

Unsure if it targets it exactly, but seems to be related that the version is too low (v3 vs v6)