### PR TITLE
Fix RFC 3986 scheme detection in `uri_has_protocol/1`

### DIFF
--- a/src/core/api/api_prefixes.pl
+++ b/src/core/api/api_prefixes.pl
@@ -516,6 +516,11 @@ test(valid_prefix_name_basic,
     valid_prefix_name("my_prefix"),
     valid_prefix_name('foo-bar').
 
+test(valid_prefix_name_hyphenated_bom_namespace,
+     []) :-
+    valid_prefix_name('dfrnt-bom'),
+    valid_prefix_name("dfrnt-bom").
+
 test(valid_prefix_name_with_dot,
      []) :-
     valid_prefix_name('v1.0'),

--- a/src/core/query/jsonld.pl
+++ b/src/core/query/jsonld.pl
@@ -321,6 +321,15 @@ test(expand_prefix_with_colon, []) :-
     prefix_expand("@schema:foo:bar", Prefixes, 'terminusdb:///schema#foo:bar'),
     prefix_expand("a:foo:bar", Prefixes, 'http://example.org/a/foo:bar').
 
+test(expand_hyphenated_prefix, []) :-
+    Prefixes = _{'dfrnt-bom': "https://example.com/dfrnt-bom/"},
+    prefix_expand("dfrnt-bom:Item", Prefixes, 'https://example.com/dfrnt-bom/Item'),
+    prefix_expand("dfrnt-bom:instance/123", Prefixes, 'https://example.com/dfrnt-bom/instance/123').
+
+test(expand_hyphenated_prefix_with_colon_in_local, []) :-
+    Prefixes = _{'dfrnt-bom': "https://example.com/dfrnt-bom/"},
+    prefix_expand("dfrnt-bom:Foo:Bar", Prefixes, 'https://example.com/dfrnt-bom/Foo:Bar').
+
 :- end_tests(jsonld_expand).
 
 /*
@@ -437,6 +446,23 @@ test(compress_base, [])
     compress(Document, Context, Compressed),
 
     json{'@type':'scm:Fact','scm:your_face':json{'@id':'is_ugly'}} :< Compressed.
+
+test(compress_hyphenated_prefix, [])
+:-
+    Context = json{ 'dfrnt-bom' : "https://example.com/dfrnt-bom/"},
+    Document = json{ '@type' : "https://example.com/dfrnt-bom/Item",
+                     '@id' : "https://example.com/dfrnt-bom/instance/123"},
+    compress(Document, Context, Compressed),
+
+    json{'@type':'dfrnt-bom:Item','@id':'dfrnt-bom:instance/123'} :< Compressed.
+
+test(compress_hyphenated_prefix_property, [])
+:-
+    Context = json{ 'dfrnt-bom' : "https://example.com/dfrnt-bom/"},
+    Document = json{ 'https://example.com/dfrnt-bom/weight' : 42},
+    compress(Document, Context, Compressed),
+
+    json{'dfrnt-bom:weight':42} :< Compressed.
 
 :- end_tests(jsonld_compress).
 

--- a/src/core/query/jsonld.pl
+++ b/src/core/query/jsonld.pl
@@ -330,6 +330,10 @@ test(expand_hyphenated_prefix_with_colon_in_local, []) :-
     Prefixes = _{'dfrnt-bom': "https://example.com/dfrnt-bom/"},
     prefix_expand("dfrnt-bom:Foo:Bar", Prefixes, 'https://example.com/dfrnt-bom/Foo:Bar').
 
+test(expand_hyphenated_scheme_unchanged, []) :-
+    Prefixes = _{},
+    prefix_expand('dfrnt-bom:///schema#BomClass', Prefixes, 'dfrnt-bom:///schema#BomClass').
+
 :- end_tests(jsonld_expand).
 
 /*

--- a/src/core/util/utils.pl
+++ b/src/core/util/utils.pl
@@ -819,11 +819,12 @@ whole_arg(_, _) :-
  *
  * Tests to see if a URI has a protocol.
  *
- * This performs a very simple check and does not support the full URI
- * specification. We can always improve on this if needed.
+ * Matches RFC 3986 \u00a73.1 scheme syntax:
+ *   ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
+ * followed by "://". Keeps the existing Unicode-friendly property escapes.
  */
 uri_has_protocol(K) :-
-    re_match('^\\p{L}\\p{Xan}*://.+', K).
+    re_match('^\\p{L}[\\p{Xan}+\\-.]*://.+', K).
 
 /*
  * uri_has_prefix(K) is semidet.
@@ -1349,5 +1350,24 @@ test(uri_has_prefix_unsafe_hyphenated, []) :-
     uri_has_prefix_unsafe('dfrnt-bom:Item', Match),
     get_dict(prefix, Match, "dfrnt-bom"),
     get_dict(suffix, Match, "Item").
+
+test(uri_has_protocol_standard, []) :-
+    uri_has_protocol('http://example.com/'),
+    uri_has_protocol('https://example.com/path').
+
+test(uri_has_protocol_hyphenated_bom_scheme, []) :-
+    uri_has_protocol('dfrnt-bom:///schema#BomClass').
+
+test(uri_has_protocol_plus_scheme, []) :-
+    uri_has_protocol('coap+tcp:///path').
+
+test(uri_has_protocol_dot_scheme, []) :-
+    uri_has_protocol('my.scheme:///path').
+
+test(uri_has_protocol_rejects_prefixed_name, [fail]) :-
+    uri_has_protocol('dfrnt-bom:Item').
+
+test(uri_has_protocol_rejects_bare_string, [fail]) :-
+    uri_has_protocol('notaprotocol').
 
 :- end_tests(utils_uri_prefix).

--- a/src/core/util/utils.pl
+++ b/src/core/util/utils.pl
@@ -1321,3 +1321,33 @@ local_memoize(State, Template, Goal) :-
                                do_local_memoize(State, Template)),
                            finalize_memoization(State))
     ;   get_local_memoized(State, Template)).
+
+:- begin_tests(utils_uri_prefix).
+
+test(uri_has_prefix_hyphenated, []) :-
+    uri_has_prefix('dfrnt-bom:Item', Match),
+    get_dict(prefix, Match, "dfrnt-bom"),
+    get_dict(suffix, Match, "Item").
+
+test(uri_has_prefix_hyphenated_empty_suffix, []) :-
+    uri_has_prefix('dfrnt-bom:', Match),
+    get_dict(prefix, Match, "dfrnt-bom"),
+    get_dict(suffix, Match, "").
+
+test(uri_has_prefix_hyphenated_with_digit, []) :-
+    uri_has_prefix('a1:b', Match),
+    get_dict(prefix, Match, "a1"),
+    get_dict(suffix, Match, "b").
+
+test(uri_has_prefix_no_colon_fails, [fail]) :-
+    uri_has_prefix('dfrnt-bom-name', _).
+
+test(uri_has_prefix_leading_hyphen_fails, [fail]) :-
+    uri_has_prefix('-bom:Item', _).
+
+test(uri_has_prefix_unsafe_hyphenated, []) :-
+    uri_has_prefix_unsafe('dfrnt-bom:Item', Match),
+    get_dict(prefix, Match, "dfrnt-bom"),
+    get_dict(suffix, Match, "Item").
+
+:- end_tests(utils_uri_prefix).

--- a/tests/test/document-hyphenated-prefix.js
+++ b/tests/test/document-hyphenated-prefix.js
@@ -1,0 +1,150 @@
+const { expect } = require('chai')
+const { Agent, db, document } = require('../lib')
+
+describe('document-hyphenated-prefix', function () {
+  this.timeout(10000)
+
+  let agent
+
+  before(async function () {
+    agent = new Agent().auth()
+  })
+
+  describe('CRUD with a hyphenated namespace prefix', function () {
+    const schema = [
+      {
+        '@type': '@context',
+        '@base': 'terminusdb:///data/',
+        '@schema': 'terminusdb:///schema#',
+        'dfrnt-bom': 'https://example.com/dfrnt-bom/',
+      },
+      {
+        '@id': 'dfrnt-bom:Item',
+        '@type': 'Class',
+        '@key': {
+          '@type': 'Random',
+        },
+        name: 'xsd:string',
+        description: 'xsd:string',
+      },
+    ]
+
+    before(async function () {
+      await db.create(agent, { label: 'Hyphenated prefix document test' })
+      await document.insert(agent, { schema, fullReplace: true })
+    })
+
+    after(async function () {
+      await db.delete(agent)
+    })
+
+    it('stores and retrieves a schema document using a hyphenated prefix', async function () {
+      const r = await document.get(agent, {
+        query: { graph_type: 'schema', id: 'dfrnt-bom:Item' },
+      })
+      expect(r.status).to.equal(200)
+      expect(r.body['@id']).to.equal('dfrnt-bom:Item')
+      expect(r.body['@type']).to.equal('Class')
+    })
+
+    it('inserts and retrieves an instance document using a hyphenated prefix', async function () {
+      const instance = {
+        '@type': 'dfrnt-bom:Item',
+        name: 'Test item',
+        description: 'Original description',
+      }
+      const result = await document.insert(agent, { instance })
+      expect(result.status).to.equal(200)
+      expect(result.body.length).to.equal(1)
+
+      const docId = result.body[0]
+      const r = await document.get(agent, { query: { id: docId } })
+      expect(r.status).to.equal(200)
+      expect(r.body['@id']).to.be.a('string')
+      expect(r.body['@type']).to.equal('dfrnt-bom:Item')
+      expect(r.body.name).to.equal('Test item')
+      expect(r.body.description).to.equal('Original description')
+    })
+
+    it('updates an instance document using a hyphenated prefix', async function () {
+      const instance = {
+        '@type': 'dfrnt-bom:Item',
+        name: 'Test item',
+        description: 'Original description',
+      }
+      const insertResult = await document.insert(agent, { instance })
+      const docId = insertResult.body[0]
+
+      const updated = {
+        '@type': 'dfrnt-bom:Item',
+        '@id': docId,
+        name: 'Test item',
+        description: 'Updated description',
+      }
+      const r = await document.replace(agent, { instance: updated })
+      expect(r.status).to.equal(200)
+
+      const retrieved = await document.get(agent, { query: { id: docId } })
+      expect(retrieved.status).to.equal(200)
+      expect(retrieved.body.description).to.equal('Updated description')
+      expect(retrieved.body['@type']).to.equal('dfrnt-bom:Item')
+      expect(retrieved.body['@id']).to.be.a('string')
+    })
+  })
+
+  describe('CRUD with a hyphenated schema namespace', function () {
+    const schema = [
+      {
+        '@type': '@context',
+        '@base': 'terminusdb:///data/',
+        '@schema': 'https://example.com/dfrnt-bom/',
+      },
+      {
+        '@id': 'Item',
+        '@type': 'Class',
+        '@key': {
+          '@type': 'Random',
+        },
+        name: 'xsd:string',
+        description: 'xsd:string',
+      },
+    ]
+
+    before(async function () {
+      await db.create(agent, { label: 'Hyphenated schema namespace document test' })
+      await document.insert(agent, { schema, fullReplace: true })
+    })
+
+    after(async function () {
+      await db.delete(agent)
+    })
+
+    it('stores and retrieves a schema document in a hyphenated schema namespace', async function () {
+      const r = await document.get(agent, {
+        query: { graph_type: 'schema', id: 'Item' },
+      })
+      expect(r.status).to.equal(200)
+      expect(r.body['@id']).to.equal('Item')
+      expect(r.body['@type']).to.equal('Class')
+    })
+
+    it('inserts and retrieves an instance document in a hyphenated schema namespace', async function () {
+      const instance = {
+        '@type': 'Item',
+        name: 'Test item',
+        description: 'Original description',
+      }
+      const result = await document.insert(agent, { instance })
+      expect(result.status).to.equal(200)
+      expect(result.body.length).to.equal(1)
+
+      const docId = result.body[0]
+      const r = await document.get(agent, { query: { id: docId } })
+      expect(r.status).to.equal(200)
+      expect(r.body['@id']).to.be.a('string')
+      expect(r.body['@type']).to.equal('Item')
+      expect(r.body.name).to.equal('Test item')
+      expect(r.body.description).to.equal('Original description')
+    })
+  })
+})

--- a/tests/test/prefixes.js
+++ b/tests/test/prefixes.js
@@ -46,5 +46,19 @@ describe('prefixes', function () {
       // Delete the created database
       await db.delete(agent)
     })
+
+    it('passes create with a hyphenated prefix', async function () {
+      const prefixes = {
+        '@base': 'http://a.me/b',
+        '@schema': 'https://b.is/schema#',
+        'dfrnt-bom': 'https://example.com/dfrnt-bom/',
+      }
+      await db.create(agent, { prefixes })
+      const r = await agent.get(api.path.prefixes(agent))
+      expect(r.status).to.equal(200)
+      prefixes['@type'] = 'Context'
+      expect(r.body).to.deep.equal(prefixes)
+      await db.delete(agent)
+    })
   })
 })


### PR DESCRIPTION
Fixes https://github.com/terminusdb/terminusdb/issues/2459

`uri_has_protocol/1` in `src/core/util/utils.pl` only allowed letters and digits in URI schemes (`^\p{L}\p{Xan}*://.+`), so schemes containing `+`, `-`, or `.` were misclassified as CURIEs. This caused IRIs like `dfrnt-bom:///schema#BomClass` to be double-expanded into a malformed IRI, resulting in `DocumentNotFound` for every class in the hyphenated namespace.

## Fix
```prolog
uri_has_protocol(K) :-
    re_match('^\\p{L}[\\p{Xan}+\\-.]*://.+', K).
```
This matches RFC 3986 §3.1: `ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`.

## Tests
- `utils_uri_prefix` (utils.pl): added tests for `dfrnt-bom:///schema#BomClass`, `coap+tcp:///path`, `my.scheme:///path`, and rejection of prefixed names / bare strings.
- `jsonld_expand` (jsonld.pl): added `expand_hyphenated_scheme_unchanged` to verify `dfrnt-bom:///schema#BomClass` passes through `prefix_expand/3` unchanged.
- `uri_has_prefix_unsafe/2` and `valid_prefix_name/1` were left unchanged; they already handle hyphenated prefixes correctly.

## Verification (specific suites)
- `run_tests(utils_uri_prefix)` — 12 passed
- `run_tests(api_prefixes)` — 42 passed
- `run_tests(jsonld_expand)` — 6 passed
- `run_tests(jsonld_compress)` — 4 passed
- `npx mocha tests/test/document-hyphenated-prefix.js tests/test/prefixes.js` — 9 passed
- `npx mocha tests/test/document-get.js` — 67 passed

## Scope
Minimal, single-line regex change in `uri_has_protocol/1`. Only broadens the set of recognized schemes; no previously accepted URIs can be rejected.
