### PR TITLE
Support for high performance WOQL set operators, fixes #2284 

### DIFF
--- a/src/core/query/definition.pl
+++ b/src/core/query/definition.pl
@@ -426,6 +426,41 @@ definition(
         types: [list(any),decimal]
     }).
 definition(
+    set_difference{
+        name: 'SetDifference',
+        fields: [list_a, list_b, result],
+        mode: [+, +, ?],
+        types: [list(any), list(any), list(any)]
+    }).
+definition(
+    set_intersection{
+        name: 'SetIntersection',
+        fields: [list_a, list_b, result],
+        mode: [+, +, ?],
+        types: [list(any), list(any), list(any)]
+    }).
+definition(
+    set_union{
+        name: 'SetUnion',
+        fields: [list_a, list_b, result],
+        mode: [+, +, ?],
+        types: [list(any), list(any), list(any)]
+    }).
+definition(
+    set_member{
+        name: 'SetMember',
+        fields: [element, set],
+        mode: [+, +],
+        types: [any, list(any)]
+    }).
+definition(
+    list_to_set{
+        name: 'ListToSet',
+        fields: [list, set],
+        mode: [+, ?],
+        types: [list(any), list(any)]
+    }).
+definition(
     slice{
         name: 'Slice',
         fields: [list, result, start, end],
@@ -1064,6 +1099,21 @@ cost_(slice(_,_,_), Cost, _Polarity) =>
     Cost = 10.
 
 cost_(slice(_,_,_,_), Cost, _Polarity) =>
+    Cost = 10.
+
+cost_(set_difference(_,_,_), Cost, _Polarity) =>
+    Cost = 10.
+
+cost_(set_intersection(_,_,_), Cost, _Polarity) =>
+    Cost = 10.
+
+cost_(set_union(_,_,_), Cost, _Polarity) =>
+    Cost = 10.
+
+cost_(set_member(_,_), Cost, _Polarity) =>
+    Cost = 5.
+
+cost_(list_to_set(_,_), Cost, _Polarity) =>
     Cost = 10.
 
 cost_(X=Y, Cost, Polarity),

--- a/src/core/query/json_woql.pl
+++ b/src/core/query/json_woql.pl
@@ -861,6 +861,47 @@ json_type_to_woql_ast('Member',JSON,WOQL,Path) :-
     json_value_to_woql_ast(L,WL,[list
                                  |Path]),
     WOQL = member(WS,WL).
+json_type_to_woql_ast('SetDifference',JSON,WOQL,Path) :-
+    _{list_a : ListA,
+      list_b : ListB,
+      result : Result
+     } :< JSON,
+    json_value_to_woql_ast(ListA,WListA,[list_a|Path]),
+    json_value_to_woql_ast(ListB,WListB,[list_b|Path]),
+    json_value_to_woql_ast(Result,WResult,[result|Path]),
+    WOQL = set_difference(WListA,WListB,WResult).
+json_type_to_woql_ast('SetIntersection',JSON,WOQL,Path) :-
+    _{list_a : ListA,
+      list_b : ListB,
+      result : Result
+     } :< JSON,
+    json_value_to_woql_ast(ListA,WListA,[list_a|Path]),
+    json_value_to_woql_ast(ListB,WListB,[list_b|Path]),
+    json_value_to_woql_ast(Result,WResult,[result|Path]),
+    WOQL = set_intersection(WListA,WListB,WResult).
+json_type_to_woql_ast('SetUnion',JSON,WOQL,Path) :-
+    _{list_a : ListA,
+      list_b : ListB,
+      result : Result
+     } :< JSON,
+    json_value_to_woql_ast(ListA,WListA,[list_a|Path]),
+    json_value_to_woql_ast(ListB,WListB,[list_b|Path]),
+    json_value_to_woql_ast(Result,WResult,[result|Path]),
+    WOQL = set_union(WListA,WListB,WResult).
+json_type_to_woql_ast('SetMember',JSON,WOQL,Path) :-
+    _{element : Element,
+      set : Set
+     } :< JSON,
+    json_value_to_woql_ast(Element,WElement,[element|Path]),
+    json_value_to_woql_ast(Set,WSet,[set|Path]),
+    WOQL = set_member(WElement,WSet).
+json_type_to_woql_ast('ListToSet',JSON,WOQL,Path) :-
+    _{list : List,
+      set : Set
+     } :< JSON,
+    json_value_to_woql_ast(List,WList,[list|Path]),
+    json_value_to_woql_ast(Set,WSet,[set|Path]),
+    WOQL = list_to_set(WList,WSet).
 json_type_to_woql_ast('Concatenate',JSON,WOQL,Path) :-
     _{list :  List,
       result : Value

--- a/src/core/query/set_operations_test.pl
+++ b/src/core/query/set_operations_test.pl
@@ -1,0 +1,372 @@
+/** <module> Set Operations Tests
+ *
+ * Tests for WOQL set operations: set_difference, set_intersection,
+ * set_union, set_member, and list_to_set.
+ *
+ * These operations use Prolog's ordsets library for O(n log n) performance.
+ */
+
+:- begin_tests(set_operations, []).
+:- use_module(library(apply), [maplist/3]).
+:- use_module(library(yall)).
+:- use_module(core(util/test_utils)).
+:- use_module(core(api)).
+:- use_module(core(query)).
+:- use_module(core(query/query_response), [run_context_ast_jsonld_response/5]).
+:- use_module(core(query/json_woql), [json_woql/2]).
+:- use_module(core(triple)).
+:- use_module(core(transaction)).
+
+% Define assertion/1 locally to satisfy linter (plunit provides it at runtime)
+:- if(\+ current_predicate(assertion/1)).
+assertion(Goal) :- call(Goal).
+:- endif.
+
+% Helper for running queries in set operation tests
+query_test_response_set(Descriptor, Query, Response) :-
+    create_context(Descriptor,
+                   commit_info{author: "set test", message: "testing"},
+                   Context),
+    json_woql(Query, AST),
+    run_context_ast_jsonld_response(Context, AST, no_data_version, _, Response).
+
+/*
+ * Test: set_difference basic operation
+ */
+test(set_difference_basic, [
+         setup((setup_temp_store(State),
+                create_db_without_schema("admin", "test"))),
+         cleanup(teardown_temp_store(State))
+     ]) :-
+    
+    Query = _{'@type': 'And',
+              'and': [
+                  _{'@type': 'Equals',
+                    'left': _{'@type': 'Value', 'variable': 'ListA'},
+                    'right': _{'@type': 'Value', 'list': [
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 1}},
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 2}},
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 3}},
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 4}}
+                    ]}},
+                  _{'@type': 'Equals',
+                    'left': _{'@type': 'Value', 'variable': 'ListB'},
+                    'right': _{'@type': 'Value', 'list': [
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 2}},
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 4}}
+                    ]}},
+                  _{'@type': 'SetDifference',
+                    'list_a': _{'@type': 'Value', 'variable': 'ListA'},
+                    'list_b': _{'@type': 'Value', 'variable': 'ListB'},
+                    'result': _{'@type': 'Value', 'variable': 'Diff'}}
+              ]},
+    
+    resolve_absolute_string_descriptor("admin/test", Descriptor),
+    query_test_response_set(Descriptor, Query, JSON),
+    [Res] = JSON.bindings,
+    get_dict('Diff', Res, Diff),
+    maplist([json{'@type':'xsd:integer','@value':V},V]>>true, Diff, DiffValues),
+    assertion(DiffValues == [1, 3]).
+
+/*
+ * Test: set_intersection basic operation
+ */
+test(set_intersection_basic, [
+         setup((setup_temp_store(State),
+                create_db_without_schema("admin", "test"))),
+         cleanup(teardown_temp_store(State))
+     ]) :-
+    
+    Query = _{'@type': 'And',
+              'and': [
+                  _{'@type': 'Equals',
+                    'left': _{'@type': 'Value', 'variable': 'ListA'},
+                    'right': _{'@type': 'Value', 'list': [
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 1}},
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 2}},
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 3}}
+                    ]}},
+                  _{'@type': 'Equals',
+                    'left': _{'@type': 'Value', 'variable': 'ListB'},
+                    'right': _{'@type': 'Value', 'list': [
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 2}},
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 3}},
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 4}}
+                    ]}},
+                  _{'@type': 'SetIntersection',
+                    'list_a': _{'@type': 'Value', 'variable': 'ListA'},
+                    'list_b': _{'@type': 'Value', 'variable': 'ListB'},
+                    'result': _{'@type': 'Value', 'variable': 'Common'}}
+              ]},
+    
+    resolve_absolute_string_descriptor("admin/test", Descriptor),
+    query_test_response_set(Descriptor, Query, JSON),
+    [Res] = JSON.bindings,
+    get_dict('Common', Res, Common),
+    maplist([json{'@type':'xsd:integer','@value':V},V]>>true, Common, CommonValues),
+    assertion(CommonValues == [2, 3]).
+
+/*
+ * Test: set_union basic operation
+ */
+test(set_union_basic, [
+         setup((setup_temp_store(State),
+                create_db_without_schema("admin", "test"))),
+         cleanup(teardown_temp_store(State))
+     ]) :-
+    
+    Query = _{'@type': 'And',
+              'and': [
+                  _{'@type': 'Equals',
+                    'left': _{'@type': 'Value', 'variable': 'ListA'},
+                    'right': _{'@type': 'Value', 'list': [
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 1}},
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 2}}
+                    ]}},
+                  _{'@type': 'Equals',
+                    'left': _{'@type': 'Value', 'variable': 'ListB'},
+                    'right': _{'@type': 'Value', 'list': [
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 2}},
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 3}}
+                    ]}},
+                  _{'@type': 'SetUnion',
+                    'list_a': _{'@type': 'Value', 'variable': 'ListA'},
+                    'list_b': _{'@type': 'Value', 'variable': 'ListB'},
+                    'result': _{'@type': 'Value', 'variable': 'All'}}
+              ]},
+    
+    resolve_absolute_string_descriptor("admin/test", Descriptor),
+    query_test_response_set(Descriptor, Query, JSON),
+    [Res] = JSON.bindings,
+    get_dict('All', Res, All),
+    maplist([json{'@type':'xsd:integer','@value':V},V]>>true, All, AllValues),
+    assertion(AllValues == [1, 2, 3]).
+
+/*
+ * Test: set_member succeeds for element in set
+ */
+test(set_member_success, [
+         setup((setup_temp_store(State),
+                create_db_without_schema("admin", "test"))),
+         cleanup(teardown_temp_store(State))
+     ]) :-
+    
+    Query = _{'@type': 'And',
+              'and': [
+                  _{'@type': 'Equals',
+                    'left': _{'@type': 'Value', 'variable': 'MySet'},
+                    'right': _{'@type': 'Value', 'list': [
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 1}},
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 2}},
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 3}}
+                    ]}},
+                  _{'@type': 'SetMember',
+                    'element': _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 2}},
+                    'set': _{'@type': 'Value', 'variable': 'MySet'}}
+              ]},
+    
+    resolve_absolute_string_descriptor("admin/test", Descriptor),
+    query_test_response_set(Descriptor, Query, JSON),
+    Bindings = JSON.bindings,
+    assertion(length(Bindings, 1)).
+
+/*
+ * Test: set_member fails for non-member
+ */
+test(set_member_failure, [
+         setup((setup_temp_store(State),
+                create_db_without_schema("admin", "test"))),
+         cleanup(teardown_temp_store(State))
+     ]) :-
+    
+    Query = _{'@type': 'And',
+              'and': [
+                  _{'@type': 'Equals',
+                    'left': _{'@type': 'Value', 'variable': 'MySet'},
+                    'right': _{'@type': 'Value', 'list': [
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 1}},
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 2}},
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 3}}
+                    ]}},
+                  _{'@type': 'SetMember',
+                    'element': _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 5}},
+                    'set': _{'@type': 'Value', 'variable': 'MySet'}}
+              ]},
+    
+    resolve_absolute_string_descriptor("admin/test", Descriptor),
+    query_test_response_set(Descriptor, Query, JSON),
+    Bindings = JSON.bindings,
+    assertion(length(Bindings, 0)).
+
+/*
+ * Test: list_to_set removes duplicates and sorts
+ */
+test(list_to_set_basic, [
+         setup((setup_temp_store(State),
+                create_db_without_schema("admin", "test"))),
+         cleanup(teardown_temp_store(State))
+     ]) :-
+    
+    Query = _{'@type': 'And',
+              'and': [
+                  _{'@type': 'Equals',
+                    'left': _{'@type': 'Value', 'variable': 'MyList'},
+                    'right': _{'@type': 'Value', 'list': [
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 3}},
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 1}},
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 2}},
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 1}}
+                    ]}},
+                  _{'@type': 'ListToSet',
+                    'list': _{'@type': 'Value', 'variable': 'MyList'},
+                    'set': _{'@type': 'Value', 'variable': 'MySet'}}
+              ]},
+    
+    resolve_absolute_string_descriptor("admin/test", Descriptor),
+    query_test_response_set(Descriptor, Query, JSON),
+    [Res] = JSON.bindings,
+    get_dict('MySet', Res, MySet),
+    maplist([json{'@type':'xsd:integer','@value':V},V]>>true, MySet, MySetValues),
+    assertion(MySetValues == [1, 2, 3]).
+
+/*
+ * Test: set_difference with empty result
+ */
+test(set_difference_empty_result, [
+         setup((setup_temp_store(State),
+                create_db_without_schema("admin", "test"))),
+         cleanup(teardown_temp_store(State))
+     ]) :-
+    
+    Query = _{'@type': 'And',
+              'and': [
+                  _{'@type': 'Equals',
+                    'left': _{'@type': 'Value', 'variable': 'ListA'},
+                    'right': _{'@type': 'Value', 'list': [
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 1}},
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 2}}
+                    ]}},
+                  _{'@type': 'Equals',
+                    'left': _{'@type': 'Value', 'variable': 'ListB'},
+                    'right': _{'@type': 'Value', 'list': [
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 1}},
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 2}},
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 3}}
+                    ]}},
+                  _{'@type': 'SetDifference',
+                    'list_a': _{'@type': 'Value', 'variable': 'ListA'},
+                    'list_b': _{'@type': 'Value', 'variable': 'ListB'},
+                    'result': _{'@type': 'Value', 'variable': 'Diff'}}
+              ]},
+    
+    resolve_absolute_string_descriptor("admin/test", Descriptor),
+    query_test_response_set(Descriptor, Query, JSON),
+    [Res] = JSON.bindings,
+    get_dict('Diff', Res, Diff),
+    assertion(Diff == []).
+
+/*
+ * Test: Incommensurable types - different types are distinct elements
+ */
+test(incommensurable_types_set_difference, [
+         setup((setup_temp_store(State),
+                create_db_without_schema("admin", "test"))),
+         cleanup(teardown_temp_store(State))
+     ]) :-
+    
+    Query = _{'@type': 'And',
+              'and': [
+                  _{'@type': 'Equals',
+                    'left': _{'@type': 'Value', 'variable': 'ListA'},
+                    'right': _{'@type': 'Value', 'list': [
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 1}},
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 2}}
+                    ]}},
+                  _{'@type': 'Equals',
+                    'left': _{'@type': 'Value', 'variable': 'ListB'},
+                    'right': _{'@type': 'Value', 'list': [
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:decimal', '@value': 1}},
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:decimal', '@value': 2}}
+                    ]}},
+                  _{'@type': 'SetDifference',
+                    'list_a': _{'@type': 'Value', 'variable': 'ListA'},
+                    'list_b': _{'@type': 'Value', 'variable': 'ListB'},
+                    'result': _{'@type': 'Value', 'variable': 'Diff'}}
+              ]},
+    
+    resolve_absolute_string_descriptor("admin/test", Descriptor),
+    query_test_response_set(Descriptor, Query, JSON),
+    [Res] = JSON.bindings,
+    get_dict('Diff', Res, Diff),
+    % Both integers remain because decimals are different types
+    length(Diff, 2).
+
+/*
+ * Test: Incommensurable types - intersection is empty for different types
+ */
+test(incommensurable_types_set_intersection, [
+         setup((setup_temp_store(State),
+                create_db_without_schema("admin", "test"))),
+         cleanup(teardown_temp_store(State))
+     ]) :-
+    
+    Query = _{'@type': 'And',
+              'and': [
+                  _{'@type': 'Equals',
+                    'left': _{'@type': 'Value', 'variable': 'ListA'},
+                    'right': _{'@type': 'Value', 'list': [
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 1}}
+                    ]}},
+                  _{'@type': 'Equals',
+                    'left': _{'@type': 'Value', 'variable': 'ListB'},
+                    'right': _{'@type': 'Value', 'list': [
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:decimal', '@value': 1}}
+                    ]}},
+                  _{'@type': 'SetIntersection',
+                    'list_a': _{'@type': 'Value', 'variable': 'ListA'},
+                    'list_b': _{'@type': 'Value', 'variable': 'ListB'},
+                    'result': _{'@type': 'Value', 'variable': 'Common'}}
+              ]},
+    
+    resolve_absolute_string_descriptor("admin/test", Descriptor),
+    query_test_response_set(Descriptor, Query, JSON),
+    [Res] = JSON.bindings,
+    get_dict('Common', Res, Common),
+    % No common elements because types differ
+    assertion(Common == []).
+
+/*
+ * Test: Incommensurable types - union contains both type variants
+ */
+test(incommensurable_types_set_union, [
+         setup((setup_temp_store(State),
+                create_db_without_schema("admin", "test"))),
+         cleanup(teardown_temp_store(State))
+     ]) :-
+    
+    Query = _{'@type': 'And',
+              'and': [
+                  _{'@type': 'Equals',
+                    'left': _{'@type': 'Value', 'variable': 'ListA'},
+                    'right': _{'@type': 'Value', 'list': [
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:integer', '@value': 1}}
+                    ]}},
+                  _{'@type': 'Equals',
+                    'left': _{'@type': 'Value', 'variable': 'ListB'},
+                    'right': _{'@type': 'Value', 'list': [
+                        _{'@type': 'Value', 'data': _{'@type': 'xsd:decimal', '@value': 1}}
+                    ]}},
+                  _{'@type': 'SetUnion',
+                    'list_a': _{'@type': 'Value', 'variable': 'ListA'},
+                    'list_b': _{'@type': 'Value', 'variable': 'ListB'},
+                    'result': _{'@type': 'Value', 'variable': 'All'}}
+              ]},
+    
+    resolve_absolute_string_descriptor("admin/test", Descriptor),
+    query_test_response_set(Descriptor, Query, JSON),
+    [Res] = JSON.bindings,
+    get_dict('All', Res, All),
+    % Both elements present because types differ
+    length(All, 2).
+
+:- end_tests(set_operations).

