### PR TITLE
Add Elixir Client link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ TerminusDB provides official client libraries for multiple languages:
 - 🐍 **[Python Client (v12)](https://pypi.org/project/terminusdb/)**: Full-featured Python library for TerminusDB
 - 🌐 **[JavaScript Client (v12)](https://www.npmjs.com/package/terminusdb)**: Browser and Node.js support
 - **[Rust Client](https://github.com/ParapluOU/terminusdb-rs)**: Full-featured Rust library for TerminusDB, community contribution
+- 🔮 **[Elixir Client](https://hex.pm/packages/terminusdb_client)**: An idiomatic Elixir client
+
 
 ## Documentation
 


### PR DESCRIPTION
Hi!

I’ve added the Elixir client, terminusdb_client, to the list of TerminusDB client libraries.

The library is available on Hex and GitHub, and aims to provide an idiomatic Elixir interface to TerminusDB.

I also plan to use it as the foundation for a large knowledge store at the bank where I work, so I expect to continue investing in the library and expanding its capabilities over time.

If you’re interested, I’d also be happy to transfer the repository to the TerminusDB GitHub organization and help maintain it as an official client library.

Thanks for building TerminusDB, and for taking the time to review this PR!