### PR TITLE
Fix false patch conflict on xsd:decimal properties

### DIFF
--- a/src/core/document/patch.pl
+++ b/src/core/document/patch.pl
@@ -111,16 +111,20 @@ pairs_and_conflicts_from_keys([Key|Keys], JSON, Diff,
 % In Prolog, atoms and strings don't unify even with identical characters,
 % so we convert both to atoms before comparison.
 %
-% Dicts (subdocument objects), lists, and numbers are compared
-% structurally — only atoms and strings use coerced comparison.
+% Numbers are compared by numeric equality so that representations such
+% as a stored xsd:decimal rational (e.g. 11r10) and a JSON float (e.g. 1.1)
+% are treated as equal.  Dicts and lists are compared structurally.
 %
+values_equal(V1, V2) :-
+    number(V1),
+    number(V2),
+    !,
+    V1 =:= V2.
 values_equal(V1, V2) :-
     (   is_dict(V1)
     ;   is_dict(V2)
     ;   is_list(V1)
     ;   is_list(V2)
-    ;   number(V1)
-    ;   number(V2)
     ),
     !,
     V1 = V2.
@@ -1072,6 +1076,30 @@ test(values_equal_null_vs_dict, [fail]) :-
     %% Direct unit test: null (atom) vs dict must fail, NOT throw.
     D = json{ '@type' : "Quantity", value : 1 },
     values_equal(null, D).
+
+test(values_equal_rational_and_float, []) :-
+    %% xsd:decimal is stored as a rational, but JSON supplies a float.
+    values_equal(11r10, 1.1).
+
+test(values_equal_float_and_integer, []) :-
+    values_equal(1.0, 1).
+
+test(values_equal_integer_and_decimal, []) :-
+    values_equal(1, 1r1).
+
+test(swap_decimal_value, []) :-
+    %% Regression: patching a decimal property with a float SwapValue
+    %% must not produce a conflict when the stored value is equal.
+    Before = _{ '@id' : "Test/1",
+                '@type' : "Test",
+                weight : 11r10 },
+    Patch = _{ weight : _{ '@op' : "SwapValue",
+                           '@before' : 1.1,
+                           '@after' : 1.2 } },
+    After =  _{ '@id' : "Test/1",
+                '@type' : "Test",
+                weight : 1.2 },
+    simple_patch(Patch, Before, success(After), []).
 
 :- end_tests(simple_patch).
 

--- a/tests/test/patch.js
+++ b/tests/test/patch.js
@@ -178,5 +178,51 @@ describe('patch', function () {
       // Should succeed without conflict
       expect(res.body).to.deep.equal([enumId])
     })
+
+    it('applies patch to decimal property without false conflict', async function () {
+      // Schema with decimal type
+      const decimalSchema = [
+        {
+          '@id': 'DecimalTest',
+          '@type': 'Class',
+          '@key': { '@type': 'Random' },
+          weight: 'xsd:decimal',
+        },
+      ]
+      await document.insert(agent, { schema: decimalSchema })
+
+      // Insert instance with a decimal value
+      const instance = [
+        {
+          '@type': 'DecimalTest',
+          weight: 1.1,
+        },
+      ]
+      const response = await document.insert(agent, { instance })
+      const decimalId = response.body[0]
+
+      // Apply patch to change decimal value using JSON numbers, reproducing the
+      // reported issue where a float-rounded @before did not match the stored rational.
+      const path = api.path.patchDb(agent)
+      const patch = {
+        '@id': decimalId,
+        weight: {
+          '@op': 'SwapValue',
+          '@before': 1.1,
+          '@after': 1.2,
+        },
+      }
+      const author = 'test'
+      const message = 'change decimal weight'
+      const res = await agent.post(path).send({ patch, author, message })
+
+      // Should succeed without conflict
+      if (res.status !== 200) {
+        console.log('DECIMAL PATCH FAILED - status:', res.status)
+        console.log('DECIMAL PATCH FAILED - body:', res.text)
+      }
+      expect(res.status).to.equal(200)
+      expect(res.body).to.deep.equal([decimalId])
+    })
   })
 })


### PR DESCRIPTION
Patching an `xsd:decimal` property via the HTTP patch endpoint incorrectly returned a `PatchConflict`, even though the `@expected` and `@found` values were identical.

## Root cause

`xsd:decimal` values are processed as rationals internally (e.g. `11r10`), but the JSON patch's `@before` value is parsed as a float (e.g. `1.1`). `values_equal/2` in [src/core/document/patch.pl](src/core/document/patch.pl:0:0-0:0) compared numbers with plain unification, so the two representations did not match and the patch was rejected as a conflict.

## Fix

`values_equal/2` now compares numbers with `=:=` numeric equality before falling back to structural comparison for dicts/lists and atom/string coercion. This lets `11r10` and `1.1` (and similar cross-type numeric pairs) compare as equal.

## Tests

Added regression tests in the `simple_patch` suite:

- `values_equal_rational_and_float` — `11r10` and `1.1`
- `values_equal_float_and_integer` — `1.0` and `1`
- `values_equal_integer_and_decimal` — `1` and `1r1`
- `swap_decimal_value` — full `SwapValue` patch on a decimal property