### PR TITLE
Reorg docker build actions (1/2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,13 +127,13 @@ jobs:
       - name: Download Docker image
         uses: actions/download-artifact@v4
         with:
-          name: terminusdb-server-docker-image
+          name: terminusdb-server-snapshot-amd64
 
       - name: Generate man page
         run: |
           sudo apt-get install --no-install-recommends ronn
           ronn --version
-          docker load < terminusdb-server-docker-image.tar.gz
+          docker load < terminusdb-server-snapshot-amd64.tar.gz
           export HELP="$(docker run --rm terminusdb/terminusdb-server:local /app/terminusdb/terminusdb help -m)"
           envsubst < docs/terminusdb.1.ronn.template > docs/terminusdb.1.ronn
           ronn --roff docs/terminusdb.1.ronn
@@ -167,15 +167,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download Docker image
+      - name: Download AMD64 Image
         uses: actions/download-artifact@v4
         with:
-          name: terminusdb-server-docker-image
+          name: terminusdb-server-snapshot-amd64
 
-      - name: Download Docker image arm64
+      - name: Download AMR64 Image
         uses: actions/download-artifact@v4
         with:
-          name: terminusdb-server-docker-image-arm64
+          name: terminusdb-server-snapshot-arm64
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2
@@ -188,11 +188,11 @@ jobs:
 
       - name: Load images
         run: |
-          docker load < terminusdb-server-docker-image.tar.gz
+          docker load < terminusdb-server-snapshot-amd64.tar.gz
           docker tag terminusdb/terminusdb-server:local terminusdb/terminusdb-server:dev-amd64-$GITHUB_SHA
           docker push terminusdb/terminusdb-server:dev-amd64-$GITHUB_SHA
           docker rmi terminusdb/terminusdb-server:local
-          docker load < terminusdb-server-docker-image-arm64.tar.gz
+          docker load < terminusdb-server-snapshot-arm64.tar.gz
           docker tag terminusdb/terminusdb-server:local terminusdb/terminusdb-server:dev-arm64-$GITHUB_SHA
           docker push terminusdb/terminusdb-server:dev-arm64-$GITHUB_SHA
           docker rmi terminusdb/terminusdb-server:local

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,6 @@ env:
   CURRENT_REPO_VERSION: 11.1.15
 
 jobs:
-  openapi_lint:
-    name: OpenAPI linting
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - run: npx @redocly/cli lint docs/openapi.yaml
-
-
   is_duplicate_run:
     name: Duplicate run?
     runs-on: ubuntu-latest
@@ -55,7 +46,7 @@ jobs:
         }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: dorny/paths-filter@v2
         id: filter
@@ -105,31 +96,23 @@ jobs:
             src/config/terminus_config.pl
             distribution/snap/snapcraft.yaml
 
-  build:
+  amd64_build:
     name: Build Docker (amd64)
     needs: versions
-    uses: ./.github/workflows/docker-build.yml
+    uses: ./.github/workflows/docker-amd64-build.yml
 
-  arm64_docker:
+  arm64_build:
     name: Build Docker (arm64)
     needs:
       - is_build_required
-    uses: ./.github/workflows/arm.yml
+    uses: ./.github/workflows/docker-arm64-build.yml
     if: needs.is_build_required.outputs.push_docker_required == 'true'
-
-  check:
-    name: Check
-    needs: build
-    uses: ./.github/workflows/check.yml
-    with:
-      test_repository: ${{ github.repository }}
-      test_ref: ${{ github.sha }}
 
  # This is required for status checks.
   all_checks_pass_with_build:
     name: All checks pass
     runs-on: ubuntu-latest
-    needs: check
+    needs: amd64_build
     steps:
       - run: echo "Celebrate! 🥳"
 
@@ -139,7 +122,7 @@ jobs:
     needs: all_checks_pass_with_build
     if: github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download Docker image
         uses: actions/download-artifact@v4
@@ -178,11 +161,11 @@ jobs:
     needs:
       - is_build_required
       - all_checks_pass_with_build
-      - arm64_docker
+      - arm64_build
     if: needs.is_build_required.outputs.push_docker_required == 'true'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download Docker image
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,4 @@
+# DO NOT USE
 name: CI
 
 on:
