### PR TITLE
Add `unfold` parameter to the diff API endpoint

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2329,6 +2329,10 @@ paths:
                 "keep":
                   type: object
                   example: { "@id" : true, "_id" : true }
+                "unfold":
+                  type: boolean
+                  default: true
+                  description: Expand subdocuments inline when retrieving documents from the specified commits. Set to false to compare folded documents by reference.
       responses:
         200:
           description: "Successful Diff"

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2332,7 +2332,7 @@ paths:
                 "unfold":
                   type: boolean
                   default: true
-                  description: Expand subdocuments inline when retrieving documents from the specified commits. Set to false to compare folded documents by reference.
+                  description: Expand subdocuments inline when retrieving documents from the specified commits. Set to false to compare documents without unfolding.
       responses:
         200:
           description: "Successful Diff"

--- a/src/cli/main.pl
+++ b/src/cli/main.pl
@@ -464,6 +464,12 @@ or two commits (path required).',
            shortflags([c]),
            default(false),
            help('Maintain explit copies of diffs in lists')],
+          [opt(unfold),
+           type(boolean),
+           longflags([unfold]),
+           shortflags([u]),
+           default(true),
+           help('Expand subdocuments inline when comparing documents from commits')],
           [opt(docid),
            type(atom),
            longflags([docid]),
@@ -1892,6 +1898,7 @@ run_command(diff, Args, Opts) :-
     option(before_commit(Before_Commit), Opts),
     option(after_commit(After_Commit), Opts),
     option(copy_value(Copy_Value), Opts),
+    option(unfold(Unfold), Opts, true),
 
     api_report_errors(
         diff,
@@ -1904,7 +1911,7 @@ run_command(diff, Args, Opts) :-
         ;   \+ var(DocId), \+ var(Before_Commit), \+ var(After_Commit),
             [Path] = Args
         ->  atom_json_dict(Keep_Atom, Keep, [default_tag(json)]),
-            Options = [keep(Keep),copy_value(Copy_Value)],
+            Options = [keep(Keep),copy_value(Copy_Value),unfold(Unfold)],
             api_diff_id(System_DB, Auth, Path, Before_Commit,
                         After_Commit, DocId, Patch, Options)
         ;   \+ var(After_Commit), \+ var(Before_Commit),
@@ -1915,6 +1922,7 @@ run_command(diff, Args, Opts) :-
             negative_to_infinity(Count_With_Neg,Count),
             Options = [keep(Keep),
                        copy_value(Copy_Value),
+                       unfold(Unfold),
                        start(Start),
                        count(Count)],
             api_diff_all_documents(System_DB, Auth, Path,
@@ -1924,7 +1932,7 @@ run_command(diff, Args, Opts) :-
             [Path] = Args
         ->  atom_json_dict(After_Atom, After, [default_tag(json)]),
             atom_json_dict(Keep_Atom, Keep, [default_tag(json)]),
-            Options = [keep(Keep),copy_value(Copy_Value)],
+            Options = [keep(Keep),copy_value(Copy_Value),unfold(Unfold)],
             api_diff_id_document(System_DB, Auth, Path,
                                  Before_Commit, After,
                                  DocId, Patch, Options)

--- a/src/core/api/api_patch.pl
+++ b/src/core/api/api_patch.pl
@@ -26,6 +26,7 @@
 :- use_module(library(lists)).
 :- use_module(library(plunit)).
 :- use_module(library(option)).
+:- use_module(library(error), [must_be/2]).
 :- use_module(library(assoc)).
 :- use_module(library(apply)).
 :- use_module(library(apply_macros)).
@@ -123,6 +124,11 @@ coerce_to_commit(Branch_Descriptor, Commit_Or_Version, Commit_Id) :-
 
 document_from_commit(Branch_Descriptor, Commit_Id, Doc_Id, Document, Transaction,
                      Map_In, Map_Out) :-
+    document_from_commit(Branch_Descriptor, Commit_Id, Doc_Id, Document, Transaction,
+                         Map_In, Map_Out, options{}).
+
+document_from_commit(Branch_Descriptor, Commit_Id, Doc_Id, Document, Transaction,
+                     Map_In, Map_Out, Options) :-
     resolve_relative_descriptor(Branch_Descriptor,
                                 ["commit", Commit_Id],
                                 Commit_Descriptor),
@@ -131,25 +137,28 @@ document_from_commit(Branch_Descriptor, Commit_Id, Doc_Id, Document, Transaction
         open_descriptor(Commit_Descriptor, commit_info{}, Transaction, Map_In, Map_Out),
         error(unresolvable_collection(Commit_Descriptor),_)),
 
-    Options = options{
+    option(unfold(Unfold), Options, true),
+    must_be(boolean, Unfold),
+
+    Get_Document_Options = options{
                   compress_ids : true,
-                  unfold: true,
+                  unfold: Unfold,
                   keep_json_type: true
               },
-    get_document(Transaction, Doc_Id, Document, Options).
+    get_document(Transaction, Doc_Id, Document, Get_Document_Options).
 
 api_diff_id(System_DB, Auth, Path, Before_Version, After_Version, Doc_Id, Diff, Options) :-
     resolve_descriptor_auth(read, System_DB, Auth, Path, instance, Branch_Descriptor),
     coerce_to_commit(Branch_Descriptor, Before_Version, Before_Commit_Id),
     coerce_to_commit(Branch_Descriptor, After_Version, After_Commit_Id),
 
-    (   document_from_commit(Branch_Descriptor, Before_Commit_Id, Doc_Id, Before, _, [], Map)
-    ->  (   document_from_commit(Branch_Descriptor, After_Commit_Id, Doc_Id, After, _, Map, _)
+    (   document_from_commit(Branch_Descriptor, Before_Commit_Id, Doc_Id, Before, _, [], Map, Options)
+    ->  (   document_from_commit(Branch_Descriptor, After_Commit_Id, Doc_Id, After, _, Map, _, Options)
         ->  simple_diff(Before,After,Diff,Options)
         ;   Diff = json{ '@op' : 'Delete',
                          '@delete' : Before }
         )
-    ;   (   document_from_commit(Branch_Descriptor, After_Commit_Id, Doc_Id, After, _, [], _)
+    ;   (   document_from_commit(Branch_Descriptor, After_Commit_Id, Doc_Id, After, _, [], _, Options)
         ->  Diff = json{ '@op' : 'Insert',
                          '@insert' : After }
         ;   fail)
@@ -159,7 +168,7 @@ api_diff_id_document(System_DB, Auth, Path, Before_Version, After_Document, Doc_
     resolve_descriptor_auth(read, System_DB, Auth, Path, instance, Branch_Descriptor),
     coerce_to_commit(Branch_Descriptor, Before_Version, Before_Commit_Id),
 
-    document_from_commit(Branch_Descriptor, Before_Commit_Id, Doc_Id, Before, Transaction, [], _),
+    document_from_commit(Branch_Descriptor, Before_Commit_Id, Doc_Id, Before, Transaction, [], _, Options),
 
     normalize_document(Transaction, After_Document, Normal_Document),
     simple_diff(Before,Normal_Document,Diff,Options).
@@ -175,13 +184,13 @@ document_diffs_from_commits(Branch_Descriptor, Before_Commit_Id, After_Commit_Id
         offset(
             Start,
             (   commits_changed_id(Branch_Descriptor, Before_Commit_Id, After_Commit_Id, Doc_Id),
-                (   document_from_commit(Branch_Descriptor, Before_Commit_Id, Doc_Id, Before, _, [], Map)
-                ->  (   document_from_commit(Branch_Descriptor, After_Commit_Id, Doc_Id, After, _, Map, _)
+                (   document_from_commit(Branch_Descriptor, Before_Commit_Id, Doc_Id, Before, _, [], Map, Options)
+                ->  (   document_from_commit(Branch_Descriptor, After_Commit_Id, Doc_Id, After, _, Map, _, Options)
                     ->  simple_diff(Before,After,Diff,Options)
                     ;   Diff = json{ '@op' : 'Delete',
                                      '@delete' : Before }
                     )
-                ;   (   document_from_commit(Branch_Descriptor, After_Commit_Id, Doc_Id, After, _, [], _)
+                ;   (   document_from_commit(Branch_Descriptor, After_Commit_Id, Doc_Id, After, _, [], _, Options)
                     ->  Diff = json{ '@op' : 'Insert',
                                      '@insert' : After }
                     ;   fail)

--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -2800,8 +2800,9 @@ diff_handler(post, Path, Request, System_DB, Auth) :-
     % We could probably just feed the document in,
     % the default is dubious.
     (   get_dict(keep,Document,_)
-    ->  Options = Document
-    ;   put_dict(_{ keep : _{ '@id' : true, '_id' : true }},
+    ->  put_dict(_{ unfold : true }, Document, Options)
+    ;   put_dict(_{ keep : _{ '@id' : true, '_id' : true },
+                    unfold : true },
                  Document, Options)
     ),
 

--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -2800,10 +2800,11 @@ diff_handler(post, Path, Request, System_DB, Auth) :-
     % We could probably just feed the document in,
     % the default is dubious.
     (   get_dict(keep,Document,_)
-    ->  put_dict(_{ unfold : true }, Document, Options)
-    ;   put_dict(_{ keep : _{ '@id' : true, '_id' : true },
+    ->  put_dict(Document, _{ unfold : true }, Options)
+    ;   put_dict(Document,
+                 _{ keep : _{ '@id' : true, '_id' : true },
                     unfold : true },
-                 Document, Options)
+                 Options)
     ),
 
     api_report_errors(

--- a/tests/test/diff-id.js
+++ b/tests/test/diff-id.js
@@ -256,6 +256,75 @@ describe('diff-id', function () {
       expect(r3.body[0].b.c).to.deep.equal({ '@after': 4, '@before': 3, '@op': 'SwapValue' })
     })
 
+    it('diff a single document with explicit unfold', async function () {
+      const class1 = util.randomString()
+      const class2 = util.randomString()
+      await document
+        .insert(agent, {
+          schema: [{ '@type': 'Class', '@id': class1, a: 'xsd:string', b: class2 },
+            {
+              '@type': 'Class',
+              '@id': class2,
+              c: 'xsd:integer',
+              '@subdocument': [],
+              '@key': { '@type': 'Lexical', '@fields': ['c'] },
+            },
+          ],
+        })
+      const r1 = await document
+        .insert(agent, {
+          instance: {
+            '@type': class1,
+            a: 'pickles and eggs',
+            b: {
+              '@type': class2,
+              c: 3,
+            },
+          },
+        })
+      const dv1 = r1.header['terminusdb-data-version']
+      const [docIdLong] = r1.body
+      const r2 = await document
+        .replace(agent, {
+          instance: {
+            '@type': class1,
+            a: 'pickles and eggs',
+            '@id': docIdLong,
+            b: {
+              '@type': class2,
+              c: 4,
+            },
+          },
+        })
+      const dv2 = r2.header['terminusdb-data-version']
+      const path = api.path.versionDiff(agent)
+
+      const unfolded = await agent.post(path).send(
+        {
+          before_data_version: dv1,
+          after_data_version: dv2,
+          document_id: docIdLong,
+          unfold: true,
+        })
+      expect(unfolded.status).to.equal(200)
+      expect(unfolded.body.b).to.deep.equal({
+        c: { '@after': 4, '@before': 3, '@op': 'SwapValue' },
+      })
+
+      const folded = await agent.post(path).send(
+        {
+          before_data_version: dv1,
+          after_data_version: dv2,
+          document_id: docIdLong,
+          unfold: false,
+        })
+      expect(folded.status).to.equal(200)
+      expect(folded.body.b['@op']).to.equal('SwapValue')
+      expect(folded.body.b['@before']).to.be.a('string')
+      expect(folded.body.b['@after']).to.be.a('string')
+      expect(folded.body.b).to.not.have.property('c')
+    })
+
     it('diff inserted object', async function () {
       const class1 = util.randomString()
       const class2 = util.randomString()


### PR DESCRIPTION
The diff API endpoint (`POST /api/diff`) always compared the full documents with subdocuments expanded inline, with a hardcoded `unfold: true`. This change exposes an `unfold` parameter on the endpoint so callers can choose between folded and unfolded comparison while preserving the existing default behavior.

## Backward compatibility

Omitting `unfold` keeps the previous behavior (`unfold: true`). The CLI
continues to default to `true` because it uses the existing
entry point and the options list now includes `unfold`. JS and
Python clients can already use the new parameter by including it in the
request body, and are also getting the option in separate PR:s.
