### PR TITLE
Issue/2216 cookies with colon crash

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+
+# Contributing to TerminusDB
+
+## How to run
+
+Using swipl (instant start), and in memory. If just for quick tests.
+
+```bash
+swipl src/start.pl serve --memory
+```
+
+Using docker (takes a long time to build)
+
+```bash
+docker build -t terminusdb-dev .
+docker run -p 6363:6363 --name terminusdb-test terminusdb-dev
+```
+
+### Fast Docker Build (Skip Tests)
+
+For faster development iterations, you can skip both Rust and Prolog tests:
+
+```bash
+docker build --build-arg SKIP_TESTS=true -t terminusdb-dev .
+docker run -p 6363:6363 --name terminusdb-test terminusdb-dev
+```
+
+This significantly reduces build time but should **only be used for development**. Always run the full test suite (without `SKIP_TESTS`) before creating pull requests or deploying to production.

--- a/docs/terminusdb.1
+++ b/docs/terminusdb.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "TERMINUSDB" "1" "May 2025" ""
+.TH "TERMINUSDB" "1" "October 2025" ""
 .SH "NAME"
 \fBterminusdb\fR \- command line interface to the terminusdb Graph DBMS
 .SH "SYNOPSIS"

--- a/src/bootstrap.pl
+++ b/src/bootstrap.pl
@@ -33,6 +33,37 @@
 % <https://github.com/SWI-Prolog/swipl/pull/22>
 user:message_hook(qsave(strip_failed(_)), warning, _).
 
+% Catch low level HTTP-related warnings (e.g., malformed cookies) to prevent server crashes
+% in the compiled binary. These warnings are logged but don't halt execution.
+% This allows the server to gracefully handle invalid cookies like:
+%   Cookie: react-resizable-panels:layout=[15,85]; path=/
+user:message_hook(http(Term), warning, Lines) :-
+    % Log the warning to stderr so it's visible in server output
+    format(user_error, '~N[WARNING] HTTP: ~w~n', [Term]),
+    % Print the detailed message lines
+    (   Lines \= []
+    ->  print_message_lines(user_error, '', Lines)
+    ;   true
+    ),
+    % Return true to prevent the warning from crashing the server
+    true.
+
+% Catch general syntax errors in HTTP headers to prevent crashes
+user:message_hook(syntax_error(Term), warning, Lines) :-
+    % Check if this is an HTTP-related syntax error by examining the error term
+    (   functor(Term, http, _)
+    ;   functor(Term, cookie, _)
+    ;   functor(Term, header, _)
+    ),
+    % Log the warning
+    format(user_error, '~N[WARNING] HTTP Syntax Error: ~w~n', [Term]),
+    (   Lines \= []
+    ->  print_message_lines(user_error, '', Lines)
+    ;   true
+    ),
+    % Return true to prevent crash
+    true.
+
 main :-
     initialize_flags,
     bootstrap_files,

--- a/src/start.pl
+++ b/src/start.pl
@@ -46,12 +46,12 @@ prolog:message(server_missing_config(BasePath)) -->
 % This allows the server to gracefully handle invalid cookies like:
 %   Cookie: react-resizable-panels:layout=[15,85]; path=/
 user:message_hook(http(Term), warning, Lines) :-
-    % Log the warning to stderr so it's visible in server output
-    format(user_error, '~N[WARNING] HTTP: ~w~n', [Term]),
-    % Print the detailed message lines
-    (   Lines \= []
-    ->  print_message_lines(user_error, '', Lines)
-    ;   true
+    % Use centralized logging from json_log module with fallback
+    catch(
+        json_log:log_http_warning('HTTP', Term, Lines),
+        _Error,
+        % Fallback if json_log not loaded yet (early in boot process)
+        format(user_error, '~N[WARNING] HTTP: ~w~n', [Term])
     ),
     % Return true to prevent the warning from crashing the server
     true.
@@ -63,11 +63,11 @@ user:message_hook(syntax_error(Term), warning, Lines) :-
     ;   functor(Term, cookie, _)
     ;   functor(Term, header, _)
     ),
-    % Log the warning
-    format(user_error, '~N[WARNING] HTTP Syntax Error: ~w~n', [Term]),
-    (   Lines \= []
-    ->  print_message_lines(user_error, '', Lines)
-    ;   true
+    % Use centralized logging with fallback
+    catch(
+        json_log:log_http_warning('HTTP Syntax Error', Term, Lines),
+        _Error,
+        format(user_error, '~N[WARNING] HTTP Syntax Error: ~w~n', [Term])
     ),
     % Return true to prevent crash
     true.


### PR DESCRIPTION
Warnings were not properly caught, where invalid cookies crashed the server, example:

```
curl -s -H "Cookie: react-resizable-panels:layout=[15,85]; path=/" http://localhost:6363/api/ok
```

Now, instead, a warning is issued in the server output when such errors happen in the built terminusdb, allowing the server to handle this in the same way as when running directly with swipl when running as a docker container or as the built binary:

```
[WARNING] HTTP: skipped_cookie([114,101,97,99,116,45,114,101,115,105,122,97,98,108,101,45,112,97,110,101,108,115,58,108,97,121,111,117,116,61,91,49,53,44,56,53,93])
Skipped illegal cookie: react-resizable-panels:layout=[15,85]
[INFO] 2025-10-05T07:28:33.720559+00:00 GET /api/ok (200)
```