@@ -11,6 +12,8 @@ env:
 
 jobs:
   is_duplicate_run:
+    # DISABLED, DO NOT USE
+    if: false  
     name: Duplicate run?
     runs-on: ubuntu-latest
 
@@ -157,99 +160,12 @@ jobs:
 
   push_docker:
     name: Push Docker image
-    runs-on: ubuntu-latest
     needs:
       - is_build_required
       - all_checks_pass_with_build
       - arm64_build
     if: needs.is_build_required.outputs.push_docker_required == 'true'
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Download AMD64 Image
-        uses: actions/download-artifact@v4
-        with:
-          name: terminusdb-server-snapshot-amd64
-
-      - name: Download AMR64 Image
-        uses: actions/download-artifact@v4
-        with:
-          name: terminusdb-server-snapshot-arm64
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: terminusdb
-          password: ${{ secrets.DOCKER_PASS }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Load images
-        run: |
-          docker load < terminusdb-server-snapshot-amd64.tar.gz
-          docker tag terminusdb/terminusdb-server:local terminusdb/terminusdb-server:dev-amd64-$GITHUB_SHA
-          docker push terminusdb/terminusdb-server:dev-amd64-$GITHUB_SHA
-          docker rmi terminusdb/terminusdb-server:local
-          docker load < terminusdb-server-snapshot-arm64.tar.gz
-          docker tag terminusdb/terminusdb-server:local terminusdb/terminusdb-server:dev-arm64-$GITHUB_SHA
-          docker push terminusdb/terminusdb-server:dev-arm64-$GITHUB_SHA
-          docker rmi terminusdb/terminusdb-server:local
-
-      - name: Determine image tags to push
-        run: |
-          VERSION=$(echo "$GITHUB_REF" | sed -e 's,.*/\(.*\),\1,')
-
-          # Use Docker `dev` tag convention for main branch
-          [ "$VERSION" == "main" ] && VERSION=dev
-
-          # Image identifiers
-          LOCAL_IMAGE=terminusdb/terminusdb-server:local
-          VERSION_IMAGE=terminusdb/terminusdb-server:$VERSION
-          DEV_COMMIT_IMAGE=terminusdb/terminusdb-server:$VERSION-$GITHUB_SHA
-          LATEST_IMAGE=terminusdb/terminusdb-server:latest
-
-          TAGS="$VERSION_IMAGE"
-
-          if [ "$VERSION" == "dev" ]; then
-            TAGS="${TAGS},${DEV_COMMIT_IMAGE}"
-          fi
-
-          # Tag and push the latest image when a version tag is pushed
-          # We also make sure that rc and beta are not pushed to the latest tag!
-          if [ $(echo "$GITHUB_REF" | grep "refs/tags/v" | grep -v "rc" | grep -v "beta") ]; then
-            # Get the major tag, for instance v11 if the version is v11.0.4
-            VERSION_MAJOR=$(echo "$VERSION" | cut -d '.' -f 1)
-            TAGS="${TAGS},${LATEST_IMAGE},terminusdb/terminusdb-server:${VERSION_MAJOR}"
-          fi
-
-          echo "docker_tags=${TAGS}" >> $GITHUB_ENV
-
-      - name: Create new image manifest
-        run: |
-          TAGS="${{ env.docker_tags }}"
-          for TAG in ${TAGS//,/ }
-          do
-              docker buildx imagetools create -t $TAG terminusdb/terminusdb-server:dev-amd64-$GITHUB_SHA terminusdb/terminusdb-server:dev-arm64-$GITHUB_SHA
-          done
-
-  trigger_enterprise_build:
-    name: Trigger enterprise build
-    runs-on: ubuntu-latest
-    needs: push_docker
-    if: |
-      github.repository == 'terminusdb/terminusdb' &&
-      github.event_name == 'push' &&
-      github.ref == 'refs/heads/main'
-
-    steps:
-      - name: Run
-        run: |
-          curl https://api.github.com/repos/${{ secrets.ENTERPRISE_REPO_OWNER }}/${{ secrets.ENTERPRISE_REPO }}/dispatches \
-            -X POST \
-            -H 'Accept: application/vnd.github.everest-preview+json' \
-            -u rrooij:${{ secrets.PAT }} -d '{ "event_type": "Trigger from community", "client_payload": {"commit": "${{ github.sha }}" } }'
+    uses: ./.github/workflows/publish.yml
 
   trigger_snap:
     name: Trigger snap build
@@ -283,19 +199,3 @@ jobs:
           snap: ${{ steps.snap_path_step.outputs.snap_path }}
           release: stable
 
-  trigger_docs_update:
-    name: Trigger docs update
-    runs-on: ubuntu-latest
-    needs: push_docker
-    if: >-
-      github.repository == 'terminusdb/terminusdb' &&
-      github.event_name == 'push' &&
-      startsWith(github.ref, 'refs/tags/v')
-
-    steps:
-      - uses: peter-evans/repository-dispatch@v2
-        with:
-          token: ${{ secrets.PAT }}
-          repository: terminusdb/terminusdb-docs
-          event-type: update-from-terminusdb
-          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'

--- a/.github/workflows/code-lint.yml
+++ b/.github/workflows/code-lint.yml
@@ -10,7 +10,7 @@ on:
       - 'tests/**'      
       - 'distribution/**'            
       - 'Makefile'            
-      - '.lint_config.pl'                  
+      - '.lint_config.pl'                
 
 jobs:
 

--- a/.github/workflows/docker-amd64-build.yml
+++ b/.github/workflows/docker-amd64-build.yml
@@ -1,4 +1,4 @@
-name: AMD64 Docker Build
+name: AMD64 Image
 
 on:
   workflow_dispatch:  
@@ -10,7 +10,7 @@ on:
 jobs:
 
   amd64_build:
-    name: AMD64 Build
+    name: Build
     runs-on: self-hosted
 
     steps:
@@ -50,7 +50,7 @@ jobs:
             path: terminusdb-server-snapshot-amd64.tar.gz
 
   amd64_tests:
-    name: AMD64 Tests
+    name: Tests
     needs: amd64_build
     uses: ./.github/workflows/docker-image-test.yml
     with:

--- a/.github/workflows/docker-amd64-build.yml
+++ b/.github/workflows/docker-amd64-build.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           context: .
           tags: terminusdb/terminusdb-server:local
-          outputs: type=docker,dest=terminusdb-server-docker-image.tar
+          outputs: type=docker,dest=terminusdb-server-snapshot-amd64.tar
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: TERMINUSDB_GIT_HASH=${{ github.sha }}
@@ -32,7 +32,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.11.2
         with:
-          input: /github/workspace/terminusdb-server-docker-image.tar
+          input: /github/workspace/terminusdb-server-snapshot-amd64.tar
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true
@@ -40,13 +40,13 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Compress image
-        run: gzip terminusdb-server-docker-image.tar
+        run: gzip terminusdb-server-snapshot-amd64.tar
 
       - name: Upload Docker image
         uses: actions/upload-artifact@v4
         with:
-            name: terminusdb-server-docker-image
-            path: terminusdb-server-docker-image.tar.gz
+            name: terminusdb-server-snapshot-amd64
+            path: terminusdb-server-snapshot-amd64.tar.gz
 
   amd64_tests:
     name: AMD64 Tests
@@ -55,7 +55,7 @@ jobs:
     with:
       test_repository: ${{ github.repository }}
       test_ref: ${{ github.sha }}
-      image_artifact: terminusdb-server-docker-image
+      image_artifact: terminusdb-server-snapshot-amd64
       image_platform: linux/amd64
       runner: self-hosted
       mocha_parallel: true

--- a/.github/workflows/docker-amd64-build.yml
+++ b/.github/workflows/docker-amd64-build.yml
@@ -1,16 +1,20 @@
-name: Docker Build
+name: AMD64 Docker Build
 
 on:
   workflow_call:
-
+  pull_request:
+    paths: 
+      - ".github/workflows/docker-amd64-build.yml"
+  
 jobs:
 
-  build:
-    name: Docker image
+  amd64_build:
+    name: AMD64 Build
     runs-on: self-hosted
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository      
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -43,3 +47,15 @@ jobs:
         with:
             name: terminusdb-server-docker-image
             path: terminusdb-server-docker-image.tar.gz
+
+  amd64_tests:
+    name: AMD64 Tests
+    needs: amd64_build
+    uses: ./.github/workflows/docker-image-test.yml
+    with:
+      test_repository: ${{ github.repository }}
+      test_ref: ${{ github.sha }}
+      image_artifact: terminusdb-server-docker-image
+      image_platform: linux/amd64
+      runner: self-hosted
+      mocha_parallel: true

--- a/.github/workflows/docker-amd64-build.yml
+++ b/.github/workflows/docker-amd64-build.yml
@@ -1,6 +1,7 @@
 name: AMD64 Docker Build
 
 on:
+  workflow_dispatch:  
   workflow_call:
   pull_request:
     paths: 

--- a/.github/workflows/docker-arm64-build.yml
+++ b/.github/workflows/docker-arm64-build.yml
@@ -1,27 +1,30 @@
 # Build and run tests every night on non-Docker systems.
-name: ARM64 docker build
+name: ARM64 Docker Build
 
 on:
-  schedule:
-    - cron:  '45 2 * * *'
   workflow_dispatch:
   workflow_call:
   pull_request:
-    paths: [ ".github/workflows/arm.yml" ]
+    paths: 
+      - ".github/workflows/docker-arm64-build.yml"
+#  schedule:
+#    - cron:  '45 2 * * *'
 
 jobs:
-  arm64_docker:
+  arm64_build:
+    name: ARM64 Build
     runs-on: buildjet-4vcpu-ubuntu-2204-arm
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository      
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
           version: latest
 
-      - name: Build
+      - name: Docker Build
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -42,12 +45,10 @@ jobs:
             name: terminusdb-server-docker-image-arm64
             path: terminusdb-server-docker-image-arm64.tar.gz
 
-  arm64_docker_tests:
-    # Only run the tests when the cron is triggered or the job
-    # is triggered manually, otherwise it takes way too long
-    if: ${{ github.event_name == 'schedule' }}
-    needs: arm64_docker
-    uses: ./.github/workflows/check.yml
+  arm64_tests:
+    name: ARM64 Tests
+    needs: arm64_build
+    uses: ./.github/workflows/docker-image-test.yml
     with:
       test_repository: ${{ github.repository }}
       test_ref: ${{ github.sha }}

--- a/.github/workflows/docker-arm64-build.yml
+++ b/.github/workflows/docker-arm64-build.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           context: .
           tags: terminusdb/terminusdb-server:local
-          outputs: type=docker,dest=terminusdb-server-docker-image-arm64.tar
+          outputs: type=docker,dest=terminusdb-server-snapshot-arm64.tar
           platforms: linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -37,13 +37,13 @@ jobs:
             TERMINUSDB_GIT_HASH=${{ github.sha }}
 
       - name: Compress image
-        run: gzip terminusdb-server-docker-image-arm64.tar
+        run: gzip terminusdb-server-snapshot-arm64.tar
 
       - name: Upload Docker image
         uses: actions/upload-artifact@v4
         with:
-            name: terminusdb-server-docker-image-arm64
-            path: terminusdb-server-docker-image-arm64.tar.gz
+            name: terminusdb-server-snapshot-arm64
+            path: terminusdb-server-snapshot-arm64.tar.gz
 
   arm64_tests:
     name: ARM64 Tests
@@ -52,7 +52,7 @@ jobs:
     with:
       test_repository: ${{ github.repository }}
       test_ref: ${{ github.sha }}
-      image_artifact: terminusdb-server-docker-image-arm64
+      image_artifact: terminusdb-server-snapshot-arm64
       image_platform: linux/arm64
       runner: ubuntu-latest
       mocha_parallel: false

--- a/.github/workflows/docker-arm64-build.yml
+++ b/.github/workflows/docker-arm64-build.yml
@@ -1,5 +1,5 @@
 # Build and run tests every night on non-Docker systems.
-name: ARM64 Docker Build
+name: ARM64 Image
 
 on:
   workflow_dispatch:
@@ -12,7 +12,7 @@ on:
 
 jobs:
   arm64_build:
-    name: ARM64 Build
+    name: Build
     runs-on: buildjet-4vcpu-ubuntu-2204-arm
 
     steps:
@@ -46,7 +46,7 @@ jobs:
             path: terminusdb-server-snapshot-arm64.tar.gz
 
   arm64_tests:
-    name: ARM64 Tests
+    name: Tests
     needs: arm64_build
     uses: ./.github/workflows/docker-image-test.yml
     with:

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -49,6 +49,10 @@ jobs:
         with:
           platforms: 'arm64'
 
+      - name: Remove old TerminusDB container if exists
+        run: |
+          docker rm -f terminusdb || true
+  
       - name: Run tests
         run: |
           docker load < ${{ inputs.image_artifact }}.tar.gz

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -26,7 +26,7 @@ on:
         default: true
 
 env:
-  NODE_VERSION: '16'
+  NODE_VERSION: '20'
 
 jobs:
 
@@ -142,7 +142,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Run
         working-directory: tests

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -10,14 +10,14 @@ on:
         required: true
         type: string
       image_artifact:
+        required: true        
         type: string
-        default: "terminusdb-server-docker-image"
       image_platform:
+        required: true                
         type: string
-        default: "linux/amd64"
       runner:
         type: string
-        default: "self-hosted"
+        required: true
       mocha_jobs:
         type: string
         default: "4"

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -1,4 +1,4 @@
-name: Check
+name: Docker Image Test
 
 on:
   workflow_call:
@@ -31,7 +31,7 @@ env:
 jobs:
 
   unit:
-    name: Unit tests
+    name: Unit Tests
     runs-on: ${{ inputs.runner }}
 
     steps:
@@ -98,11 +98,11 @@ jobs:
   #       run: tox -e test
 
   integration_tests_basic:
-    name: Integration tests (basic)
+    name: Integration Tests
     runs-on: ${{ inputs.runner }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: ${{ inputs.test_repository }}
           ref: ${{ inputs.test_ref }}
@@ -142,9 +142,9 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '20'
 
-      - name: Run tests
+      - name: Run
         working-directory: tests
         env:
           TERMINUSDB_DOCKER_CONTAINER: terminusdb
@@ -317,50 +317,3 @@ jobs:
   #         TERMINUSDB_ACCESS_TOKEN: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InRlc3RrZXkifQ.eyJodHRwOi8vdGVybWludXNkYi5jb20vc2NoZW1hL3N5c3RlbSNhZ2VudF9uYW1lIjoiYWRtaW4iLCJodHRwOi8vdGVybWludXNkYi5jb20vc2NoZW1hL3N5c3RlbSN1c2VyX2lkZW50aWZpZXIiOiJhZG1pbkB1c2VyLmNvbSIsImlzcyI6Imh0dHBzOi8vdGVybWludXNodWIuZXUuYXV0aDAuY29tLyIsInN1YiI6ImFkbWluIiwiYXVkIjpbImh0dHBzOi8vdGVybWludXNodWIvcmVnaXN0ZXJVc2VyIiwiaHR0cHM6Ly90ZXJtaW51c2h1Yi5ldS5hdXRoMC5jb20vdXNlcmluZm8iXSwiaWF0IjoxNTkzNzY5MTgzLCJhenAiOiJNSkpuZEdwMHpVZE03bzNQT1RRUG1SSkltWTJobzBhaSIsInNjb3BlIjoib3BlbmlkIHByb2ZpbGUgZW1haWwifQ.Ru03Bi6vSIQ57bC41n6fClSdxlb61m0xX6Q34Yh91gql0_CyfYRWTuqzqPMFoCefe53hPC5E-eoSFdID_u6w1ih_pH-lTTqus9OWgi07Qou3QNs8UZBLiM4pgLqcBKs0N058jfg4y6h9GjIBGVhX9Ni2ez3JGNcz1_U45BhnreE
   #       run: npm install-ci-test
 
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - uses: actions/checkout@v3
-        with:
-          repository: ${{ inputs.test_repository }}
-          ref: ${{ inputs.test_ref }}
-
-      - name: Set up QEMU
-        if: ${{ inputs.image_platform == 'linux/arm64' }}
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: 'arm64'
-
-      - name: Download Docker image
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ inputs.image_artifact }}
-
-      - run: make download-lint
-
-      - name: Run lint
-        run: |
-          docker load < ${{ inputs.image_artifact }}.tar.gz
-          docker run --platform ${{ inputs.image_platform }} \
-            -v $(pwd):/app/terminusdb \
-            terminusdb/terminusdb-server:local \
-            make lint
-
-  clippy:
-    name: Clippy comments
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-      - run: sudo apt update && sudo apt install software-properties-common -y
-      - run: sudo apt-add-repository ppa:swi-prolog/stable -y && sudo apt update && sudo apt install swi-prolog-nox protobuf-compiler libprotobuf-dev
-      - uses: actions-rs/clippy-check@v1
-        continue-on-error: true
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --manifest-path=src/rust/Cargo.toml

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -1,5 +1,5 @@
 
-name: Generate Documentation
+name: Documentation
 
 on:
   push:
@@ -8,11 +8,15 @@ on:
       - 'src/**'
       - 'docs/**'      
       - 'Makefile'            
-
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '.github/workflows/generate-docs.yml'
+    
 jobs:
 
   check:
-    name: Update docs
+    name: Check
     runs-on: ubuntu-latest
     
     outputs:
@@ -45,7 +49,7 @@ jobs:
         fi
 
   docs:
-    name: Update docs
+    name: Generate
     needs: check
     if: ${{ needs.check.outputs.changed == 'true' }}
 

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -1,0 +1,100 @@
+
+name: Generate Documentation
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'docs/**'      
+      - 'Makefile'            
+
+jobs:
+
+  check:
+    name: Update docs
+    runs-on: ubuntu-latest
+    
+    outputs:
+      changed: ${{ steps.check_changes.outputs.relevant_changed }}
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Check for file changes
+      id: check_changes
+      run: |
+        git fetch --deepen=10
+
+        # Check that HEAD~1 exists
+        if git rev-parse HEAD~1 >/dev/null 2>&1; then
+          CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD)
+        else
+          echo "Only one commit available; treating all files as changed"
+          CHANGED_FILES=$(git diff --name-only HEAD)
+        fi
+
+        RELEVANT_CHANGED=$(echo "$CHANGED_FILES" | grep -E '^(src/|docs/|Makefile|\.github/workflows/)' || true)
+        if [ -n "$RELEVANT_CHANGED" ]; then
+          echo "Relevant files changed: $RELEVANT_CHANGED"
+          echo "::set-output name=relevant_changed::true"
+        else
+          echo "No relevant files changed"
+          echo "::set-output name=relevant_changed::false"
+        fi
+
+  docs:
+    name: Update docs
+    needs: check
+    if: ${{ needs.check.outputs.changed == 'true' }}
+
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install swi-prolog 
+        run: ./.github/install-swi-prolog.sh stable
+
+      - name: Checkout tus
+        uses: actions/checkout@v4
+        with:
+          repository: terminusdb/tus
+          path: tus
+          ref: v0.0.5
+
+      - name: Install tus
+        run: swipl -g "pack_install('file://$GITHUB_WORKSPACE/tus', [interactive(false)])"
+
+      - name: Install Protobuf Compiler (Linux)
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Init TerminusDB
+        run: |
+          ./terminusdb store init
+
+      - name: Start TerminusDB
+        run: |
+          ./terminusdb serve &
+          echo $! > terminusdb.pid
+          sleep 5  # wait for server to start
+
+      - name: Generate man page
+        run: |
+          sudo apt-get install --no-install-recommends ronn
+          ronn --version
+          export HELP="$(./terminusdb help -m)"
+          envsubst < docs/terminusdb.1.ronn.template > docs/terminusdb.1.ronn
+          ronn --roff docs/terminusdb.1.ronn
+
+      - name: Stop TerminusDB
+        run: |
+            kill $(cat terminusdb.pid)      
+  
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Update man page
+          file_pattern: docs/terminusdb.1.*          

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -75,6 +75,9 @@ jobs:
       - name: Install Protobuf Compiler (Linux)
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
+      - name: Build TerminusDB
+        run: make
+
       - name: Init TerminusDB
         run: |
           ./terminusdb store init

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -50,7 +50,7 @@ jobs:
             CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }})
           fi
 
