### PR TITLE
Change runner to buildjet for ARM64 build

### DIFF
--- a/.github/workflows/docker-arm64-build.yml
+++ b/.github/workflows/docker-arm64-build.yml
@@ -55,5 +55,5 @@ jobs:
       test_ref: ${{ github.sha }}
       image_artifact: terminusdb-server-snapshot-arm64
       image_platform: linux/arm64
-      runner: ubuntu-latest
+      runner: buildjet-4vcpu-ubuntu-2204-arm
       mocha_parallel: false


### PR DESCRIPTION
Change to the arm64 buildjet-4vcpu-ubuntu-2204-arm runner instead of emulation