--- a/tests/test/woql-set-operations.js
+++ b/tests/test/woql-set-operations.js
@@ -1,0 +1,709 @@
+const { expect } = require('chai')
+const { Agent, db, woql } = require('../lib')
+
+describe('woql-set-operations', function () {
+  this.timeout(200000)
+
+  let agent
+
+  before(async function () {
+    agent = new Agent().auth()
+    await db.create(agent)
+  })
+
+  after(async function () {
+    await db.delete(agent)
+  })
+
+  describe('set_difference', function () {
+    it('computes difference between two lists', async function () {
+      const query = {
+        '@type': 'And',
+        and: [
+          {
+            '@type': 'Equals',
+            left: { '@type': 'Value', variable: 'ListA' },
+            right: {
+              '@type': 'Value',
+              list: [
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 1 } },
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 2 } },
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 3 } },
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 4 } },
+              ],
+            },
+          },
+          {
+            '@type': 'Equals',
+            left: { '@type': 'Value', variable: 'ListB' },
+            right: {
+              '@type': 'Value',
+              list: [
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 2 } },
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 4 } },
+              ],
+            },
+          },
+          {
+            '@type': 'SetDifference',
+            list_a: { '@type': 'Value', variable: 'ListA' },
+            list_b: { '@type': 'Value', variable: 'ListB' },
+            result: { '@type': 'Value', variable: 'Diff' },
+          },
+        ],
+      }
+
+      const result = await woql.post(agent, query)
+      expect(result.status).to.equal(200)
+      expect(result.body.bindings).to.have.length(1)
+      const diff = result.body.bindings[0].Diff
+      const diffValues = diff.map(v => v['@value'])
+      expect(diffValues).to.deep.equal([1, 3])
+    })
+
+    it('returns empty list when first list is subset of second', async function () {
+      const query = {
+        '@type': 'And',
+        and: [
+          {
+            '@type': 'Equals',
+            left: { '@type': 'Value', variable: 'ListA' },
+            right: {
+              '@type': 'Value',
+              list: [
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 1 } },
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 2 } },
+              ],
+            },
+          },
+          {
+            '@type': 'Equals',
+            left: { '@type': 'Value', variable: 'ListB' },
+            right: {
+              '@type': 'Value',
+              list: [
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 1 } },
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 2 } },
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 3 } },
+              ],
+            },
+          },
+          {
+            '@type': 'SetDifference',
+            list_a: { '@type': 'Value', variable: 'ListA' },
+            list_b: { '@type': 'Value', variable: 'ListB' },
+            result: { '@type': 'Value', variable: 'Diff' },
+          },
+        ],
+      }
+
+      const result = await woql.post(agent, query)
+      expect(result.status).to.equal(200)
+      expect(result.body.bindings).to.have.length(1)
+      const diff = result.body.bindings[0].Diff
+      expect(diff).to.deep.equal([])
+    })
+
+    it('handles empty lists', async function () {
+      const query = {
+        '@type': 'And',
+        and: [
+          {
+            '@type': 'Equals',
+            left: { '@type': 'Value', variable: 'ListA' },
+            right: { '@type': 'Value', list: [] },
+          },
+          {
+            '@type': 'Equals',
+            left: { '@type': 'Value', variable: 'ListB' },
+            right: {
+              '@type': 'Value',
+              list: [
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 1 } },
+              ],
+            },
+          },
+          {
+            '@type': 'SetDifference',
+            list_a: { '@type': 'Value', variable: 'ListA' },
+            list_b: { '@type': 'Value', variable: 'ListB' },
+            result: { '@type': 'Value', variable: 'Diff' },
+          },
+        ],
+      }
+
+      const result = await woql.post(agent, query)
+      expect(result.status).to.equal(200)
+      expect(result.body.bindings).to.have.length(1)
+      const diff = result.body.bindings[0].Diff
+      expect(diff).to.deep.equal([])
+    })
+  })
+
+  describe('set_intersection', function () {
+    it('computes intersection of two lists', async function () {
+      const query = {
+        '@type': 'And',
+        and: [
+          {
+            '@type': 'Equals',
+            left: { '@type': 'Value', variable: 'ListA' },
+            right: {
+              '@type': 'Value',
+              list: [
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 1 } },
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 2 } },
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 3 } },
+              ],
+            },
+          },
+          {
+            '@type': 'Equals',
+            left: { '@type': 'Value', variable: 'ListB' },
+            right: {
+              '@type': 'Value',
+              list: [
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 2 } },
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 3 } },
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 4 } },
+              ],
+            },
+          },
+          {
+            '@type': 'SetIntersection',
+            list_a: { '@type': 'Value', variable: 'ListA' },
+            list_b: { '@type': 'Value', variable: 'ListB' },
+            result: { '@type': 'Value', variable: 'Common' },
+          },
+        ],
+      }
+
+      const result = await woql.post(agent, query)
+      expect(result.status).to.equal(200)
+      expect(result.body.bindings).to.have.length(1)
+      const common = result.body.bindings[0].Common
+      const commonValues = common.map(v => v['@value'])
+      expect(commonValues).to.deep.equal([2, 3])
+    })
+
+    it('returns empty list when no common elements', async function () {
+      const query = {
+        '@type': 'And',
+        and: [
+          {
+            '@type': 'Equals',
+            left: { '@type': 'Value', variable: 'ListA' },
+            right: {
+              '@type': 'Value',
+              list: [
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 1 } },
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 2 } },
+              ],
+            },
+          },
+          {
+            '@type': 'Equals',
+            left: { '@type': 'Value', variable: 'ListB' },
+            right: {
+              '@type': 'Value',
+              list: [
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 3 } },
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 4 } },
+              ],
+            },
+          },
+          {
+            '@type': 'SetIntersection',
+            list_a: { '@type': 'Value', variable: 'ListA' },
+            list_b: { '@type': 'Value', variable: 'ListB' },
+            result: { '@type': 'Value', variable: 'Common' },
+          },
+        ],
+      }
+
+      const result = await woql.post(agent, query)
+      expect(result.status).to.equal(200)
+      expect(result.body.bindings).to.have.length(1)
+      const common = result.body.bindings[0].Common
+      expect(common).to.deep.equal([])
+    })
+  })
+
+  describe('set_union', function () {
+    it('computes union of two lists', async function () {
+      const query = {
+        '@type': 'And',
+        and: [
+          {
+            '@type': 'Equals',
+            left: { '@type': 'Value', variable: 'ListA' },
+            right: {
+              '@type': 'Value',
+              list: [
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 1 } },
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 2 } },
+              ],
+            },
+          },
+          {
+            '@type': 'Equals',
+            left: { '@type': 'Value', variable: 'ListB' },
+            right: {
+              '@type': 'Value',
+              list: [
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 2 } },
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 3 } },
+              ],
+            },
+          },
+          {
+            '@type': 'SetUnion',
+            list_a: { '@type': 'Value', variable: 'ListA' },
+            list_b: { '@type': 'Value', variable: 'ListB' },
+            result: { '@type': 'Value', variable: 'All' },
+          },
+        ],
+      }
+
+      const result = await woql.post(agent, query)
+      expect(result.status).to.equal(200)
+      expect(result.body.bindings).to.have.length(1)
+      const all = result.body.bindings[0].All
+      const allValues = all.map(v => v['@value'])
+      expect(allValues).to.deep.equal([1, 2, 3])
+    })
+
+    it('removes duplicates', async function () {
+      const query = {
+        '@type': 'And',
+        and: [
+          {
+            '@type': 'Equals',
+            left: { '@type': 'Value', variable: 'ListA' },
+            right: {
+              '@type': 'Value',
+              list: [
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 1 } },
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 1 } },
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 2 } },
+              ],
+            },
+          },
+          {
+            '@type': 'Equals',
+            left: { '@type': 'Value', variable: 'ListB' },
+            right: {
+              '@type': 'Value',
+              list: [
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 2 } },
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 2 } },
+              ],
+            },
+          },
+          {
+            '@type': 'SetUnion',
+            list_a: { '@type': 'Value', variable: 'ListA' },
+            list_b: { '@type': 'Value', variable: 'ListB' },
+            result: { '@type': 'Value', variable: 'All' },
+          },
+        ],
+      }
+
+      const result = await woql.post(agent, query)
+      expect(result.status).to.equal(200)
+      expect(result.body.bindings).to.have.length(1)
+      const all = result.body.bindings[0].All
+      const allValues = all.map(v => v['@value'])
+      expect(allValues).to.deep.equal([1, 2])
+    })
+  })
+
+  describe('set_member', function () {
+    it('checks membership in a set efficiently', async function () {
+      const query = {
+        '@type': 'And',
+        and: [
+          {
+            '@type': 'Equals',
+            left: { '@type': 'Value', variable: 'MySet' },
+            right: {
+              '@type': 'Value',
+              list: [
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 1 } },
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 2 } },
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 3 } },
+              ],
+            },
+          },
+          {
+            '@type': 'SetMember',
+            element: { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 2 } },
+            set: { '@type': 'Value', variable: 'MySet' },
+          },
+        ],
+      }
+
+      const result = await woql.post(agent, query)
+      expect(result.status).to.equal(200)
+      expect(result.body.bindings).to.have.length(1)
+    })
+
+    it('fails for non-member', async function () {
+      const query = {
+        '@type': 'And',
+        and: [
+          {
+            '@type': 'Equals',
+            left: { '@type': 'Value', variable: 'MySet' },
+            right: {
+              '@type': 'Value',
+              list: [
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 1 } },
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 2 } },
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 3 } },
+              ],
+            },
+          },
+          {
+            '@type': 'SetMember',
+            element: { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 5 } },
+            set: { '@type': 'Value', variable: 'MySet' },
+          },
+        ],
+      }
+
+      const result = await woql.post(agent, query)
+      expect(result.status).to.equal(200)
+      expect(result.body.bindings).to.have.length(0)
+    })
+  })
+
+  describe('list_to_set', function () {
+    it('converts list to set removing duplicates and sorting', async function () {
+      const query = {
+        '@type': 'And',
+        and: [
+          {
+            '@type': 'Equals',
+            left: { '@type': 'Value', variable: 'MyList' },
+            right: {
+              '@type': 'Value',
+              list: [
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 3 } },
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 1 } },
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 2 } },
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 1 } },
+              ],
+            },
+          },
+          {
+            '@type': 'ListToSet',
+            list: { '@type': 'Value', variable: 'MyList' },
+            set: { '@type': 'Value', variable: 'MySet' },
+          },
+        ],
+      }
+
+      const result = await woql.post(agent, query)
+      expect(result.status).to.equal(200)
+      expect(result.body.bindings).to.have.length(1)
+      const mySet = result.body.bindings[0].MySet
+      const mySetValues = mySet.map(v => v['@value'])
+      expect(mySetValues).to.deep.equal([1, 2, 3])
+    })
+  })
+
+  describe('incommensurable types behavior', function () {
+    it('treats same value with different types as distinct elements in set_difference', async function () {
+      const query = {
+        '@type': 'And',
+        and: [
+          {
+            '@type': 'Equals',
+            left: { '@type': 'Value', variable: 'ListA' },
+            right: {
+              '@type': 'Value',
+              list: [
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 1 } },
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 2 } },
+              ],
+            },
+          },
+          {
+            '@type': 'Equals',
+            left: { '@type': 'Value', variable: 'ListB' },
+            right: {
+              '@type': 'Value',
+              list: [
+                { '@type': 'Value', data: { '@type': 'xsd:decimal', '@value': 1 } },
+                { '@type': 'Value', data: { '@type': 'xsd:decimal', '@value': 2 } },
+              ],
+            },
+          },
+          {
+            '@type': 'SetDifference',
+            list_a: { '@type': 'Value', variable: 'ListA' },
+            list_b: { '@type': 'Value', variable: 'ListB' },
+            result: { '@type': 'Value', variable: 'Diff' },
+          },
+        ],
+      }
+
+      const result = await woql.post(agent, query)
+      expect(result.status).to.equal(200)
+      expect(result.body.bindings).to.have.length(1)
+      const diff = result.body.bindings[0].Diff
+      // Both integers remain because decimals are different types
+      expect(diff.length).to.equal(2)
+      const diffValues = diff.map(v => v['@value'])
+      expect(diffValues).to.deep.equal([1, 2])
+    })
+
+    it('treats same value with different types as distinct in set_intersection', async function () {
+      const query = {
+        '@type': 'And',
+        and: [
+          {
+            '@type': 'Equals',
+            left: { '@type': 'Value', variable: 'ListA' },
+            right: {
+              '@type': 'Value',
+              list: [
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 1 } },
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 2 } },
+              ],
+            },
+          },
+          {
+            '@type': 'Equals',
+            left: { '@type': 'Value', variable: 'ListB' },
+            right: {
+              '@type': 'Value',
+              list: [
+                { '@type': 'Value', data: { '@type': 'xsd:decimal', '@value': 1 } },
+                { '@type': 'Value', data: { '@type': 'xsd:decimal', '@value': 2 } },
+              ],
+            },
+          },
+          {
+            '@type': 'SetIntersection',
+            list_a: { '@type': 'Value', variable: 'ListA' },
+            list_b: { '@type': 'Value', variable: 'ListB' },
+            result: { '@type': 'Value', variable: 'Common' },
+          },
+        ],
+      }
+
+      const result = await woql.post(agent, query)
+      expect(result.status).to.equal(200)
+      expect(result.body.bindings).to.have.length(1)
+      const common = result.body.bindings[0].Common
+      // No common elements because types differ
+      expect(common).to.deep.equal([])
+    })
+
+    it('treats same value with different types as distinct in set_union', async function () {
+      const query = {
+        '@type': 'And',
+        and: [
+          {
+            '@type': 'Equals',
+            left: { '@type': 'Value', variable: 'ListA' },
+            right: {
+              '@type': 'Value',
+              list: [
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 1 } },
+              ],
+            },
+          },
+          {
+            '@type': 'Equals',
+            left: { '@type': 'Value', variable: 'ListB' },
+            right: {
+              '@type': 'Value',
+              list: [
+                { '@type': 'Value', data: { '@type': 'xsd:decimal', '@value': 1 } },
+              ],
+            },
+          },
+          {
+            '@type': 'SetUnion',
+            list_a: { '@type': 'Value', variable: 'ListA' },
+            list_b: { '@type': 'Value', variable: 'ListB' },
+            result: { '@type': 'Value', variable: 'All' },
+          },
+        ],
+      }
+
+      const result = await woql.post(agent, query)
+      expect(result.status).to.equal(200)
+      expect(result.body.bindings).to.have.length(1)
+      const all = result.body.bindings[0].All
+      // Both elements present because types differ
+      expect(all.length).to.equal(2)
+    })
+
+    it('set_member requires exact type match', async function () {
+      const query = {
+        '@type': 'And',
+        and: [
+          {
+            '@type': 'Equals',
+            left: { '@type': 'Value', variable: 'MySet' },
+            right: {
+              '@type': 'Value',
+              list: [
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 1 } },
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 2 } },
+              ],
+            },
+          },
+          {
+            '@type': 'SetMember',
+            element: { '@type': 'Value', data: { '@type': 'xsd:decimal', '@value': 1 } },
+            set: { '@type': 'Value', variable: 'MySet' },
+          },
+        ],
+      }
+
+      const result = await woql.post(agent, query)
+      expect(result.status).to.equal(200)
+      // No match because decimal 1 is not in set of integers
+      expect(result.body.bindings).to.have.length(0)
+    })
+
+    it('list_to_set preserves distinct types', async function () {
+      const query = {
+        '@type': 'And',
+        and: [
+          {
+            '@type': 'Equals',
+            left: { '@type': 'Value', variable: 'MyList' },
+            right: {
+              '@type': 'Value',
+              list: [
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 1 } },
+                { '@type': 'Value', data: { '@type': 'xsd:decimal', '@value': 1 } },
+                { '@type': 'Value', data: { '@type': 'xsd:integer', '@value': 1 } },
+              ],
+            },
+          },
+          {
+            '@type': 'ListToSet',
+            list: { '@type': 'Value', variable: 'MyList' },
+            set: { '@type': 'Value', variable: 'MySet' },
+          },
+        ],
+      }
+
+      const result = await woql.post(agent, query)
+      expect(result.status).to.equal(200)
+      expect(result.body.bindings).to.have.length(1)
+      const mySet = result.body.bindings[0].MySet
+      // Two elements: integer 1 and decimal 1 (duplicate integer removed)
+      expect(mySet.length).to.equal(2)
+    })
+  })
+
+  describe('performance test', function () {
+    // Helper to build Value list arrays
+    const buildArray = (size, offset = 0) => Array.from({ length: size }, (_, i) => ({
+      '@type': 'Value',
+      data: { '@type': 'xsd:integer', '@value': offset + i },
+    }))
+
+    // Helper to measure set operation time by comparing with/without
+    const measureSetOpTime = async (size, opType, opName) => {
+      const arrayA = buildArray(size, 0)
+      const arrayB = buildArray(size, Math.floor(size / 2))
+
+      // Query WITHOUT set operation
+      const queryWithout = {
+        '@type': 'And',
+        and: [
+          {
+            '@type': 'Equals',
+            left: { '@type': 'Value', variable: 'ListA' },
+            right: { '@type': 'Value', list: arrayA },
+          },
+          {
+            '@type': 'Equals',
+            left: { '@type': 'Value', variable: 'ListB' },
+            right: { '@type': 'Value', list: arrayB },
+          },
+        ],
+      }
+
+      // Query WITH set operation
+      const queryWith = {
+        '@type': 'And',
+        and: [
+          {
+            '@type': 'Equals',
+            left: { '@type': 'Value', variable: 'ListA' },
+            right: { '@type': 'Value', list: arrayA },
+          },
+          {
+            '@type': 'Equals',
+            left: { '@type': 'Value', variable: 'ListB' },
+            right: { '@type': 'Value', list: arrayB },
+          },
+          {
+            '@type': opType,
+            list_a: { '@type': 'Value', variable: 'ListA' },
+            list_b: { '@type': 'Value', variable: 'ListB' },
+            result: { '@type': 'Value', variable: 'Result' },
+          },
+        ],
+      }
+
+      // Run without
+      const startWithout = Date.now()
+      await woql.post(agent, queryWithout)
+      const elapsedWithout = Date.now() - startWithout
+
+      // Run with
+      const startWith = Date.now()
+      const resultWith = await woql.post(agent, queryWith)
+      const elapsedWith = Date.now() - startWith
+
+      expect(resultWith.status).to.equal(200)
+
+      const opTime = elapsedWith - elapsedWithout
+      console.log('        ' + opName + ' ' + size + 'x' + size + ' elements: ' + opTime + 'ms')
+      return opTime
+    }
+
+    // set_difference timing tests
+    it('set_difference timing: 1000 elements', async function () {
+      const time = await measureSetOpTime(1000, 'SetDifference', 'set_difference')
+      expect(time).to.be.below(100)
+    })
+
+    it('set_difference timing: 5000 elements', async function () {
+      const time = await measureSetOpTime(5000, 'SetDifference', 'set_difference')
+      expect(time).to.be.below(200)
+    })
+
+    it('set_difference timing: 10000 elements', async function () {
+      const time = await measureSetOpTime(10000, 'SetDifference', 'set_difference')
+      expect(time).to.be.below(500)
+    })
+
+    // set_intersection timing tests
+    it('set_intersection timing: 1000 elements', async function () {
+      const time = await measureSetOpTime(1000, 'SetIntersection', 'set_intersection')
+      expect(time).to.be.below(100)
+    })
+
+    it('set_intersection timing: 5000 elements', async function () {
+      const time = await measureSetOpTime(5000, 'SetIntersection', 'set_intersection')
+      expect(time).to.be.below(200)
+    })
+
+    it('set_intersection timing: 10000 elements', async function () {
+      const time = await measureSetOpTime(10000, 'SetIntersection', 'set_intersection')
+      expect(time).to.be.below(500)
+    })
+  })
+})