-          RELEVANT_CHANGED=$(echo "$CHANGED_FILES" | grep -E '^(src/|docs/|tests/|distribution/|Makefile)' || true)
+          RELEVANT_CHANGED=$(echo "$CHANGED_FILES" | grep -E '^(src/|docs/|tests/|distribution/|Makefile|\.github/workflows/)' || true)
           if [ -n "$RELEVANT_CHANGED" ]; then
             echo "Relevant files changed: $RELEVANT_CHANGED"
             echo "::set-output name=relevant_changed::true"
@@ -118,7 +118,7 @@ jobs:
         run: |
           git fetch --depth=2
           CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }})
-          RELEVANT_CHANGED=$(echo "$CHANGED_FILES" | grep -E '^(src/|docs/|tests/|distribution/|Makefile)' || true)
+          RELEVANT_CHANGED=$(echo "$CHANGED_FILES" | grep -E '^(src/|docs/|tests/|distribution/|Makefile|\.github/workflows/)' || true)
           if [ -n "$RELEVANT_CHANGED" ]; then
             echo "Relevant files changed: $RELEVANT_CHANGED"
             echo "::set-output name=relevant_changed::true"

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -1,4 +1,3 @@
-# Build and run tests every night on non-Docker systems.
 name: Native Build
 
 on:
