### PR TITLE
Add user and group

### DIFF
--- a/docker/no-root/Dockerfile
+++ b/docker/no-root/Dockerfile
@@ -3,4 +3,6 @@
 ARG BASE_IMAGE=terminusdb/terminusdb-server:local
 FROM ${BASE_IMAGE}
 RUN chown -R 1000:1000 /app/terminusdb/storage
+RUN groupadd -g 1000 terminusdb
+RUN useradd -m -u 1000 -g 1000 terminusdb
 USER 1000


### PR DESCRIPTION
Adding the following for RC2 overall:
* Two docker image variants: 11_2_rc2 and 11_2_rc2-noroot (the latter not running as root, user 1000)
* The auto-optimizer is enabled by default in the image for consistent performance