### PR DESCRIPTION
This PR adds five new WOQL predicates for efficient set operations, with full support in both the JavaScript and Python client libraries.

## Background

WOQL queries that need to compare or manipulate sets currently rely on the `member/2` predicate with nested iterations, resulting in O(n²) complexity. For example, comparing two lists of 5000 elements each can take approximately 10 seconds. This performance bottleneck limits the practical use of set-based operations in production environments.

## Task

Implement native WOQL set operations that leverage Prolog's ordsets library for O(n log n) performance:

- `set_difference` - compute elements in list A but not in list B
- `set_intersection` - compute elements common to both lists  
- `set_union` - compute all unique elements from both lists
- `set_member` - efficient O(log n) membership check using binary search
- `list_to_set` - convert a list to a sorted set (removes duplicates)

## Goal

Reduce the complexity of set operations from O(n²) to O(n log n), enabling practical use of set comparisons on large datasets. A comparison of 5000×5000 elements should complete in under 100ms rather than ~10 seconds.

## Design Decision: Type Handling

Set operations use **full typed literal comparison**. This means:

- `2^^xsd:integer` and `2^^xsd:decimal` are treated as **different** elements
- Types from original lists are preserved exactly in results
- For `set_intersection` and `set_union`, the type from the first list (ListA) takes precedence when elements match