@@ -7,11 +6,8 @@ on:
   pull_request:
     branches: [ main ]
   workflow_dispatch:
-    #  schedule:
-    #- cron:  '45 1 * * *'
 
 jobs:
-
   unit-tests:
     name: "Unit Tests"
     strategy:
@@ -38,8 +34,8 @@ jobs:
           git fetch --deepen=10
 
           if [ "${{ github.event_name }}" == "push" ]; then
-              # Check that HEAD~1 exists
-              if git rev-parse HEAD~1 >/dev/null 2>&1; then
+            # Check that HEAD~1 exists
+            if git rev-parse HEAD~1 >/dev/null 2>&1; then
               CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD)
             else
               echo "Only one commit available; treating all files as changed"
@@ -176,10 +172,6 @@ jobs:
 
       - name: Run tests
         if: ${{ steps.check_changes.outputs.relevant_changed == 'true' }}                        
-#        env:
-#          TERMINUSDB_DOCKER_CONTAINER: terminusdb
-#          MOCHA_JOBS: "4"
-#          MOCHA_PARALLEL: true
         run: |
             cd tests        
             npm install-ci-test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,120 @@
+name: Publish (AMD64, ARM64)
+
+on:
+  workflow_dispatch:  
+  workflow_call:
+
+jobs:
+
+  push_docker:
+    name: Push Docker image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository      
+        uses: actions/checkout@v4
+
+      - name: Download AMD64 Image
+        uses: actions/download-artifact@v4
+        with:
+          name: terminusdb-server-snapshot-amd64
+
+      - name: Download AMR64 Image
+        uses: actions/download-artifact@v4
+        with:
+          name: terminusdb-server-snapshot-arm64
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: terminusdb
+          password: ${{ secrets.DOCKER_PASS }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Load images
+        run: |
+          docker load < terminusdb-server-snapshot-amd64.tar.gz
+          docker tag terminusdb/terminusdb-server:local terminusdb/terminusdb-server:dev-amd64-$GITHUB_SHA
+          docker push terminusdb/terminusdb-server:dev-amd64-$GITHUB_SHA
+          docker rmi terminusdb/terminusdb-server:local
+          docker load < terminusdb-server-snapshot-arm64.tar.gz
+          docker tag terminusdb/terminusdb-server:local terminusdb/terminusdb-server:dev-arm64-$GITHUB_SHA
+          docker push terminusdb/terminusdb-server:dev-arm64-$GITHUB_SHA
+          docker rmi terminusdb/terminusdb-server:local
+
+      - name: Determine image tags to push
+        run: |
+          # Extract version from GITHUB_REF (e.g., refs/heads/main or refs/tags/v1.2.3)        
+          VERSION=$(echo "$GITHUB_REF" | sed -e 's,.*/\(.*\),\1,')
+
+          # Use Docker `dev` tag convention for the main branch
+          if [ "$VERSION" == "main" ]; then
+            VERSION="dev"
+          fi
+
+          # Image identifiers
+          LOCAL_IMAGE=terminusdb/terminusdb-server:local
+          VERSION_IMAGE=terminusdb/terminusdb-server:$VERSION
+          DEV_COMMIT_IMAGE=terminusdb/terminusdb-server:$VERSION-$GITHUB_SHA
+          LATEST_IMAGE=terminusdb/terminusdb-server:latest
+
+          TAGS="$VERSION_IMAGE"
+
+          if [ "$VERSION" == "dev" ]; then
+            TAGS="${TAGS},${DEV_COMMIT_IMAGE}"
+          fi
+
+          # Tag and push the latest image when a version tag is pushed
+          # Exclude tags like rc and beta from the latest tag
+          if echo "$GITHUB_REF" | grep -q "refs/tags/v" && ! echo "$VERSION" | grep -qE "(rc|beta)"; then
+            # Get the major version from the version (e.g., v11 from v11.0.4)
+            VERSION_MAJOR=$(echo "$VERSION" | cut -d '.' -f 1)
+            TAGS="${TAGS},${LATEST_IMAGE},terminusdb/terminusdb-server:${VERSION_MAJOR}"
+          fi
+
+          # Set the tags as an environment variable
+          echo "docker_tags=${TAGS}" >> $GITHUB_ENV
+
+      - name: Create new image manifest
+        run: |
+          TAGS="${{ env.docker_tags }}"
+          for TAG in ${TAGS//,/ }
+          do
+              docker buildx imagetools create -t $TAG terminusdb/terminusdb-server:dev-amd64-$GITHUB_SHA terminusdb/terminusdb-server:dev-arm64-$GITHUB_SHA
+          done
+
+  trigger_enterprise_build:
+    name: Trigger enterprise build
+    runs-on: ubuntu-latest
+    needs: push_docker
+    if: |
+      github.repository == 'terminusdb/terminusdb' &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Run
+        run: |
+          curl https://api.github.com/repos/${{ secrets.ENTERPRISE_REPO_OWNER }}/${{ secrets.ENTERPRISE_REPO }}/dispatches \
+            -X POST \
+            -H 'Accept: application/vnd.github.everest-preview+json' \
+            -u rrooij:${{ secrets.PAT }} -d '{ "event_type": "Trigger from community", "client_payload": {"commit": "${{ github.sha }}" } }'
+
+  trigger_docs_update:
+    name: Trigger docs update
+    runs-on: ubuntu-latest
+    needs: push_docker
+    if: >-
+      github.repository == 'terminusdb/terminusdb' &&
+      github.event_name == 'push' &&
+      startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+      - uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.PAT }}
+          repository: terminusdb/terminusdb-docs
+          event-type: update-from-terminusdb
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'

