### PR TITLE
Bugfix/better signals handling

### DIFF
--- a/distribution/init_docker.sh
+++ b/distribution/init_docker.sh
@@ -26,5 +26,5 @@ if [ ! -d /app/terminusdb/storage/db ]; then
 fi
 
 echo "SERVER_PORT $TERMINUSDB_SERVER_PORT"
-/app/terminusdb/terminusdb serve
+exec /app/terminusdb/terminusdb serve
 

--- a/src/cli/main.pl
+++ b/src/cli/main.pl
@@ -2720,12 +2720,17 @@ api_error_cli(API, Error) :-
     json_write_dict(user_error,JSON, [serialize_unknown(true)]),
     halt(Status).
 
-initialise_hup :-
+initialise_signals :-
     (   current_prolog_flag(unix, true)
-    ->  on_signal(hup, _, hup)
+    ->  on_signal(hup, _, shutdown_signal),
+        on_signal(term, _, shutdown_signal),
+        on_signal(int, _, shutdown_signal)
     ;   true).
 
-:- initialise_hup.
+:- initialise_signals.
+
+shutdown_signal(_Signal) :-
+    thread_send_message(main, stop).
 
 initialise_log_settings :-
     get_time(Time),

--- a/src/core/util/test_utils.pl
+++ b/src/core/util/test_utils.pl
@@ -508,17 +508,12 @@ spawn_server(Path, URL, PID, Options) :-
               error(Error, _)).
 
 kill_server(PID) :-
-    % Use SIGTERM for graceful shutdown (signal handlers now properly configured)
-    % Falls back to SIGKILL if needed
-    catch(
-        (   process_kill(PID),  % Default SIGTERM
-            process_wait(PID, _, [timeout(5)])
-        ),
-        _,
-        (   process_kill(PID, 9),  % SIGKILL as fallback
-            process_wait(PID, _)
-        )
-    ).
+    % As of SWI-Prolog v8.4.0, process_kill(PID), which defaults to SIGTERM,
+    % does not terminate the process on all systems. Until that is fixed, we use
+    % SIGKILL to work around this issue.
+    % See: https://github.com/terminusdb/terminusdb/pull/828
+    process_kill(PID, 9),
+    process_wait(PID, _).
 
 setup_temp_server(Store-Dir-PID, URL, Options) :-
     setup_temp_store(Store-Dir),

--- a/src/interactive.pl
+++ b/src/interactive.pl
@@ -17,12 +17,14 @@
 :- use_module(library(settings)).
 :- initialization(main).
 
-initialise_hup :-
+initialise_signals :-
     (   current_prolog_flag(unix, true)
-    ->  on_signal(hup, _, hup)
+    ->  on_signal(hup, _, shutdown_signal),
+        on_signal(term, _, shutdown_signal),
+        on_signal(int, _, shutdown_signal)
     ;   true).
 
-:- initialise_hup.
+:- initialise_signals.
 
 
 initialise_log_settings :-
@@ -60,8 +62,8 @@ prolog:message(server_missing_config(BasePath)) -->
 :- use_module(cli(main)).
 :- use_module(library(debug)).
 
-hup(_Signal) :-
-  thread_send_message(main, stop).
+shutdown_signal(_Signal) :-
+    thread_send_message(main, stop).
 
 main(_Argv) :-
     initialize_flags,

--- a/src/start.pl
+++ b/src/start.pl
@@ -18,12 +18,14 @@
 
 :- use_module(library(settings)).
 
-initialise_hup :-
+initialise_signals :-
     (   current_prolog_flag(unix, true)
-    ->  on_signal(hup, _, hup)
+    ->  on_signal(hup, _, shutdown_signal),
+        on_signal(term, _, shutdown_signal),
+        on_signal(int, _, shutdown_signal)
     ;   true).
 
-:- initialise_hup.
+:- initialise_signals.
 
 
 initialise_log_settings :-
@@ -58,8 +60,8 @@ prolog:message(server_missing_config(BasePath)) -->
 :- use_module(cli(main)).
 :- use_module(library(debug)).
 
-hup(_Signal) :-
-  thread_send_message(main, stop).
+shutdown_signal(_Signal) :-
+    thread_send_message(main, stop).
 
 main(_Argv) :-
     initialize_flags,


### PR DESCRIPTION
This enables faster docker restarts and better signal handling for TerminusDB, supporting SIGTERM and SIGINT properly. The docker startscript now uses exec so that signals are forwarded correctly.