### PR TITLE
fix: handle dicts/lists/numbers in SwapValue patches

### DIFF
--- a/src/core/document/patch.pl
+++ b/src/core/document/patch.pl
@@ -111,6 +111,19 @@ pairs_and_conflicts_from_keys([Key|Keys], JSON, Diff,
 % In Prolog, atoms and strings don't unify even with identical characters,
 % so we convert both to atoms before comparison.
 %
+% Dicts (subdocument objects), lists, and numbers are compared
+% structurally — only atoms and strings use coerced comparison.
+%
+values_equal(V1, V2) :-
+    (   is_dict(V1)
+    ;   is_dict(V2)
+    ;   is_list(V1)
+    ;   is_list(V2)
+    ;   number(V1)
+    ;   number(V2)
+    ),
+    !,
+    V1 = V2.
 values_equal(V1, V2) :-
     % Convert both to atoms for comparison
     (   atom(V1) -> A1 = V1 ; atom_string(A1, V1)),
@@ -958,6 +971,107 @@ test(star_wars_films_patch, []) :-
 		                    ],
 	                   url:"http://swapi.co/api/starships/12/"
 	                 }).
+
+% ------------------------------------------------------------------
+% Tests for values_equal/2 with dicts, lists, and numbers
+% (Regression: atom_string/2 crashes on dict arguments)
+% ------------------------------------------------------------------
+
+test(swap_null_to_subdocument, []) :-
+    %% SwapValue from null to a subdocument dict — the original crash case.
+    Before = _{ '@id' : "Entity/e1",
+                '@type' : "Entity",
+                quantity : null
+              },
+    SubDoc = json{ '@id' : "Entity/e1/quantity/Quantity/1",
+                   '@type' : "Quantity",
+                   value : 42
+                 },
+    Patch = _{ quantity : _{ '@op' : "SwapValue",
+                             '@before' : null,
+                             '@after' : SubDoc }
+             },
+    After = _{ '@id' : "Entity/e1",
+               '@type' : "Entity",
+               quantity : SubDoc
+             },
+    simple_patch(Patch, Before, success(After), []).
+
+test(swap_subdocument_to_null, []) :-
+    %% SwapValue from a subdocument dict back to null.
+    SubDoc = json{ '@id' : "Entity/e1/quantity/Quantity/1",
+                   '@type' : "Quantity",
+                   value : 42
+                 },
+    Before = _{ '@id' : "Entity/e1",
+                '@type' : "Entity",
+                quantity : SubDoc
+              },
+    Patch = _{ quantity : _{ '@op' : "SwapValue",
+                             '@before' : SubDoc,
+                             '@after' : null }
+             },
+    After = _{ '@id' : "Entity/e1",
+               '@type' : "Entity",
+               quantity : null
+             },
+    simple_patch(Patch, Before, success(After), []).
+
+test(swap_between_subdocuments, []) :-
+    %% SwapValue between two different subdocument dicts.
+    SubDoc1 = json{ '@id' : "Entity/e1/quantity/Quantity/1",
+                    '@type' : "Quantity",
+                    value : 42
+                  },
+    SubDoc2 = json{ '@id' : "Entity/e1/quantity/Quantity/2",
+                    '@type' : "Quantity",
+                    value : 99
+                  },
+    Before = _{ '@id' : "Entity/e1",
+                '@type' : "Entity",
+                quantity : SubDoc1
+              },
+    Patch = _{ quantity : _{ '@op' : "SwapValue",
+                             '@before' : SubDoc1,
+                             '@after' : SubDoc2 }
+             },
+    After = _{ '@id' : "Entity/e1",
+               '@type' : "Entity",
+               quantity : SubDoc2
+             },
+    simple_patch(Patch, Before, success(After), []).
+
+test(swap_string_value_regression, []) :-
+    %% Regression: normal string SwapValue must still work.
+    Before = _{ '@id' : "Person/1",
+                '@type' : "Person",
+                name : "alice"
+              },
+    Patch = _{ name : _{ '@op' : "SwapValue",
+                         '@before' : "alice",
+                         '@after' : "bob" }
+             },
+    After = _{ '@id' : "Person/1",
+               '@type' : "Person",
+               name : "bob"
+             },
+    simple_patch(Patch, Before, success(After), []).
+
+test(values_equal_dict_identity, []) :-
+    %% Direct unit test: equal dicts should unify.
+    D = json{ '@type' : "Quantity", value : 1 },
+    values_equal(D, D).
+
+test(values_equal_dict_not_equal, [fail]) :-
+    %% Direct unit test: different dicts must fail.
+    D1 = json{ '@type' : "Quantity", value : 1 },
+    D2 = json{ '@type' : "Quantity", value : 2 },
+    values_equal(D1, D2).
+
+test(values_equal_null_vs_dict, [fail]) :-
+    %% Direct unit test: null (atom) vs dict must fail, NOT throw.
+    D = json{ '@type' : "Quantity", value : 1 },
+    values_equal(null, D).
 
 :- end_tests(simple_patch).
 


### PR DESCRIPTION
## Summary
- Replaces #2406 from a writable public fork because the original PR branch can no longer be updated.
- Cherry-picks the original fix for `values_equal/2` so `SwapValue` handles dicts, lists, numbers, and null without crashing on `atom_string/2`.
- Adds regression coverage for subdocument swap cases and direct `values_equal/2` comparisons.

## Testing
- `docker build . --file Dockerfile --target base_community --build-arg SKIP_TESTS=true --build-arg SWIPL_VERSION=10.0.1 --build-arg TERMINUSDB_GIT_HASH="$(git rev-parse --verify HEAD)"`
- `docker run --rm cd9f02017816bc9c8787f3463dea88c1d3516c4ce0692c8447eeba6b2411b034 make test SUITE=simple_patch` - All 26 tests passed

## Local note
- Native `make test SUITE=simple_patch` requires a newer system SWI-Prolog than Ubuntu 22.04's `8.4.2`; the project Docker build uses `swipl:10.0.1` and passes.