### PR TITLE
Add use-system-gmp feature flag for system GMP/MPFR

### DIFF
--- a/distribution/Makefile.rust
+++ b/distribution/Makefile.rust
@@ -21,10 +21,10 @@ endif
 
 ifeq "$(shell uname)" "Darwin"
   DYLIB_EXT := dylib
-  FEATURES := --no-default-features
+  FEATURES ?= --no-default-features
 else
   DYLIB_EXT := so
-  FEATURES :=
+  FEATURES ?=
 endif
 
 TARGET := $(COMMUNITY_SRC_DIR)/librust.$(DYLIB_EXT)

--- a/src/rust/terminusdb-community/Cargo.toml
+++ b/src/rust/terminusdb-community/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [features]
 default = []
 gmp = ["gmp-mpfr-sys"]
+use-system-gmp = ["gmp-mpfr-sys/use-system-libs"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -39,10 +40,10 @@ tdb-succinct = "0.1.2"
 # Security fix: Force upgrade of transitive dependencies to fix CVE in idna 0.5.0
 # Punycode domain masking vulnerability - upgrade to idna 1.0.3+
 url = "2.5.4"
+gmp-mpfr-sys = { version = "~1.5", default-features = false, optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 rug = { version = "1.17", default-features = false, features = [] }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 rug = {version = "1.17", default-features = false, features=["integer","rational"]}
-gmp-mpfr-sys = { version = "~1.5", default-features = false, features = ["use-system-libs"], optional = true }


### PR DESCRIPTION
~This change makes the Rust build prefer system-provided GMP/MPFR (via `gmp-mpfr-sys`’s `use-system-libs` feature) instead of building bundled copies, as already done with: https://github.com/terminusdb/terminusdb/blob/4dbf984c3786975a81a5293e8bbd4d9b432bfec7/src/rust/terminusdb-community/Cargo.toml#L48~

Add `use-system-gmp` feature flag for system GMP/MPFR

Optional cargo feature to use system GMP/MPFR libraries instead of bundled.

Context: this was identified while packaging TerminusDB in Nixpkgs: https://github.com/NixOS/nixpkgs/pull/303209

<!--
Thanks for taking the time to contribute!

Is this your first pull request? If you don't mind, please read this first.

<https://github.com/terminusdb/terminusdb/blob/main/docs/CONTRIBUTING.md>
-->
