### PR TITLE
Add api to render embeddings using handlebars

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -857,6 +857,17 @@ paths:
       parameters:
         - $ref: '#/components/parameters/resource_path'
         - $ref: '#/components/parameters/graph_type'
+        - name: format
+          in: query
+          required: false
+          description: |
+            Output format for retrieved documents.
+            - `json` (default): Standard JSON document representation
+            - `embedding`: Text/plain rendered embedding string using schema-defined Handlebars template. Requires the document type to have an embedding query defined in `@metadata.embedding`.
+          schema:
+            type: string
+            enum: [json, embedding]
+            default: json
         - name: skip
           in: query
           description: Skip a certain amount of documents

--- a/src/core/api/api_document.pl
+++ b/src/core/api/api_document.pl
@@ -63,6 +63,7 @@
 
 document_input_format(json).
 document_output_format(json).
+document_output_format(embedding).
 
 detect_input_format(ContentType, Format) :-
     (   re_match('^application/json', ContentType, [])
@@ -105,6 +106,7 @@ accept_to_format(application/json, json).
 accept_to_format(application/'ld+json', jsonld).
 accept_to_format(application/'rdf+xml', rdfxml).
 accept_to_format(text/turtle, turtle).
+accept_to_format(text/plain, embedding).
 
 before_read(Descriptor, Requested_Data_Version, Actual_Data_Version, Transaction) :-
     do_or_die(
@@ -668,7 +670,8 @@ format_read_documents(Format, Transaction, Graph_Type, Id, Ids, Type, Query, Con
     database_context_object(Transaction, SchemaContext),
     database_prefixes(Transaction, InternalPrefixes),
     put_dict(schema_context, Config, SchemaContext, Config1),
-    put_dict(internal_prefixes, Config1, InternalPrefixes, ConfigWithCtx),
+    put_dict(internal_prefixes, Config1, InternalPrefixes, Config2),
+    put_dict(transaction, Config2, Transaction, ConfigWithCtx),
 
     Request = ConfigWithCtx.request,
     document_stream_headers(Format, Request, DataVersion),
@@ -699,6 +702,129 @@ format_read_documents(Format, Transaction, Graph_Type, Id, Ids, Type, Query, Con
 
     document_stream_end(Format, ConfigWithCtx).
 
+% Embedding helpers
+embedding_type_queries_from_transaction(Transaction, TypeQueries) :-
+    database_schema(Transaction, Schema),
+    findall(
+        Type-Query-Template,
+        (   xrdf(Schema, Type, sys:metadata, _),
+            schema_metadata_descriptor(Schema, Type, metadata(Metadata)),
+            get_dict(embedding, Metadata, Embedding),
+            get_dict(query, Embedding, Query),
+            (   get_dict(template, Embedding, Template)
+            ->  true
+            ;   Template = none)),
+        TypeQueries
+    ).
+
+% Normalize a document type IRI to the schema namespace.
+% Some instance documents store rdf:type with the @base prefix;
+% for matching against schema classes we need the @schema prefix.
+normalize_document_type(Transaction, DocType, Normalized) :-
+    database_prefixes(Transaction, Prefixes),
+    (   get_dict('@base', Prefixes, Base),
+        get_dict('@schema', Prefixes, Schema),
+        atom_concat(Base, Local, DocType)
+    ->  atom_concat(Schema, Local, Normalized)
+    ;   Normalized = DocType
+    ).
+
+embedding_document_types(Transaction, _Graph_Type, Id, Ids, Type, Query, DocTypes) :-
+    database_prefixes(Transaction, Prefixes),
+    (   nonvar(Query)
+    ->  expand_query_document(Transaction, Type, Query, _Query_Ex, Type_Ex),
+        (   ground(Type_Ex)
+        ->  prefix_expand(Type_Ex, Prefixes, Expanded),
+          findall(DT, (class_subsumed(Transaction, DT, Expanded),
+                       is_instance_class(Transaction, _, DT)),
+                  DocTypes)
+        ;   findall(DT, is_instance_class(Transaction, _, DT), DocTypes)
+        )
+    ;   ground(Id)
+    ->  findall(Norm,
+                (   ask(Transaction, t(Id, rdf:type, DT),
+                        [compress_prefixes(false)]),
+                    normalize_document_type(Transaction, DT, Norm)),
+                DocTypes)
+    ;   ground(Ids)
+    ->  findall(Norm,
+                (   member(OneId, Ids),
+                    ask(Transaction, t(OneId, rdf:type, DT),
+                        [compress_prefixes(false)]),
+                    normalize_document_type(Transaction, DT, Norm)),
+                DocTypes)
+    ;   ground(Type)
+    ->  prefix_expand(Type, Prefixes, Expanded),
+        findall(DT, (class_subsumed(Transaction, DT, Expanded),
+                     is_instance_class(Transaction, _, DT)),
+                DocTypes)
+    ;   findall(DT, is_instance_class(Transaction, _, DT), DocTypes)
+    ).
+
+% Embedding stream handlers
+document_stream_headers(embedding, Request, DataVersion) :-
+    routes:write_cors_headers(Request),
+    (   DataVersion \= no_data_version
+    ->  routes:write_data_version_header(DataVersion)
+    ;   true
+    ),
+    format("Transfer-Encoding: chunked~n"),
+    format("Content-type: text/plain; charset=UTF-8~n~n").
+
+document_stream_start(embedding, Config, StreamState) :-
+    System_DB = Config.system_db,
+    Transaction = Config.transaction,
+    embedding_type_queries_from_transaction(Transaction, TypeQueries),
+    maplist([Type-Query-_Template, Type-Query]>>true, TypeQueries, Queries),
+    convlist([Type-Query-Template, Type-Template]>>ground(Template),
+             TypeQueries, Templates),
+    all_class_frames(Transaction, Frames,
+                     [compress_ids(true), expand_abstract(true), simple(true)]),
+    '$embedding':embedding_context(System_DB, Transaction, Templates, Queries,
+                                   Frames, EmbeddingContext),
+    StreamState = state(System_DB, Transaction, EmbeddingContext).
+
+document_stream_write(embedding, _Config, StreamState, Document) :-
+    StreamState = state(System_DB, Transaction, EmbeddingContext),
+    get_dict('@type', Document, Type),
+    database_prefixes(Transaction, Prefixes),
+    prefix_expand_schema(Type, Prefixes, Type_Ex),
+    get_dict('@id', Document, Id),
+    prefix_expand(Id, Prefixes, Id_Ex),
+    '$embedding':embedding_string_for(System_DB, Transaction, EmbeddingContext,
+                                       Type_Ex, Id_Ex, EmbeddingString),
+    format("~w~n", [EmbeddingString]).
+
+document_stream_end(embedding, _Config).
+
+% Embedding selector with full pre-flight
+api_read_document_selector(System_DB, Auth, Path, Graph_Type, Id, Ids, Type,
+                           Query, Config, Requested_Data_Version,
+                           Actual_Data_Version, _Initial_Goal) :-
+    get_dict(format, Config, embedding),
+    !,
+    die_if(Graph_Type \= instance,
+           error(embedding_only_supported_for_instance_graphs, _)),
+    resolve_descriptor_auth(read, System_DB, Auth, Path, Graph_Type,
+                            Descriptor),
+    before_read(Descriptor, Requested_Data_Version, Actual_Data_Version,
+                Transaction),
+    embedding_type_queries_from_transaction(Transaction, TypeQueries),
+    die_if(TypeQueries = [],
+           error(no_embedding_queries_defined, _)),
+    embedding_document_types(Transaction, Graph_Type, Id, Ids, Type, Query,
+                             DocTypes),
+    list_to_set(DocTypes, UniqueTypes),
+    forall(
+        member(DocType, UniqueTypes),
+        (   member(SchemaType-_Query-_Template, TypeQueries),
+            class_subsumed(Transaction, DocType, SchemaType)
+        ->  true
+        ;   throw(error(no_embedding_query_for_type(DocType), _))
+        )),
+    put_dict(system_db, Config, System_DB, ConfigWithSystem),
+    format_read_documents(embedding, Transaction, Graph_Type, Id, Ids, Type,
+                        Query, ConfigWithSystem, Actual_Data_Version).
 
 :- meta_predicate api_read_document_selector(+,+,+,+,+,+,+,+,+,+,+,1).
 api_read_document_selector(System_DB, Auth, Path, Graph_Type, Id, Ids, Type, Query, Config, Requested_Data_Version, Actual_Data_Version, _Initial_Goal) :-
@@ -1661,5 +1787,240 @@ test(document_input_format_json) :-
 test(document_output_format_json) :-
     document_output_format(json).
 
+test(document_output_format_embedding) :-
+    document_output_format(embedding).
+
+test(detect_output_format_param_embedding) :-
+    detect_output_format([format=embedding], [], embedding).
+
+test(accept_to_format_text_plain) :-
+    accept_to_format(text/plain, embedding).
+
 :- end_tests(document_format_detection).
+
+:- begin_tests(document_embedding, []).
+:- use_module(core(util/test_utils)).
+:- use_module(core(transaction)).
+:- use_module(core(document)).
+:- use_module(core(query)).
+
+test(embedding_format_registered) :-
+    document_output_format(embedding).
+
+test(embedding_accept_header) :-
+    accept_to_format(text/plain, embedding).
+
+test(embedding_type_queries_from_transaction, [
+         setup((setup_temp_store(State),
+                create_db_with_test_schema("admin", "testdb"))),
+         cleanup(teardown_temp_store(State))
+     ]) :-
+    open_descriptor(system_descriptor{}, System),
+    super_user_authority(Auth),
+    open_string('
+[
+  {
+    "@type": "@context",
+    "@base": "http://example.com/data/world/",
+    "@schema": "http://example.com/schema/worldOntology#"
+  },
+  {
+    "@type": "Class",
+    "@id": "Animal",
+    "@key": { "@type": "Lexical", "@fields": ["name"] },
+    "name": "xsd:string",
+    "@metadata": {
+      "embedding": {
+        "query": "query($id: ID){ Animal(id : $id) { name } }",
+        "template": "The animal is named {{name}}."
+      }
+    }
+  }
+]
+', Stream),
+    Options = [author("test"),
+               full_replace(true),
+               graph_type(schema),
+               message("test")],
+    api_insert_documents(System, Auth, "admin/testdb", Stream, no_data_version, _, _, Options),
+
+    resolve_absolute_string_descriptor("admin/testdb", TestDB),
+    open_descriptor(TestDB, Transaction),
+
+    embedding_type_queries_from_transaction(Transaction, TypeQueries),
+    TypeQueries = [_Type-Query-Template],
+    Query = "query($id: ID){ Animal(id : $id) { name } }",
+    Template = "The animal is named {{name}}.".
+
+test(embedding_metadata_stored, [
+         setup((setup_temp_store(State),
+                create_db_with_test_schema("admin", "testdb"))),
+         cleanup(teardown_temp_store(State))
+     ]) :-
+    % Insert a schema with embedding metadata
+    open_descriptor(system_descriptor{}, System),
+    super_user_authority(Auth),
+    open_string('
+[
+  {
+    "@type": "@context",
+    "@base": "http://example.com/data/world/",
+    "@schema": "http://example.com/schema/worldOntology#"
+  },
+  {
+    "@type": "Class",
+    "@id": "Animal",
+    "@key": { "@type": "Lexical", "@fields": ["name"] },
+    "name": "xsd:string",
+    "@metadata": {
+      "embedding": {
+        "query": "query($id: ID){ Animal(id : $id) { name } }",
+        "template": "The animal is named {{name}}."
+      }
+    }
+  }
+]
+', Stream),
+    Options = [author("test"),
+               full_replace(true),
+               graph_type(schema),
+               message("test")],
+    api_insert_documents(System, Auth, "admin/testdb", Stream, no_data_version, _, _, Options),
+
+    % Get the transaction and check metadata is stored
+    resolve_absolute_string_descriptor("admin/testdb", TestDB),
+    open_descriptor(TestDB, Transaction),
+
+    % Check that @metadata is stored
+    ask(Transaction, t(_Animal, sys:metadata, _Metadata, schema)).
+
+test(embedding_type_queries_empty_when_no_embeddings, [
+         setup((setup_temp_store(State),
+                create_db_with_test_schema("admin", "testdb"))),
+         cleanup(teardown_temp_store(State))
+     ]) :-
+    % Use the default test schema which has no embedding metadata
+    resolve_absolute_string_descriptor("admin/testdb", TestDB),
+    open_descriptor(TestDB, Transaction),
+
+    embedding_type_queries_from_transaction(Transaction, TypeQueries),
+    TypeQueries = [].
+
+test(embedding_document_types_single, [
+         setup((setup_temp_store(State),
+                create_db_with_test_schema("admin", "testdb"))),
+         cleanup(teardown_temp_store(State))
+     ]) :-
+    % Insert a schema with embedding metadata
+    open_descriptor(system_descriptor{}, System),
+    super_user_authority(Auth),
+    open_string('
+[
+  {
+    "@type": "@context",
+    "@base": "http://example.com/data/world/",
+    "@schema": "http://example.com/schema/worldOntology#"
+  },
+  {
+    "@type": "Class",
+    "@id": "Animal",
+    "@key": { "@type": "Lexical", "@fields": ["name"] },
+    "name": "xsd:string",
+    "@metadata": {
+      "embedding": {
+        "query": "query($id: ID){ Animal(id : $id) { name } }",
+        "template": "The animal is named {{name}}."
+      }
+    }
+  }
+]
+', Stream),
+    Options = [author("test"),
+               full_replace(true),
+               graph_type(schema),
+               message("test")],
+    api_insert_documents(System, Auth, "admin/testdb", Stream, no_data_version, _, _, Options),
+
+    % Insert an instance document
+    open_string('
+{
+  "@type": "Animal",
+  "name": "Plato"
+}
+', InstanceStream),
+    InstanceOptions = [author("test"),
+                        graph_type(instance),
+                        message("test")],
+    api_insert_documents(System, Auth, "admin/testdb", InstanceStream, no_data_version, _, [Id], InstanceOptions),
+
+    % Test embedding_document_types
+    resolve_absolute_string_descriptor("admin/testdb", TestDB),
+    open_descriptor(TestDB, Transaction),
+
+    embedding_document_types(Transaction, instance, Id, [], _Type, _Query, DocTypes),
+    % This should identify Animal as the document type
+    memberchk('http://example.com/schema/worldOntology#Animal', DocTypes).
+
+test(embedding_api_end_to_end, [
+         setup((setup_temp_store(State),
+                create_db_with_empty_schema("admin", "testdb"))),
+         cleanup(teardown_temp_store(State))
+     ]) :-
+    open_descriptor(system_descriptor{}, System),
+    super_user_authority(Auth),
+
+    % Insert schema with embedding metadata
+    open_string('
+{ "@type": "@context",
+  "@schema": "http://example.com/schema#",
+  "@base": "http://example.com/data/"
+}
+
+{ "@type": "Class",
+  "@id": "Animal",
+  "@key": { "@type": "Lexical", "@fields": ["name"] },
+  "name": "xsd:string",
+  "@metadata": {
+    "embedding": {
+      "query": "query($id: ID){ Animal(id: $id) { name } }",
+      "template": "The animal is named {{name}}."
+    }
+  }
+}', SchemaStream),
+    SchemaOptions = [author("test"),
+                     full_replace(true),
+                     graph_type(schema),
+                     message("test")],
+    api_insert_documents(System, Auth, "admin/testdb", SchemaStream, no_data_version, _, _, SchemaOptions),
+
+    % Insert instance document
+    open_string('
+{ "@type": "Animal", "name": "Plato" }
+', InstanceStream),
+    InstanceOptions = [author("test"),
+                       graph_type(instance),
+                       message("test")],
+    api_insert_documents(System, Auth, "admin/testdb", InstanceStream, no_data_version, _, [Id], InstanceOptions),
+
+    % Call the API selector with format=embedding and capture output
+    Config = config{ format: embedding,
+                     compress: true,
+                     unfold: true,
+                     skip: 0,
+                     count: unlimited,
+                     as_list: false,
+                     minimized: true,
+                     request: [] },
+    with_output_to(
+        string(EmbeddingOutput),
+        (   document_stream_headers(embedding, [], no_data_version),
+            api_read_document_selector(System, Auth, "admin/testdb", instance,
+                                       Id, [], _, _, Config,
+                                       no_data_version, _, _)
+        )
+    ),
+    % Verify the output contains the rendered template
+    once(sub_string(EmbeddingOutput, _, _, _, "The animal is named Plato.")).
+
+:- end_tests(document_embedding).
 

--- a/src/core/api/api_error.pl
+++ b/src/core/api/api_error.pl
@@ -2626,6 +2626,31 @@ api_document_error_jsonld(Type, error(json_id_not_provided(Document), _),JSON) :
                               'api:document' : Document },
              'api:message' : Msg
             }.
+api_document_error_jsonld(Type, error(embedding_only_supported_for_instance_graphs, _), JSON) :-
+    document_error_type(Type, JSON_Type),
+    format(string(Msg), "Embedding output format is only supported for instance graphs.", []),
+    JSON = _{'@type' : JSON_Type,
+             'api:status' : "api:failure",
+             'api:error' : _{ '@type' : 'api:EmbeddingOnlyForInstanceGraphs'},
+             'api:message' : Msg
+            }.
+api_document_error_jsonld(Type, error(no_embedding_queries_defined, _), JSON) :-
+    document_error_type(Type, JSON_Type),
+    format(string(Msg), "No embedding queries are defined in the schema.", []),
+    JSON = _{'@type' : JSON_Type,
+             'api:status' : "api:failure",
+             'api:error' : _{ '@type' : 'api:NoEmbeddingQueriesDefined'},
+             'api:message' : Msg
+            }.
+api_document_error_jsonld(Type, error(no_embedding_query_for_type(DocType), _), JSON) :-
+    document_error_type(Type, JSON_Type),
+    format(string(Msg), "No embedding query is defined for type: ~q", [DocType]),
+    JSON = _{'@type' : JSON_Type,
+             'api:status' : "api:failure",
+             'api:error' : _{ '@type' : 'api:NoEmbeddingQueryForType',
+                              'api:document_type' : DocType },
+             'api:message' : Msg
+            }.
 
 /**
  * generic_exception_jsonld(Error,JSON) is det.

--- a/src/core/api/api_indexer.pl
+++ b/src/core/api/api_indexer.pl
@@ -7,7 +7,8 @@
           ]).
 
 :- use_module(core(document/history),[commits_changed_id/5]).
-:- use_module(core(document),[get_document/3, all_class_frames/3]).
+:- use_module(core(document),[get_document/3, all_class_frames/3,
+                              schema_metadata_descriptor/3]).
 :- use_module(core(query)).
 :- use_module(core(transaction)).
 :- use_module(core(util)).
@@ -43,17 +44,17 @@ api_check_job(Task_Id, Status) :-
         []).
 
 embedding_type_queries(Commit_Descriptor, TypeQueries) :-
+    open_descriptor(Commit_Descriptor, Transaction),
+    database_schema(Transaction, Schema),
     findall(
         Type-Query-Template,
-        (   ask(Commit_Descriptor,
-                (   t(Embedding, json:query,  Query_Point, schema),
-                    opt(t(Embedding, json:template, Template_Point, schema)),
-                    t(Meta, json:embedding,  Embedding, schema),
-                    t(Type, sys:metadata, Meta, schema))),
-            Query_Point = Query^^xsd:string,
-            (   ground(Template_Point)
-            ->  Template_Point = Template^^_
-            ;   true)),
+        (   xrdf(Schema, Type, sys:metadata, _),
+            schema_metadata_descriptor(Schema, Type, metadata(Metadata)),
+            get_dict(embedding, Metadata, Embedding),
+            get_dict(query, Embedding, Query),
+            (   get_dict(template, Embedding, Template)
+            ->  true
+            ;   Template = none)),
         TypeQueries
     ).
 

--- a/src/core/api/api_indexer.pl
+++ b/src/core/api/api_indexer.pl
@@ -16,7 +16,7 @@
 :- use_module(library(http/json)).
 :- use_module(library(http/http_client)).
 :- use_module(core(api/api_graphql)).
-:- use_module(core(triple), [super_user_authority/1]).
+:- use_module(core(triple), [super_user_authority/1, database_schema/2, xrdf/4]).
 :- use_module(library(apply)).
 :- use_module(library(apply_macros)).
 :- use_module(library(yall)).

--- a/src/core/document.pl
+++ b/src/core/document.pl
@@ -71,6 +71,7 @@
               all_class_frames/2,
               all_class_frames/3,
               is_schemaless/1,
+              schema_metadata_descriptor/3,
 
               % query.pl
               match_query_document_uri/4,

--- a/src/core/document.pl
+++ b/src/core/document.pl
@@ -63,6 +63,7 @@
 
               % instance.pl
               is_instance/3,
+              is_instance_class/3,
 
               % schema.pl
               class_subsumed/3,

--- a/tests/lib/document.js
+++ b/tests/lib/document.js
@@ -14,6 +14,7 @@ function commonGetParams (params) {
   result.skip = params.integer('skip')
   result.compress_ids = params.boolean('compress_ids')
   result.prefixed = params.boolean('prefixed')
+  result.format = params.string('format')
   params.assertEmpty()
   return result
 }

--- a/tests/test/document-embedding.js
+++ b/tests/test/document-embedding.js
@@ -92,5 +92,15 @@ describe('document-embedding', function () {
       expect(r.type).to.equal('text/plain')
       expect(r.text).to.include('The animal is named Plato.')
     })
+
+    it('returns 200 text/plain via Accept header', async function () {
+      const r = await document
+        .get(agent, { query: { id: 'Animal/Plato' } })
+        .set('Accept', 'text/plain')
+        .unverified()
+      expect(r.status).to.equal(200)
+      expect(r.type).to.equal('text/plain')
+      expect(r.text).to.include('The animal is named Plato.')
+    })
   })
 })

--- a/tests/test/document-embedding.js
+++ b/tests/test/document-embedding.js
@@ -1,0 +1,96 @@
+const { expect } = require('chai')
+const { Agent, db, document } = require('../lib')
+
+describe('document-embedding', function () {
+  describe('error cases (schema without embedding definition)', function () {
+    let agent
+
+    const schemaNoEmbedding = {
+      '@id': 'Animal',
+      '@type': 'Class',
+      '@key': { '@type': 'Lexical', '@fields': ['name'] },
+      name: 'xsd:string',
+    }
+
+    before(async function () {
+      agent = new Agent().auth()
+      await db.create(agent)
+      await document.insert(agent, { schema: schemaNoEmbedding })
+      await document.insert(agent, { instance: { '@type': 'Animal', name: 'Plato' } })
+    })
+
+    after(async function () {
+      await db.delete(agent)
+    })
+
+    it('fails for schema graph type with EmbeddingOnlyForInstanceGraphs error', async function () {
+      const r = await document
+        .get(agent, {
+          query: { format: 'embedding', graph_type: 'schema', id: 'Animal/Plato' },
+        })
+        .unverified()
+      expect(r.status).to.equal(400)
+      expect(r.body['api:error']).to.have.property('@type', 'api:EmbeddingOnlyForInstanceGraphs')
+    })
+
+    it('fails when schema has no embedding definitions with NoEmbeddingQueriesDefined error', async function () {
+      const r = await document
+        .get(agent, { query: { format: 'embedding', id: 'Animal/Plato' } })
+        .unverified()
+      expect(r.status).to.equal(400)
+      expect(r.body['api:error']).to.have.property('@type', 'api:NoEmbeddingQueriesDefined')
+    })
+
+    it('fails when requesting by type with no embedding definitions with NoEmbeddingQueriesDefined error', async function () {
+      const r = await document
+        .get(agent, { query: { format: 'embedding', type: 'Animal' } })
+        .unverified()
+      expect(r.status).to.equal(400)
+      expect(r.body['api:error']).to.have.property('@type', 'api:NoEmbeddingQueriesDefined')
+    })
+  })
+
+  describe('success cases (schema with embedding definition)', function () {
+    let agent
+
+    const schemaWithEmbedding = [
+      {
+        '@type': '@context',
+        '@base': 'http://example.com/data/',
+        '@schema': 'http://example.com/schema#',
+      },
+      {
+        '@id': 'Animal',
+        '@type': 'Class',
+        '@key': { '@type': 'Lexical', '@fields': ['name'] },
+        name: 'xsd:string',
+        '@metadata': {
+          embedding: {
+            query: 'query ($id: ID) { Animal(id: $id) { name } }',
+            template: 'The animal is named {{name}}.',
+          },
+        },
+      },
+    ]
+
+    before(async function () {
+      agent = new Agent().auth()
+      await db.create(agent)
+      await document.insert(agent, { schema: schemaWithEmbedding, fullReplace: true })
+      await document.insert(agent, { instance: { '@type': 'Animal', name: 'Plato' } })
+    })
+
+    after(async function () {
+      await db.delete(agent)
+    })
+
+    it('returns 200 text/plain with rendered template for a document with embedding definition', async function () {
+      const r = await document
+        .get(agent, { query: { format: 'embedding', id: 'Animal/Plato' } })
+        .unverified()
+      expect(r.status).to.equal(200)
+      expect(r.type).to.equal('text/plain')
+      expect(r.text).to.include('The animal is named Plato.')
+    })
+  })
+})


### PR DESCRIPTION
## Overview

This PR implements a new API endpoint for retrieving document embeddings via the existing document GET endpoint by adding an `embedding` output format (in addition to `json`). When requested, the endpoint queries the document data using a GraphQL query defined in the schema's `@metadata.embedding` section (previously only active with VectorLink), renders the result through a Handlebars template, and returns the resulting text as `text/plain`.

### OpenAPI Documentation (`docs/openapi.yaml`)

- Added `format` query parameter to the document GET endpoint documenting `json` (default) and `embedding` options.

## Schema Format for Embedding Definitions

Classes can define embedding queries in their `@metadata`:

```json
{
  "@type": "Class",
  "@id": "Animal",
  "name": "xsd:string",
  "@metadata": {
    "embedding": {
      "query": "query($id: ID){ Animal(id: $id) { name } }",
      "template": "The animal is named {{name}}."
    }
  }
}
```

## How to test with CURL

This is how it works from the command line.

### Create a database

```bash
curl -u admin:root -X POST "http://localhost:6363/api/db/admin/mydb" \
  -H "Content-Type: application/json" \
  -d '{"comment":"test db","label":"mydb"}'
```

### Add a schema with embedding metadata

```bash
curl -u admin:root -X POST "http://localhost:6363/api/document/admin/mydb?graph_type=schema&author=admin&message=add+schema&full_replace=true" \
  -H "Content-Type: application/json" \
  -d '[{
    "@type": "@context",
    "@schema": "http://example.com/schema#",
    "@base": "http://example.com/data/"
  },{
    "@type": "Class",
    "@id": "Animal",
    "@key": { "@type": "Lexical", "@fields": ["name"] },
    "name": "xsd:string",
    "@metadata": {
      "embedding": {
        "query": "query($id: ID){ Animal(id: $id) { name } }",
        "template": "The animal is named {{name}}."
      }
    }
  }]' 
```

### Insert an instance document

```bash
curl -u admin:root -X PUT "http://localhost:6363/api/document/admin/mydb?graph_type=instance&author=admin&create=true&message=add+animal" \
  -H "Content-Type: application/json" \
  -d '{"@type": "Animal", "name": "Plato"}'
```

### Request embedding via query parameter

```bash
curl -u admin:root "http://localhost:6363/api/document/admin/mydb?id=Animal/Plato&format=embedding"
# → The animal is named Plato.
```

### Request embedding via Accept header

```bash
curl -u admin:root -H "Accept: text/plain" "http://localhost:6363/api/document/admin/mydb?id=Animal/Plato"
# → The animal is named Plato.
```



