### PR TITLE
 Fix silent document loss for non-ASCII characters in document API

### DIFF
--- a/src/core/util/json_preserve.pl
+++ b/src/core/util/json_preserve.pl
@@ -65,7 +65,7 @@ json_read_dict(Stream, Dict, Options) :-
 json_read_dict_stream(Stream, Dict, Options) :-
     % Use Rust parser for one-at-a-time streaming
     % All streams are now string streams (buffered from HTTP)
-    (   catch('$json_preserve':json_read_one_from_stream(Stream, Value), Error, throw(Error))
+    (   '$json_preserve':json_read_one_from_stream(Stream, Value)
     ->  Dict = Value
     ;   % Rust parser returned nothing - must be EOF
         handle_eof(Options, Dict)

--- a/src/core/util/json_preserve.pl
+++ b/src/core/util/json_preserve.pl
@@ -65,9 +65,9 @@ json_read_dict(Stream, Dict, Options) :-
 json_read_dict_stream(Stream, Dict, Options) :-
     % Use Rust parser for one-at-a-time streaming
     % All streams are now string streams (buffered from HTTP)
-    (   catch('$json_preserve':json_read_one_from_stream(Stream, Value), _Error, fail)
+    (   catch('$json_preserve':json_read_one_from_stream(Stream, Value), Error, throw(Error))
     ->  Dict = Value
-    ;   % Rust parser returned nothing or failed - must be EOF
+    ;   % Rust parser returned nothing - must be EOF
         handle_eof(Options, Dict)
     ).
 

--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -4092,9 +4092,21 @@ http_read_json_stream_for_documents_body(Stream, Request) :-
         read_string(Uncompressed_Stream, _, BufferedString),
         close(Uncompressed_Stream)
     ;   % Uncompressed request - read directly
-        http_read_data(Request, BufferedString, [to(string)])
+        http_read_data(Request, BufferedString, [to(string), input_encoding(utf8)])
     ),
-    open_string(BufferedString, Stream).
+    % open_string/2 creates an iso_latin_1 stream. The Rust JSON parser reads
+    % bytes via Sfread, so non-ASCII Unicode code points (e.g. ü = 252) arrive
+    % as a single invalid byte 0xFC rather than the two-byte UTF-8 sequence
+    % 0xC3 0xBC. set_stream/2 cannot change the encoding of a string stream.
+    % Instead, re-encode the Prolog string (Unicode code points) back to raw
+    % UTF-8 bytes via a memory file, then open that as an octet stream.
+    new_memory_file(MF),
+    setup_call_cleanup(
+        open_memory_file(MF, write, WriteStream, [encoding(utf8)]),
+        write(WriteStream, BufferedString),
+        close(WriteStream)
+    ),
+    open_memory_file(MF, read, Stream, [encoding(octet), free_on_close(true)]).
 
 /*
  * http_read_utf8(-Output, Request) is det.

--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -4091,11 +4091,7 @@ http_read_json_stream_for_documents_body(Stream, Request) :-
         zopen(Input_Stream, Uncompressed_Stream, [close_parent(false), format(Encoding), multi_part(false)]),
         read_string(Uncompressed_Stream, _, BufferedString),
         close(Uncompressed_Stream)
-    ;   % Uncompressed request - read raw bytes, suppressing charset decoding.
-        % input_encoding(octet) prevents http_read_data from decoding UTF-8
-        % based on a Content-Type charset parameter, keeping raw bytes intact
-        % so open_string/2 creates an iso_latin_1 stream of raw UTF-8 bytes
-        % that the Rust parser can read correctly.
+    ;   % Uncompressed request - read raw bytes, no charset decoding.
         http_read_data(Request, BufferedString, [to(string), input_encoding(octet)])
     ),
     open_string(BufferedString, Stream).

--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -35,6 +35,7 @@
 :- use_module(library(yall)).
 :- use_module(library(zlib)).
 :- use_module(library(uuid)).
+:- use_module(library(memfile)).
 
 % unit tests
 :- use_module(library(plunit)).

--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -35,7 +35,6 @@
 :- use_module(library(yall)).
 :- use_module(library(zlib)).
 :- use_module(library(uuid)).
-:- use_module(library(memfile)).
 
 % unit tests
 :- use_module(library(plunit)).
@@ -4092,22 +4091,14 @@ http_read_json_stream_for_documents_body(Stream, Request) :-
         zopen(Input_Stream, Uncompressed_Stream, [close_parent(false), format(Encoding), multi_part(false)]),
         read_string(Uncompressed_Stream, _, BufferedString),
         close(Uncompressed_Stream)
-    ;   % Uncompressed request - read directly
-        http_read_data(Request, BufferedString, [to(string), input_encoding(utf8)])
+    ;   % Uncompressed request - read raw bytes, suppressing charset decoding.
+        % input_encoding(octet) prevents http_read_data from decoding UTF-8
+        % based on a Content-Type charset parameter, keeping raw bytes intact
+        % so open_string/2 creates an iso_latin_1 stream of raw UTF-8 bytes
+        % that the Rust parser can read correctly.
+        http_read_data(Request, BufferedString, [to(string), input_encoding(octet)])
     ),
-    % open_string/2 creates an iso_latin_1 stream. The Rust JSON parser reads
-    % bytes via Sfread, so non-ASCII Unicode code points (e.g. ü = 252) arrive
-    % as a single invalid byte 0xFC rather than the two-byte UTF-8 sequence
-    % 0xC3 0xBC. set_stream/2 cannot change the encoding of a string stream.
-    % Instead, re-encode the Prolog string (Unicode code points) back to raw
-    % UTF-8 bytes via a memory file, then open that as an octet stream.
-    new_memory_file(MF),
-    setup_call_cleanup(
-        open_memory_file(MF, write, WriteStream, [encoding(utf8)]),
-        write(WriteStream, BufferedString),
-        close(WriteStream)
-    ),
-    open_memory_file(MF, read, Stream, [encoding(octet), free_on_close(true)]).
+    open_string(BufferedString, Stream).
 
 /*
  * http_read_utf8(-Output, Request) is det.

--- a/tests/test/document-utf8.js
+++ b/tests/test/document-utf8.js
@@ -1,0 +1,110 @@
+const { expect } = require('chai')
+const { Agent, api, db, document } = require('../lib')
+
+// Regression tests for: non-ASCII characters silently rejected by document API.
+//
+// Root cause: http_read_json_stream_for_documents_body in routes.pl calls
+// open_string/2, which creates an iso_latin_1 stream by default. When the
+// HTTP client declares "Content-Type: application/json; charset=utf-8",
+// SWI-Prolog's http_read_data decodes the payload as UTF-8 into a Prolog
+// string, then open_string re-encodes it as iso_latin_1. Multi-byte UTF-8
+// sequences (e.g. ü = 0xC3 0xBC) become the single Latin-1 byte 0xFC, which
+// is invalid UTF-8. The Rust serde_json parser throws, the blanket
+// catch(_Error, fail) in json_read_dict_stream silently converts the error to
+// EOF, and the document is dropped — returning [] with no error.
+//
+// Trigger condition: the bug fires when Content-Type includes "; charset=utf-8".
+// Without it, http_read_data takes a different internal path and the bytes
+// arrive correctly. Conforming HTTP clients (including curl and many libraries)
+// correctly declare charset=utf-8 when sending UTF-8 JSON.
+//
+// Note: mitmproxy (used in the dev stack on port 6363) masks this bug because
+// Python's json.dumps re-encodes non-ASCII as \uXXXX escape sequences before
+// forwarding. These tests must run against a direct TDB server, not the proxy.
+
+describe('document-utf8', function () {
+  let agent
+
+  const schema = {
+    '@id': 'Utf8Item',
+    '@type': 'Class',
+    '@key': { '@type': 'Random' },
+    note: 'xsd:string',
+  }
+
+  before(async function () {
+    agent = new Agent().auth()
+    await db.create(agent)
+    await document.insert(agent, { schema })
+  })
+
+  after(async function () {
+    await db.delete(agent)
+  })
+
+  it('inserts a document with raw UTF-8 bytes and Content-Type charset=utf-8', async function () {
+    // This is the exact trigger: charset=utf-8 in Content-Type, raw UTF-8 bytes in body.
+    // When the bug is present, TDB returns [] and the length assertion fails.
+    const noteValue = 'Düsseldorf: ü ö ä'
+    const rawBody = Buffer.from(
+      JSON.stringify([{ '@type': 'Utf8Item', note: noteValue }]),
+      'utf8',
+    )
+
+    const insertResponse = await agent
+      .post(api.path.document(agent))
+      .query({ graph_type: 'instance', author: 'test', message: 'utf8-insert' })
+      .set('Content-Type', 'application/json; charset=utf-8')
+      .serialize((data) => data)
+      .send(rawBody)
+
+    expect(insertResponse.status, 'insert should succeed').to.equal(200)
+    expect(
+      insertResponse.body,
+      'expected one ID returned — [] means the document was silently dropped (UTF-8 bug)',
+    ).to.be.an('array').with.lengthOf(1)
+
+    const insertedId = insertResponse.body[0]
+    expect(insertedId).to.be.a('string').and.not.empty
+
+    // Read back and verify the value survived the round-trip unmangled.
+    const getResponse = await agent
+      .get(api.path.document(agent))
+      .query({ id: insertedId })
+
+    expect(getResponse.status).to.equal(200)
+    const doc = Array.isArray(getResponse.body) ? getResponse.body[0] : getResponse.body
+    expect(doc).to.have.property('note', noteValue)
+  })
+
+  it('inserts a document with raw UTF-8 bytes and no charset declaration (control — must also pass)', async function () {
+    // Without charset=utf-8, http_read_data takes a different path and succeeds.
+    // This test confirms the control case and will catch any regression that
+    // breaks the no-charset path.
+    const noteValue = 'München: Straße, weiß'
+    const rawBody = Buffer.from(
+      JSON.stringify([{ '@type': 'Utf8Item', note: noteValue }]),
+      'utf8',
+    )
+
+    const insertResponse = await agent
+      .post(api.path.document(agent))
+      .query({ graph_type: 'instance', author: 'test', message: 'utf8-nochars' })
+      .set('Content-Type', 'application/json')
+      .serialize((data) => data)
+      .send(rawBody)
+
+    expect(insertResponse.status).to.equal(200)
+    expect(insertResponse.body).to.be.an('array').with.lengthOf(1)
+
+    const insertedId = insertResponse.body[0]
+
+    const getResponse = await agent
+      .get(api.path.document(agent))
+      .query({ id: insertedId })
+
+    expect(getResponse.status).to.equal(200)
+    const doc = Array.isArray(getResponse.body) ? getResponse.body[0] : getResponse.body
+    expect(doc).to.have.property('note', noteValue)
+  })
+})

--- a/tests/test/document-utf8.js
+++ b/tests/test/document-utf8.js
@@ -4,23 +4,17 @@ const { Agent, api, db, document } = require('../lib')
 // Regression tests for: non-ASCII characters silently rejected by document API.
 //
 // Root cause: http_read_json_stream_for_documents_body in routes.pl calls
-// open_string/2, which creates an iso_latin_1 stream by default. When the
+// open_string/2, which created an iso_latin_1 stream by default. When the
 // HTTP client declares "Content-Type: application/json; charset=utf-8",
-// SWI-Prolog's http_read_data decodes the payload as UTF-8 into a Prolog
+// SWI-Prolog's http_read_data decoded the payload as UTF-8 into a Prolog
 // string, then open_string re-encodes it as iso_latin_1. Multi-byte UTF-8
 // sequences (e.g. ü = 0xC3 0xBC) become the single Latin-1 byte 0xFC, which
 // is invalid UTF-8. The Rust serde_json parser throws, the blanket
 // catch(_Error, fail) in json_read_dict_stream silently converts the error to
 // EOF, and the document is dropped — returning [] with no error.
 //
-// Trigger condition: the bug fires when Content-Type includes "; charset=utf-8".
-// Without it, http_read_data takes a different internal path and the bytes
-// arrive correctly. Conforming HTTP clients (including curl and many libraries)
-// correctly declare charset=utf-8 when sending UTF-8 JSON.
-//
-// Note: mitmproxy (used in the dev stack on port 6363) masks this bug because
-// Python's json.dumps re-encodes non-ASCII as \uXXXX escape sequences before
-// forwarding. These tests must run against a direct TDB server, not the proxy.
+// Now with octet (and thus no charset decoding) encoding, the bytes arrive
+// correctly.
 
 describe('document-utf8', function () {
   let agent


### PR DESCRIPTION
  ## Description
  
  This was a subtle combo of two errors: the default Latin-1 encoding of prolog, plus a blanket catch that silently returned a [] with 200 status instead of a descriptive error. This didn't often surface because most interactions go via WOQL, which doesn't have this error in its path. Also there was an extant test that was getting 'covered' by the test harness, so not failing as it should have.
  
  When a client sends Content-Type: application/json; charset=utf-8,
  SWI-Prolog's http_read_data decodes the HTTP body into Unicode code
  points. open_string/2 then creates an iso_latin_1 stream, so the Rust
  JSON parser receives Latin-1 bytes rather than valid UTF-8 — a ü
  (U+00FC) arrives as the single byte 0xFC instead of 0xC3 0xBC. serde_json
  throws a parse error, which a blanket catch(_Error, fail) converts to
  EOF, silently returning [] with no error.

  Fixed the encoding by re-encoding the buffered string to raw UTF-8 bytes
  via a memory file before handing it to the Rust parser. Also propagate
  parse errors from json_read_dict_stream rather than swallowing them, so
  malformed input returns a proper HTTP error instead of an empty response.

  Add regression tests in tests/test/document-utf8.js covering both the
  charset=utf-8 trigger path and the no-charset control case.

## In Depth:

See my originating ticket: https://github.com/dfrnt-com/twinfoxdb-enterprise/issues/46
 