**Rationale**: This approach is consistent with Prolog's term comparison semantics and preserves type information which may be semantically important. Users who need value-based comparison (ignoring types) should normalize their data types before performing set operations.

## Changes

### TerminusDB Engine

**`src/core/query/definition.pl`**
- Added definitions for `SetDifference`, `SetIntersection`, `SetUnion`, `SetMember`, and `ListToSet` predicates
- Specified field names, modes, and types for each operation

**`src/core/query/woql_compile.pl`**
- Added `use_module(library(ordsets))` import for efficient set operations
- Implemented `compile_wf` clauses for all five set operations
- Added implementation predicates using ordsets:
  - `set_difference_impl/3` - uses `ord_subtract`
  - `set_intersection_impl/3` - uses `ord_intersection`
  - `set_union_impl/3` - uses `ord_union`
  - `set_member_impl/2` - uses `ord_memberchk`
  - `list_to_set_impl/2` - uses `list_to_ord_set`
- Added `unwrap_value/2` helper for typed literal handling

**`src/core/query/set_operations_test.pl`** (new file)
- Unit tests for all set operations
- Tests cover basic functionality, edge cases (empty results, non-members)

**`tests/test/woql-set-operations.js`** (new file)
- Integration tests using the WOQL JSON API
- Tests for correctness and performance with large sets

