### PR TITLE
tests: respect TERMINUSDB_EXEC_PATH override

### DIFF
--- a/tests/terminusdb.sh
+++ b/tests/terminusdb.sh
@@ -49,5 +49,5 @@ elif [[ $use_exec -eq 0 ]]; then
   if [ -t 1 ]; then
     set -x
   fi
-  TERMINUSDB_LOG_LEVEL="ERROR" "$TERMINUSDB_EXEC_PATH" "$@"
+  exec env TERMINUSDB_LOG_LEVEL="ERROR" "$TERMINUSDB_EXEC_PATH" "$@"
 fi

--- a/tests/test/cli-version.js
+++ b/tests/test/cli-version.js
@@ -1,7 +1,6 @@
-const path = require('path')
 const exec = require('util').promisify(require('child_process').exec)
 const { expect } = require('chai')
-const { info } = require('../lib')
+const { info, util } = require('../lib')
 
 describe('cli-version', function () {
   it('passes string match (git hash matches binary)', async function () {
@@ -14,16 +13,9 @@ describe('cli-version', function () {
       return
     }
 
-    const testDir = path.join(__dirname, '..')
-    const terminusdbSh = path.join(testDir, 'terminusdb.sh')
-    const rootDir = path.join(testDir, '..')
-    const terminusdbExec = path.join(rootDir, 'terminusdb')
-
     const terminusdbVersion = await info.terminusdbVersion()
     const gitHash = await info.gitHash()
-    const r = await exec(`${terminusdbSh} --version`, {
-      env: { ...process.env, TERMINUSDB_EXEC_PATH: process.env.TERMINUSDB_EXEC_PATH || terminusdbExec },
-    })
+    const r = await exec(`${util.terminusdbScript()} --version`)
     expect(r.stdout).to.match(new RegExp(
       `^TerminusDB v${terminusdbVersion} \\(${gitHash}\\)\nterminusdb-store v.*`,
     ))

--- a/tests/test/memory-mode.js
+++ b/tests/test/memory-mode.js
@@ -1,10 +1,8 @@
 const { expect } = require('chai')
 const { spawn } = require('child_process')
 const http = require('http')
-const path = require('path')
-
+const { util } = require('../lib')
 // Skip these tests when no local binary is available (e.g., Docker-based CI)
-// These tests spawn the local terminusdb binary directly
 const SKIP_MEMORY_MODE_TESTS = process.env.SKIP_MEMORY_MODE_TESTS === 'true'
 
 describe('In-Memory Mode', function () {
@@ -72,9 +70,7 @@ describe('In-Memory Mode', function () {
     })
 
     it('should start server in memory mode with custom password', async function () {
-      const terminusdbPath = process.env.TERMINUSDB_EXEC_PATH || path.join(__dirname, '../../terminusdb')
-
-      serverProcess = spawn(terminusdbPath, ['serve', '--memory', PASSWORD], {
+      serverProcess = spawn(util.terminusdbScript(), ['serve', '--memory', PASSWORD], {
         env: { ...process.env, TERMINUSDB_SERVER_PORT: PORT.toString() },
         stdio: ['ignore', 'pipe', 'pipe'],
       })
@@ -95,9 +91,7 @@ describe('In-Memory Mode', function () {
     })
 
     it('should start server in memory mode with default password', async function () {
-      const terminusdbPath = process.env.TERMINUSDB_EXEC_PATH || path.join(__dirname, '../../terminusdb')
-
-      serverProcess = spawn(terminusdbPath, ['serve', '-m'], {
+      serverProcess = spawn(util.terminusdbScript(), ['serve', '-m'], {
         env: { ...process.env, TERMINUSDB_SERVER_PORT: PORT.toString() },
         stdio: ['ignore', 'pipe', 'pipe'],
       })
@@ -118,9 +112,7 @@ describe('In-Memory Mode', function () {
     })
 
     it('should allow database creation in memory mode', async function () {
-      const terminusdbPath = process.env.TERMINUSDB_EXEC_PATH || path.join(__dirname, '../../terminusdb')
-
-      serverProcess = spawn(terminusdbPath, ['serve', '--memory', PASSWORD], {
+      serverProcess = spawn(util.terminusdbScript(), ['serve', '--memory', PASSWORD], {
         env: { ...process.env, TERMINUSDB_SERVER_PORT: PORT.toString() },
         stdio: ['ignore', 'pipe', 'pipe'],
       })
@@ -149,9 +141,7 @@ describe('In-Memory Mode', function () {
     })
 
     it('should return info endpoint with version information', async function () {
-      const terminusdbPath = process.env.TERMINUSDB_EXEC_PATH || path.join(__dirname, '../../terminusdb')
-
-      serverProcess = spawn(terminusdbPath, ['serve', '--memory', PASSWORD], {
+      serverProcess = spawn(util.terminusdbScript(), ['serve', '--memory', PASSWORD], {
         env: { ...process.env, TERMINUSDB_SERVER_PORT: PORT.toString() },
         stdio: ['ignore', 'pipe', 'pipe'],
       })
@@ -199,9 +189,7 @@ describe('In-Memory Mode', function () {
     let auth
 
     before(async function () {
-      const terminusdbPath = process.env.TERMINUSDB_EXEC_PATH || path.join(__dirname, '../../terminusdb')
-
-      serverProcess = spawn(terminusdbPath, ['serve', '--memory', PASSWORD], {
+      serverProcess = spawn(util.terminusdbScript(), ['serve', '--memory', PASSWORD], {
         env: { ...process.env, TERMINUSDB_SERVER_PORT: PORT.toString() },
         stdio: ['ignore', 'pipe', 'pipe'],
       })


### PR DESCRIPTION
This PR makes specific test files prefer `TERMINUSDB_EXEC_PATH` when spawning the TerminusDB CLI, while keeping the existing in-tree `./terminusdb` default when the variable is unset.

Updated:
- `tests/test/cli-version.js` (env passed to `terminusdb.sh --version`)
- `tests/test/memory-mode.js` (binary path used for `spawn(...)` in the memory-mode tests)

This helps downstream packagers and CI environments run the JS integration tests against an installed binary, wrapper script, or non-standard build output location without patching the repository.

Context: originally identified while packaging TerminusDB in Nixpkgs: https://github.com/NixOS/nixpkgs/pull/303209

<!--
Thanks for taking the time to contribute!

Is this your first pull request? If you don't mind, please read this first.

<https://github.com/terminusdb/terminusdb/blob/main/docs/CONTRIBUTING.md>
-->