--- a/.github/workflows/remove-old-docker.yml
+++ b/.github/workflows/remove-old-docker.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.repository == 'terminusdb/terminusdb'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Remove old Docker images
         run: |

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -2,17 +2,17 @@
 name: Snap
 
 on:
-  schedule:
-    - cron:  '45 2 * * *'
   workflow_dispatch:
   workflow_call:
+#  schedule:
+#    - cron:  '45 2 * * *'
 
 jobs:
   snap:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - run: rsync -r ./ distribution/terminusdb_source/
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 ---
 
 [![Native Build](https://github.com/terminusdb/terminusdb/actions/workflows/native-build.yml/badge.svg?branch=main&event=push)](https://github.com/terminusdb/terminusdb/actions/workflows/native-build.yml)
-[![Docker Build](https://github.com/terminusdb/terminusdb/actions/workflows/docker-build.yml/badge.svg?branch=main)](https://github.com/terminusdb/terminusdb/actions/workflows/docker-build.yml)
+[![AMD64 Docker Build](https://github.com/terminusdb/terminusdb/actions/workflows/docker-amd64-build.yml/badge.svg?branch=main)](https://github.com/terminusdb/terminusdb/actions/workflows/docker-amd64-build.yml)
+[![ARM64 Docker Build](https://github.com/terminusdb/terminusdb/actions/workflows/docker-arm64-build.yml/badge.svg?branch=main)](https://github.com/terminusdb/terminusdb/actions/workflows/docker-arm64-build.yml)
 [![Issues](https://img.shields.io/github/issues/terminusdb/terminusdb)](https://github.com/terminusdb/terminusdb/issues)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 


### PR DESCRIPTION
This PR extracts Docker image builds into separate actions (on demand, can be scheduled). It hooks documentation generation to the push event and separates the publish action (on demand, could be hooked up to the release event).

Remaining tasks: fix snap and version change. (The next PR will make ci.yml obsolete.)