### JavaScript Client

**`lib/query/woqlQuery.js`**
- Added `set_difference(listA, listB, result)` method
- Added `set_intersection(listA, listB, result)` method
- Added `set_union(listA, listB, result)` method
- Added `set_member(element, set)` method
- Added `list_to_set(list, set)` method

**`integration_tests/woql_set_operations.test.ts`** (new file)
- Integration tests for all set operations via the client library

### Python Client

**`terminusdb_client/woqlquery/woql_query.py`**
- Added `set_difference(list_a, list_b, result)` method
- Added `set_intersection(list_a, list_b, result)` method  
- Added `set_union(list_a, list_b, result)` method
- Added `set_member(element, set_list)` method
- Added `list_to_set(input_list, result_set)` method

**`terminusdb_client/tests/integration_tests/test_woql_set_operations.py`** (new file)
- Integration tests for all set operations via the Python client

## Usage Examples

### JavaScript Client
```javascript
// Find elements in A but not in B
WOQL.and(
  WOQL.eq("v:ListA", [1, 2, 3, 4]),
  WOQL.eq("v:ListB", [2, 4]),
  WOQL.set_difference("v:ListA", "v:ListB", "v:Diff")
)
// Result: Diff = [1, 3]

// Check if element is in set
WOQL.and(
  WOQL.eq("v:MySet", [1, 2, 3]),
  WOQL.set_member(2, "v:MySet")
)
// Succeeds if 2 is in MySet
```

### Python Client
```python
# Find common elements
WOQLQuery().woql_and(
    WOQLQuery().eq("v:ListA", [1, 2, 3]),
    WOQLQuery().eq("v:ListB", [2, 3, 4]),
    WOQLQuery().set_intersection("v:ListA", "v:ListB", "v:Common")
)
# Result: Common = [2, 3]

# Convert list to set (removes duplicates, sorts)
WOQLQuery().woql_and(
    WOQLQuery().eq("v:MyList", [3, 1, 2, 1]),
    WOQLQuery().list_to_set("v:MyList", "v:MySet")
)
# Result: MySet = [1, 2, 3]
```

### Raw WOQL JSON
```json
{
  "@type": "SetDifference",
  "list_a": {"@type": "Value", "variable": "ListA"},
  "list_b": {"@type": "Value", "variable": "ListB"},
  "result": {"@type": "Value", "variable": "Diff"}
}
```

## Performance

The implementation uses Prolog's ordsets library which provides:
- O(n log n) for set operations (sort + linear merge)
- O(log n) for membership checks via binary search

This represents a significant improvement over the previous O(n²) approach using nested `member/2` calls.

### Benchmark Results

Measured set operation time (excluding data transfer overhead) for provided datasets with two lists, where the difference vs intersection is half of the elements.

Linearly comparing them would be 100'000x100'000 comparisons, 10B comparisons, instead of how the algoritm performs approx 3000x less operations, or the equivalent of approx. 3.4 million operations:

| Elements | set_difference | set_intersection |
|----------|----------------|------------------|
| 1,000    | 7ms            | 5ms              |
| 5,000    | 30ms           | 17ms             |
| 10,000   | 64ms           | 66ms             |
| 100,000  | 577ms          | 445ms            |

The scaling pattern confirms O(n log n) complexity. The 100,000 element benchmark demonstrates the operations remain practical even at scale, completing in under 600ms.