### PR TITLE
Fully specified, and accurate, intervals in retrieval path, with nanosecond precision

### DIFF
--- a/src/core/query/json_woql.pl
+++ b/src/core/query/json_woql.pl
@@ -1947,7 +1947,7 @@ test(dateTimeStamp, []) :-
                                       "@type": "xsd:dateTimeStamp"}}}',
     atom_json_dict(JSON_Atom, JSON, []),
     json_woql(JSON,WOQL),
-    WOQL = (v('X')=date_time(2004,4,12,8,20,0,0)^^'http://www.w3.org/2001/XMLSchema#dateTimeStamp').
+    WOQL = (v('X')=date_time(2004,4,12,18,20,0,0)^^'http://www.w3.org/2001/XMLSchema#dateTimeStamp').
 
 test(gyear, []) :-
     JSON_Atom= '{"@type": "Equals",

--- a/src/core/query/woql_compile.pl
+++ b/src/core/query/woql_compile.pl
@@ -1320,16 +1320,17 @@ woql_interval(Start, End, Interval) :-
     (   nonvar(Interval)
     ->  Interval = IV^^'http://terminusdb.com/schema/xdd#dateTimeInterval',
         IV = date_time_interval(C1,C2,_Dur,_Flag),
-        interval_component_typed(C1, Start),
-        interval_component_typed(C2, End)
+        interval_component_typed_datetime(C1, Start),
+        interval_component_typed_datetime(C2, End)
     ;   nonvar(Start), nonvar(End)
     ->  Start = D1^^_,
         End = D2^^_,
-        interval_component_stamp(D1, S1),
-        interval_component_stamp(D2, S2),
-        DiffSecs is S2 - S1,
-        seconds_to_duration(DiffSecs, Dur),
-        Interval = date_time_interval(D1,D2,Dur,explicit)^^'http://terminusdb.com/schema/xdd#dateTimeInterval'
+        bump_interval_end_component(D2, D2_Bumped),
+        interval_component_stamp_ns(D1, NS1),
+        interval_component_stamp_ns(D2_Bumped, NS2),
+        DiffNanos is NS2 - NS1,
+        nanoseconds_to_duration(DiffNanos, Dur),
+        Interval = date_time_interval(D1,D2_Bumped,Dur,explicit)^^'http://terminusdb.com/schema/xdd#dateTimeInterval'
     ;   throw(error(instantiation_error(interval), _))
     ).
 
@@ -1337,6 +1338,25 @@ interval_component_typed(date(Y,M,D,O), Val) :- !,
     Val = date(Y,M,D,O)^^'http://www.w3.org/2001/XMLSchema#date'.
 interval_component_typed(date_time(Y,M,D,HH,MM,SS,NS), Val) :- !,
     Val = date_time(Y,M,D,HH,MM,SS,NS)^^'http://www.w3.org/2001/XMLSchema#dateTime'.
+
+% Date-only components are normalised to midnight UTC dateTime for interval
+% decomposition and relation checks. This keeps the interval API dateTime-only.
+interval_component_typed_datetime(date(Y,M,D,_O), Val) :- !,
+    Val = date_time(Y,M,D,0,0,0,0)^^'http://www.w3.org/2001/XMLSchema#dateTime'.
+interval_component_typed_datetime(date_time(Y,M,D,HH,MM,SS,NS), Val) :- !,
+    Val = date_time(Y,M,D,HH,MM,SS,NS)^^'http://www.w3.org/2001/XMLSchema#dateTime'.
+
+/*
+ * bump_interval_end_component(+Component, -Bumped) is det.
+ *
+ * Date-only end components are interpreted as the start of the next calendar
+ * day (half-open ISO 8601 / XBRL convention). Date-time components are unchanged.
+ */
+bump_interval_end_component(date(Y,M,D,O), date(NY,NM,ND,O)) :- !,
+    date_time_stamp(date(Y,M,D,0,0,0,0,-,-), Stamp),
+    NextStamp is Stamp + 86400,
+    stamp_date_time(NextStamp, date(NY,NM,ND,0,0,0.0,_,_,_), 0).
+bump_interval_end_component(X, X).
 
 /*
  * Duration computation helpers for xdd:dateTimeInterval.
@@ -1351,6 +1371,47 @@ interval_component_stamp(date(Y,M,D,_O), Stamp) :-
 interval_component_stamp(date_time(Y,M,D,HH,MM,SS,NS), Stamp) :-
     S is SS + NS / 1000000000,
     date_time_stamp(date(Y,M,D,HH,MM,S,0,-,-), Stamp).
+
+% Convert an interval component to a Unix timestamp in nanoseconds.
+interval_component_stamp_ns(date(Y,M,D,_O), StampNanos) :-
+    date_time_stamp(date(Y,M,D,0,0,0,0,-,-), Stamp),
+    StampNanos is floor(Stamp * 1000000000).
+interval_component_stamp_ns(date_time(Y,M,D,HH,MM,SS,NS), StampNanos) :-
+    date_time_stamp(date(Y,M,D,HH,MM,SS,0,-,-), Stamp),
+    StampNanos is floor(Stamp * 1000000000) + NS.
+
+% Convert a nanoseconds difference to an xsd:duration term (days/time only).
+nanoseconds_to_duration(Nanos, duration(Sign,0,0,Days,Hours,Mins,SSec)) :-
+    (   Nanos < 0
+    ->  Sign = -1, AbsNanos is abs(Nanos)
+    ;   Sign = 1, AbsNanos = Nanos),
+    Days is AbsNanos // 86400000000000,
+    Rem1 is AbsNanos mod 86400000000000,
+    Hours is Rem1 // 3600000000000,
+    Rem2 is Rem1 mod 3600000000000,
+    Mins is Rem2 // 60000000000,
+    Rem3 is Rem2 mod 60000000000,
+    SSec is Rem3 / 1000000000.
+
+% Convert a nanoseconds difference to an xsd:duration term, omitting zero time components.
+nanoseconds_to_duration_significant(Nanos, duration(Sign,0,0,Days,Hours,Mins,SSec)) :-
+    (   Nanos < 0
+    ->  Sign = -1, AbsNanos is abs(Nanos)
+    ;   Sign = 1, AbsNanos = Nanos),
+    Days is AbsNanos // 86400000000000,
+    Rem1 is AbsNanos mod 86400000000000,
+    (   Days =:= 0
+    ->  Hours is Rem1 // 3600000000000,
+        Rem2 is Rem1 mod 3600000000000,
+        Mins is Rem2 // 60000000000,
+        Rem3 is Rem2 mod 60000000000,
+        (   Rem3 =:= 0
+        ->  SSec = 0.0
+        ;   SSec is Rem3 / 1000000000)
+    ;   Hours = 0,
+        Mins = 0,
+        SSec = 0.0
+    ).
 
 % Convert a Unix timestamp back to a component matching the type of a template.
 stamp_to_component_like(Stamp, date(_,_,_,_), date(Y,M,D,0)) :- !,
@@ -1391,7 +1452,7 @@ woql_interval_start_duration(Start, Duration, Interval) :-
     (   nonvar(Interval)
     ->  Interval = IV^^'http://terminusdb.com/schema/xdd#dateTimeInterval',
         IV = date_time_interval(C1,_C2,Dur,_Flag),
-        interval_component_typed(C1, Start),
+        interval_component_typed_datetime(C1, Start),
         Duration = Dur^^'http://www.w3.org/2001/XMLSchema#duration'
     ;   nonvar(Start), nonvar(Duration)
     ->  Start = C1^^_,
@@ -1412,13 +1473,14 @@ woql_interval_duration_end(Duration, End, Interval) :-
     (   nonvar(Interval)
     ->  Interval = IV^^'http://terminusdb.com/schema/xdd#dateTimeInterval',
         IV = date_time_interval(_C1,C2,Dur,_Flag),
-        interval_component_typed(C2, End),
+        interval_component_typed_datetime(C2, End),
         Duration = Dur^^'http://www.w3.org/2001/XMLSchema#duration'
     ;   nonvar(Duration), nonvar(End)
     ->  End = C2^^_,
         Duration = Dur^^'http://www.w3.org/2001/XMLSchema#duration',
-        subtract_duration_from_component(C2, Dur, C1),
-        Interval = date_time_interval(C1,C2,Dur,duration_end)^^'http://terminusdb.com/schema/xdd#dateTimeInterval'
+        bump_interval_end_component(C2, C2_Bumped),
+        subtract_duration_from_component(C2_Bumped, Dur, C1),
+        Interval = date_time_interval(C1,C2_Bumped,Dur,duration_end)^^'http://terminusdb.com/schema/xdd#dateTimeInterval'
     ;   throw(error(instantiation_error(interval_duration_end), _))
     ).
 
@@ -1491,10 +1553,10 @@ classify_interval_relation(Rel, Xs, Xe, Ys, Ye) :-
 woql_interval_relation_typed(Rel, X, Y) :-
     X = date_time_interval(Xc1,Xc2,_,_)^^'http://terminusdb.com/schema/xdd#dateTimeInterval',
     Y = date_time_interval(Yc1,Yc2,_,_)^^'http://terminusdb.com/schema/xdd#dateTimeInterval',
-    interval_component_typed(Xc1, Xs),
-    interval_component_typed(Xc2, Xe),
-    interval_component_typed(Yc1, Ys),
-    interval_component_typed(Yc2, Ye),
+    interval_component_typed_datetime(Xc1, Xs),
+    interval_component_typed_datetime(Xc2, Xe),
+    interval_component_typed_datetime(Yc1, Ys),
+    interval_component_typed_datetime(Yc2, Ye),
     woql_interval_relation(Rel, Xs, Xe, Ys, Ye).
 
 /*
@@ -1685,10 +1747,10 @@ woql_date_duration(Start, End, Duration) :-
     ->  % Compute duration from Start and End (day-count/time)
         Start = C1^^_,
         End = C2^^_,
-        interval_component_stamp(C1, S1),
-        interval_component_stamp(C2, S2),
-        DiffSecs is S2 - S1,
-        seconds_to_duration_significant(DiffSecs, Dur),
+        interval_component_stamp_ns(C1, NS1),
+        interval_component_stamp_ns(C2, NS2),
+        DiffNanos is NS2 - NS1,
+        nanoseconds_to_duration_significant(DiffNanos, Dur),
         Duration = Dur^^'http://www.w3.org/2001/XMLSchema#duration'
     ;   nonvar(Start), nonvar(Duration)
     ->  % Compute End = Start + Duration (EOM-aware)
@@ -8357,7 +8419,7 @@ test(interval_construct, [
              },
     query_test_response_test_branch(Query, JSON),
     [Binding] = JSON.bindings,
-    Binding.i = _{'@type': 'xdd:dateTimeInterval', '@value': "2025-01-01/2025-04-01"}.
+    Binding.i = _{'@type': 'xdd:dateTimeInterval', '@value': "2025-01-01T00:00:00Z/2025-04-02T00:00:00Z"}.
 
 test(interval_deconstruct, [
     setup((setup_temp_store(State),
@@ -8370,12 +8432,12 @@ test(interval_deconstruct, [
                'end' : _{'@type' : "DataValue",
                          variable : "e"},
                interval : _{'@type' : "DataValue",
-                            'data' : _{'@type': 'xdd:dateTimeInterval', '@value': "2025-01-01/2025-04-01"}}
+                            'data' : _{'@type': 'xdd:dateTimeInterval', '@value': "2025-01-01/2025-03-31"}}
              },
     query_test_response_test_branch(Query, JSON),
     [Binding] = JSON.bindings,
-    Binding.s = _{'@type': 'xsd:date', '@value': "2025-01-01"},
-    Binding.e = _{'@type': 'xsd:date', '@value': "2025-04-01"}.
+    Binding.s = _{'@type': 'xsd:dateTime', '@value': "2025-01-01T00:00:00Z"},
+    Binding.e = _{'@type': 'xsd:dateTime', '@value': "2025-04-01T00:00:00Z"}.
 
 test(interval_validate, [
     setup((setup_temp_store(State),
@@ -8384,11 +8446,11 @@ test(interval_validate, [
 ]) :-
     Query = _{ '@type' : "Interval",
                start : _{'@type' : "DataValue",
-                         'data' : _{'@type': 'xsd:date', '@value': "2025-01-01"}},
+                         'data' : _{'@type': 'xsd:dateTime', '@value': "2025-01-01T00:00:00Z"}},
                'end' : _{'@type' : "DataValue",
-                         'data' : _{'@type': 'xsd:date', '@value': "2025-04-01"}},
+                         'data' : _{'@type': 'xsd:dateTime', '@value': "2025-04-01T00:00:00Z"}},
                interval : _{'@type' : "DataValue",
-                            'data' : _{'@type': 'xdd:dateTimeInterval', '@value': "2025-01-01/2025-04-01"}}
+                            'data' : _{'@type': 'xdd:dateTimeInterval', '@value': "2025-01-01/2025-03-31"}}
              },
     query_test_response_test_branch(Query, JSON),
     length(JSON.bindings, 1).
@@ -8400,9 +8462,9 @@ test(interval_validate_mismatch, [
 ]) :-
     Query = _{ '@type' : "Interval",
                start : _{'@type' : "DataValue",
-                         'data' : _{'@type': 'xsd:date', '@value': "2025-01-01"}},
+                         'data' : _{'@type': 'xsd:dateTime', '@value': "2025-01-01T00:00:00Z"}},
                'end' : _{'@type' : "DataValue",
-                         'data' : _{'@type': 'xsd:date', '@value': "2025-06-01"}},
+                         'data' : _{'@type': 'xsd:dateTime', '@value': "2025-06-01T00:00:00Z"}},
                interval : _{'@type' : "DataValue",
                             'data' : _{'@type': 'xdd:dateTimeInterval', '@value': "2025-01-01/2025-04-01"}}
              },
@@ -8459,7 +8521,7 @@ test(interval_mixed_date_datetime, [
              },
     query_test_response_test_branch(Query, JSON),
     [Binding] = JSON.bindings,
-    Binding.i = _{'@type': 'xdd:dateTimeInterval', '@value': "2025-01-01/2025-04-01T12:00:00Z"}.
+    Binding.i = _{'@type': 'xdd:dateTimeInterval', '@value': "2025-01-01T00:00:00Z/2025-04-01T12:00:00Z"}.
 
 test(interval_typecast_datetime_string, [
     setup((setup_temp_store(State),
@@ -8489,11 +8551,11 @@ test(interval_start_duration_from_interval, [
                duration : _{'@type' : "DataValue",
                             variable : "d"},
                interval : _{'@type' : "DataValue",
-                            'data' : _{'@type': 'xdd:dateTimeInterval', '@value': "2025-01-01/2025-04-01"}}
+                            'data' : _{'@type': 'xdd:dateTimeInterval', '@value': "2025-01-01/2025-03-31"}}
              },
     query_test_response_test_branch(Query, JSON),
     [Binding] = JSON.bindings,
-    Binding.s = _{'@type': 'xsd:date', '@value': "2025-01-01"},
+    Binding.s = _{'@type': 'xsd:dateTime', '@value': "2025-01-01T00:00:00Z"},
     Binding.d = _{'@type': 'xsd:duration', '@value': "P90D"}.
 
 test(interval_start_duration_construct, [
@@ -8511,7 +8573,7 @@ test(interval_start_duration_construct, [
              },
     query_test_response_test_branch(Query, JSON),
     [Binding] = JSON.bindings,
-    Binding.i = _{'@type': 'xdd:dateTimeInterval', '@value': "2025-01-01/2025-04-01"}.
+    Binding.i = _{'@type': 'xdd:dateTimeInterval', '@value': "2025-01-01T00:00:00Z/2025-04-01T00:00:00Z"}.
 
 test(interval_duration_end_from_interval, [
     setup((setup_temp_store(State),
@@ -8524,11 +8586,11 @@ test(interval_duration_end_from_interval, [
                'end' : _{'@type' : "DataValue",
                          variable : "e"},
                interval : _{'@type' : "DataValue",
-                            'data' : _{'@type': 'xdd:dateTimeInterval', '@value': "2025-01-01/2025-04-01"}}
+                            'data' : _{'@type': 'xdd:dateTimeInterval', '@value': "2025-01-01/2025-03-31"}}
              },
     query_test_response_test_branch(Query, JSON),
     [Binding] = JSON.bindings,
-    Binding.e = _{'@type': 'xsd:date', '@value': "2025-04-01"},
+    Binding.e = _{'@type': 'xsd:dateTime', '@value': "2025-04-01T00:00:00Z"},
     Binding.d = _{'@type': 'xsd:duration', '@value': "P90D"}.
 
 test(interval_duration_end_construct, [
@@ -8540,13 +8602,13 @@ test(interval_duration_end_construct, [
                duration : _{'@type' : "DataValue",
                             'data' : _{'@type': 'xsd:duration', '@value': "P90D"}},
                'end' : _{'@type' : "DataValue",
-                         'data' : _{'@type': 'xsd:date', '@value': "2025-04-01"}},
+                         'data' : _{'@type': 'xsd:date', '@value': "2025-03-31"}},
                interval : _{'@type' : "DataValue",
                             variable : "i"}
              },
     query_test_response_test_branch(Query, JSON),
     [Binding] = JSON.bindings,
-    Binding.i = _{'@type': 'xdd:dateTimeInterval', '@value': "2025-01-01/2025-04-01"}.
+    Binding.i = _{'@type': 'xdd:dateTimeInterval', '@value': "2025-01-01T00:00:00Z/2025-04-01T00:00:00Z"}.
 
 test(interval_start_duration_datetime, [
     setup((setup_temp_store(State),
@@ -8565,6 +8627,162 @@ test(interval_start_duration_datetime, [
     [Binding] = JSON.bindings,
     Binding.s = _{'@type': 'xsd:dateTime', '@value': "2025-01-01T09:00:00Z"},
     Binding.d = _{'@type': 'xsd:duration', '@value': "PT8H30M"}.
+
+test(interval_start_duration_nanoseconds_from_interval, [
+    setup((setup_temp_store(State),
+           create_db_without_schema(admin,test))),
+    cleanup(teardown_temp_store(State))
+]) :-
+    Query = _{ '@type' : "IntervalStartDuration",
+               start : _{'@type' : "DataValue",
+                         variable : "s"},
+               duration : _{'@type' : "DataValue",
+                            variable : "d"},
+               interval : _{'@type' : "DataValue",
+                            'data' : _{'@type': 'xdd:dateTimeInterval', '@value': "2025-01-01T00:00:00Z/2025-01-01T00:00:00.500Z"}}
+             },
+    query_test_response_test_branch(Query, JSON),
+    [Binding] = JSON.bindings,
+    Binding.s = _{'@type': 'xsd:dateTime', '@value': "2025-01-01T00:00:00Z"},
+    Binding.d = _{'@type': 'xsd:duration', '@value': "PT0.5S"}.
+
+test(interval_start_duration_nanoseconds_construct, [
+    setup((setup_temp_store(State),
+           create_db_without_schema(admin,test))),
+    cleanup(teardown_temp_store(State))
+]) :-
+    Query = _{ '@type' : "IntervalStartDuration",
+               start : _{'@type' : "DataValue",
+                         'data' : _{'@type': 'xsd:dateTime', '@value': "2025-01-01T00:00:00Z"}},
+               duration : _{'@type' : "DataValue",
+                            'data' : _{'@type': 'xsd:duration', '@value': "PT0.5S"}},
+               interval : _{'@type' : "DataValue",
+                            variable : "i"}
+             },
+    query_test_response_test_branch(Query, JSON),
+    [Binding] = JSON.bindings,
+    Binding.i = _{'@type': 'xdd:dateTimeInterval', '@value': "2025-01-01T00:00:00Z/2025-01-01T00:00:00.500Z"}.
+
+test(interval_duration_end_nanoseconds_from_interval, [
+    setup((setup_temp_store(State),
+           create_db_without_schema(admin,test))),
+    cleanup(teardown_temp_store(State))
+]) :-
+    Query = _{ '@type' : "IntervalDurationEnd",
+               duration : _{'@type' : "DataValue",
+                            variable : "d"},
+               'end' : _{'@type' : "DataValue",
+                         variable : "e"},
+               interval : _{'@type' : "DataValue",
+                            'data' : _{'@type': 'xdd:dateTimeInterval', '@value': "2025-01-01T00:00:00.000Z/2025-01-01T00:00:00.500Z"}}
+             },
+    query_test_response_test_branch(Query, JSON),
+    [Binding] = JSON.bindings,
+    Binding.e = _{'@type': 'xsd:dateTime', '@value': "2025-01-01T00:00:00.500Z"},
+    Binding.d = _{'@type': 'xsd:duration', '@value': "PT0.5S"}.
+
+test(interval_duration_end_nanoseconds_construct, [
+    setup((setup_temp_store(State),
+           create_db_without_schema(admin,test))),
+    cleanup(teardown_temp_store(State))
+]) :-
+    Query = _{ '@type' : "IntervalDurationEnd",
+               duration : _{'@type' : "DataValue",
+                            'data' : _{'@type': 'xsd:duration', '@value': "PT0.5S"}},
+               'end' : _{'@type' : "DataValue",
+                         'data' : _{'@type': 'xsd:dateTime', '@value': "2025-01-01T00:00:00.500Z"}},
+               interval : _{'@type' : "DataValue",
+                            variable : "i"}
+             },
+    query_test_response_test_branch(Query, JSON),
+    [Binding] = JSON.bindings,
+    Binding.i = _{'@type': 'xdd:dateTimeInterval', '@value': "2025-01-01T00:00:00Z/2025-01-01T00:00:00.500Z"}.
+
+test(interval_start_duration_tenth_second, [
+    setup((setup_temp_store(State),
+           create_db_without_schema(admin,test))),
+    cleanup(teardown_temp_store(State))
+]) :-
+    Query = _{ '@type' : "IntervalStartDuration",
+               start : _{'@type' : "DataValue",
+                         'data' : _{'@type': 'xsd:dateTime', '@value': "2025-01-01T00:00:00Z"}},
+               duration : _{'@type' : "DataValue",
+                            'data' : _{'@type': 'xsd:duration', '@value': "PT0.1S"}},
+               interval : _{'@type' : "DataValue",
+                            variable : "i"}
+             },
+    query_test_response_test_branch(Query, JSON),
+    [Binding] = JSON.bindings,
+    Binding.i = _{'@type': 'xdd:dateTimeInterval', '@value': "2025-01-01T00:00:00Z/2025-01-01T00:00:00.100Z"}.
+
+test(interval_start_duration_two_tenths_second, [
+    setup((setup_temp_store(State),
+           create_db_without_schema(admin,test))),
+    cleanup(teardown_temp_store(State))
+]) :-
+    Query = _{ '@type' : "IntervalStartDuration",
+               start : _{'@type' : "DataValue",
+                         'data' : _{'@type': 'xsd:dateTime', '@value': "2025-01-01T00:00:00Z"}},
+               duration : _{'@type' : "DataValue",
+                            'data' : _{'@type': 'xsd:duration', '@value': "PT0.2S"}},
+               interval : _{'@type' : "DataValue",
+                            variable : "i"}
+             },
+    query_test_response_test_branch(Query, JSON),
+    [Binding] = JSON.bindings,
+    Binding.i = _{'@type': 'xdd:dateTimeInterval', '@value': "2025-01-01T00:00:00Z/2025-01-01T00:00:00.200Z"}.
+
+test(interval_start_duration_full_nanos, [
+    setup((setup_temp_store(State),
+           create_db_without_schema(admin,test))),
+    cleanup(teardown_temp_store(State))
+]) :-
+    Query = _{ '@type' : "IntervalStartDuration",
+               start : _{'@type' : "DataValue",
+                         'data' : _{'@type': 'xsd:dateTime', '@value': "2025-01-01T00:00:00Z"}},
+               duration : _{'@type' : "DataValue",
+                            'data' : _{'@type': 'xsd:duration', '@value': "PT0.123456789S"}},
+               interval : _{'@type' : "DataValue",
+                            variable : "i"}
+             },
+    query_test_response_test_branch(Query, JSON),
+    [Binding] = JSON.bindings,
+    Binding.i = _{'@type': 'xdd:dateTimeInterval', '@value': "2025-01-01T00:00:00Z/2025-01-01T00:00:00.123456789Z"}.
+
+test(interval_duration_end_tenth_second, [
+    setup((setup_temp_store(State),
+           create_db_without_schema(admin,test))),
+    cleanup(teardown_temp_store(State))
+]) :-
+    Query = _{ '@type' : "IntervalDurationEnd",
+               duration : _{'@type' : "DataValue",
+                            'data' : _{'@type': 'xsd:duration', '@value': "PT0.1S"}},
+               'end' : _{'@type' : "DataValue",
+                         'data' : _{'@type': 'xsd:dateTime', '@value': "2025-01-01T00:00:00.100Z"}},
+               interval : _{'@type' : "DataValue",
+                            variable : "i"}
+             },
+    query_test_response_test_branch(Query, JSON),
+    [Binding] = JSON.bindings,
+    Binding.i = _{'@type': 'xdd:dateTimeInterval', '@value': "2025-01-01T00:00:00Z/2025-01-01T00:00:00.100Z"}.
+
+test(interval_start_duration_explicit_nanos_roundtrip, [
+    setup((setup_temp_store(State),
+           create_db_without_schema(admin,test))),
+    cleanup(teardown_temp_store(State))
+]) :-
+    Query = _{ '@type' : "IntervalStartDuration",
+               start : _{'@type' : "DataValue",
+                         variable : "s"},
+               duration : _{'@type' : "DataValue",
+                            variable : "d"},
+               interval : _{'@type' : "DataValue",
+                            'data' : _{'@type': 'xdd:dateTimeInterval', '@value': "2025-01-01T00:00:00.000Z/2025-01-01T00:00:00.123456789Z"}}
+             },
+    query_test_response_test_branch(Query, JSON),
+    [Binding] = JSON.bindings,
+    Binding.s = _{'@type': 'xsd:dateTime', '@value': "2025-01-01T00:00:00Z"},
+    Binding.d = _{'@type': 'xsd:duration', '@value': "PT0.123456789S"}.
 
 test(day_after_mid_month, [
     setup((setup_temp_store(State),
@@ -9037,9 +9255,9 @@ test(interval_relation_typed_meets, [
                relation : _{'@type' : "DataValue",
                             'data' : _{'@type': 'xsd:string', '@value': "meets"}},
                x : _{'@type' : "DataValue",
-                     'data' : _{'@type': 'xdd:dateTimeInterval', '@value': "2024-01-01/2024-04-01"}},
+                     'data' : _{'@type': 'xdd:dateTimeInterval', '@value': "2024-01-01/2024-03-31"}},
                y : _{'@type' : "DataValue",
-                     'data' : _{'@type': 'xdd:dateTimeInterval', '@value': "2024-04-01/2024-07-01"}}
+                     'data' : _{'@type': 'xdd:dateTimeInterval', '@value': "2024-04-01/2024-06-30"}}
              },
     query_test_response_test_branch(Query, JSON),
     length(JSON.bindings, 1).
@@ -9053,7 +9271,7 @@ test(interval_relation_typed_meets_fails, [
                relation : _{'@type' : "DataValue",
                             'data' : _{'@type': 'xsd:string', '@value': "meets"}},
                x : _{'@type' : "DataValue",
-                     'data' : _{'@type': 'xdd:dateTimeInterval', '@value': "2024-01-01/2024-04-01"}},
+                     'data' : _{'@type': 'xdd:dateTimeInterval', '@value': "2024-01-01/2024-03-31"}},
                y : _{'@type' : "DataValue",
                      'data' : _{'@type': 'xdd:dateTimeInterval', '@value': "2024-05-01/2024-07-01"}}
              },
@@ -9101,9 +9319,9 @@ test(interval_relation_typed_classify, [
                relation : _{'@type' : "DataValue",
                             variable : "rel"},
                x : _{'@type' : "DataValue",
-                     'data' : _{'@type': 'xdd:dateTimeInterval', '@value': "2024-01-01/2024-04-01"}},
+                     'data' : _{'@type': 'xdd:dateTimeInterval', '@value': "2024-01-01/2024-03-31"}},
                y : _{'@type' : "DataValue",
-                     'data' : _{'@type': 'xdd:dateTimeInterval', '@value': "2024-04-01/2024-07-01"}}
+                     'data' : _{'@type': 'xdd:dateTimeInterval', '@value': "2024-04-01/2024-06-30"}}
              },
     query_test_response_test_branch(Query, JSON),
     [Binding] = JSON.bindings,

--- a/src/core/query/woql_compile.pl
+++ b/src/core/query/woql_compile.pl
@@ -8784,6 +8784,24 @@ test(interval_start_duration_explicit_nanos_roundtrip, [
     Binding.s = _{'@type': 'xsd:dateTime', '@value': "2025-01-01T00:00:00Z"},
     Binding.d = _{'@type': 'xsd:duration', '@value': "PT0.123456789S"}.
 
+test(interval_start_duration_timezone_nanos_roundtrip, [
+    setup((setup_temp_store(State),
+           create_db_without_schema(admin,test))),
+    cleanup(teardown_temp_store(State))
+]) :-
+    Query = _{ '@type' : "IntervalStartDuration",
+               start : _{'@type' : "DataValue",
+                         variable : "s"},
+               duration : _{'@type' : "DataValue",
+                            variable : "d"},
+               interval : _{'@type' : "DataValue",
+                            'data' : _{'@type': 'xdd:dateTimeInterval', '@value': "2025-01-01T09:00:00.000+02:00/2025-01-01T09:00:00.123456789+02:00"}}
+             },
+    query_test_response_test_branch(Query, JSON),
+    [Binding] = JSON.bindings,
+    Binding.s = _{'@type': 'xsd:dateTime', '@value': "2025-01-01T07:00:00Z"},
+    Binding.d = _{'@type': 'xsd:duration', '@value': "PT0.123456789S"}.
+
 test(day_after_mid_month, [
     setup((setup_temp_store(State),
            create_db_without_schema(admin,test))),

--- a/src/core/triple/casting.pl
+++ b/src/core/triple/casting.pl
@@ -328,18 +328,34 @@ typecast_switch('http://terminusdb.com/schema/xdd#dateTimeInterval', 'http://www
     ;   throw(error(casting_error(Val,'http://terminusdb.com/schema/xdd#dateTimeInterval'),_))
     ).
 
+/*
+ * bump_date_component(+Component, -BumpedComponent) is det.
+ *
+ * An unqualified (date-only) end component in a dateTimeInterval is interpreted
+ * as 00:00:00Z on the calendar day after the written date, following the half-open
+ * ISO 8601 / XBRL convention. Date-time components are returned unchanged.
+ */
+bump_date_component(date(Y,M,D,Offset), date(NY,NM,ND,Offset)) :-
+    !,
+    date_time_stamp(date(Y,M,D,0,0,0,0,-,-), Stamp),
+    NextStamp is Stamp + 86400,
+    stamp_date_time(NextStamp, date(NY,NM,ND,0,0,0.0,_,_,_), 0).
+bump_date_component(X, X).
+
 parse_date_time_interval(Val, Cast) :-
     atom_codes(Val, Codes),
     phrase(dateTimeInterval(X, Y, Z), Codes),
     !,
+    bump_date_component(Y, BY),
     normalise_interval_component(X, NX),
-    normalise_interval_component(Y, NY),
-    Cast = date_time_interval(NX, NY, Z, explicit).
+    normalise_interval_component(BY, NBY),
+    Cast = date_time_interval(NX, NBY, Z, explicit).
 parse_date_time_interval(Val, Cast) :-
     atom_codes(Val, Codes),
     phrase(dateTimeInterval(X, Y), Codes),
     !,
-    parse_two_component_interval(X, Y, Cast).
+    bump_date_component(Y, BY),
+    parse_two_component_interval(X, BY, Cast).
 
 parse_two_component_interval(X, Y, date_time_interval(NX, NY, X, duration_end)) :-
     is_duration(X),
@@ -391,19 +407,22 @@ normalise_interval_component(date_time(Y,Mo,D,H,M,S,NS,Offset), Norm) :- !,
 normalise_interval_component(duration(Sign,Y,Mo,D,H,M,S), duration(Sign,Y,Mo,D,H,M,S)) :- !.
 
 compute_duration_between(Start, End, duration(Sign, 0, 0, Days, Hours, Minutes, Seconds)) :-
-    component_to_timestamp(Start, T1),
-    component_to_timestamp(End, T2),
+    component_to_timestamp_ns(Start, T1),
+    component_to_timestamp_ns(End, T2),
     Diff is T2 - T1,
     (   Diff >= 0
     ->  Sign = 1, AbsDiff = Diff
     ;   Sign = -1, AbsDiff is abs(Diff)
     ),
-    Days is truncate(AbsDiff / 86400),
-    Rem1 is AbsDiff - Days * 86400,
-    Hours is truncate(Rem1 / 3600),
-    Rem2 is Rem1 - Hours * 3600,
-    Minutes is truncate(Rem2 / 60),
-    Seconds is Rem2 - Minutes * 60 * 1.0.
+    Days is AbsDiff // 86400000000000,
+    Rem1 is AbsDiff mod 86400000000000,
+    Hours is Rem1 // 3600000000000,
+    Rem2 is Rem1 mod 3600000000000,
+    Minutes is Rem2 // 60000000000,
+    Rem3 is Rem2 mod 60000000000,
+    (   Rem3 =:= 0
+    ->  Seconds = 0.0
+    ;   Seconds is Rem3 / 1000000000 * 1.0).
 
 component_to_timestamp(date(Y,M,D,_), T) :-
     !,
@@ -412,7 +431,15 @@ component_to_timestamp(date_time(Y,Mo,D,H,Mi,S,NS), T) :-
     Sec is S + NS / 1000000000,
     date_time_stamp(date(Y,Mo,D,H,Mi,Sec,0,-,-), T).
 
-interval_component_string(date(Y,M,D,Offset), S) :- !, date_string(date(Y,M,D,Offset), S).
+component_to_timestamp_ns(date(Y,M,D,_), T) :-
+    !,
+    date_time_stamp(date(Y,M,D,0,0,0,0,-,-), Stamp),
+    T is floor(Stamp * 1000000000).
+component_to_timestamp_ns(date_time(Y,Mo,D,H,Mi,S,NS), T) :-
+    date_time_stamp(date(Y,Mo,D,H,Mi,S,0,-,-), Stamp),
+    T is floor(Stamp * 1000000000) + NS.
+
+interval_component_string(date(Y,M,D,_Offset), S) :- !, date_time_string(date_time(Y,M,D,0,0,0,0), S).
 interval_component_string(duration(Sign,Y,Mo,D,H,M,SS), S) :- !, duration_string(duration(Sign,Y,Mo,D,H,M,SS), S).
 interval_component_string(DT, S) :- date_time_string(DT, S).
 %%% xsd:string => xdd:integerRange
@@ -1421,5 +1448,60 @@ test(anyuri_iri_chinese, []) :-
              'http://www.w3.org/2001/XMLSchema#anyURI',
              [],
              "http://例え.jp/文件"^^'http://www.w3.org/2001/XMLSchema#anyURI').
+
+test(dateTimeInterval_string_from_dates, []) :-
+    typecast(date_time_interval(date(2025,1,1,0), date(2025,4,1,0), duration(1,0,0,90,0,0,0.0), explicit)^^'http://terminusdb.com/schema/xdd#dateTimeInterval',
+             'http://www.w3.org/2001/XMLSchema#string', [],
+             "2025-01-01T00:00:00Z/2025-04-01T00:00:00Z"^^'http://www.w3.org/2001/XMLSchema#string').
+
+test(dateTimeInterval_string_from_datetimes, []) :-
+    typecast(date_time_interval(date_time(2025,1,1,10,30,0,0), date_time(2025,4,1,15,45,0,0), duration(1,0,0,90,5,15,0.0), explicit)^^'http://terminusdb.com/schema/xdd#dateTimeInterval',
+             'http://www.w3.org/2001/XMLSchema#string', [],
+             "2025-01-01T10:30:00Z/2025-04-01T15:45:00Z"^^'http://www.w3.org/2001/XMLSchema#string').
+
+test(dateTimeInterval_string_mixed_date_datetime, []) :-
+    typecast(date_time_interval(date(2025,1,1,0), date_time(2025,4,1,12,0,0,0), duration(1,0,0,90,12,0,0.0), explicit)^^'http://terminusdb.com/schema/xdd#dateTimeInterval',
+             'http://www.w3.org/2001/XMLSchema#string', [],
+             "2025-01-01T00:00:00Z/2025-04-01T12:00:00Z"^^'http://www.w3.org/2001/XMLSchema#string').
+
+test(dateTimeInterval_string_from_dates_roundtrip, []) :-
+    typecast("2025-01-01/2025-04-01"^^'http://www.w3.org/2001/XMLSchema#string',
+             'http://terminusdb.com/schema/xdd#dateTimeInterval', [],
+             IV^^'http://terminusdb.com/schema/xdd#dateTimeInterval'),
+    typecast(IV^^'http://terminusdb.com/schema/xdd#dateTimeInterval',
+             'http://www.w3.org/2001/XMLSchema#string', [],
+             "2025-01-01T00:00:00Z/2025-04-02T00:00:00Z"^^'http://www.w3.org/2001/XMLSchema#string').
+
+test(dateTimeInterval_unqualified_end_bumps_to_next_year, []) :-
+    typecast("2019-01-01/2019-12-31"^^'http://www.w3.org/2001/XMLSchema#string',
+             'http://terminusdb.com/schema/xdd#dateTimeInterval', [],
+             IV^^'http://terminusdb.com/schema/xdd#dateTimeInterval'),
+    typecast(IV^^'http://terminusdb.com/schema/xdd#dateTimeInterval',
+             'http://www.w3.org/2001/XMLSchema#string', [],
+             "2019-01-01T00:00:00Z/2020-01-01T00:00:00Z"^^'http://www.w3.org/2001/XMLSchema#string').
+
+test(dateTimeInterval_unqualified_end_bumps_over_leap_day, []) :-
+    typecast("2020-02-01/2020-02-29"^^'http://www.w3.org/2001/XMLSchema#string',
+             'http://terminusdb.com/schema/xdd#dateTimeInterval', [],
+             IV^^'http://terminusdb.com/schema/xdd#dateTimeInterval'),
+    typecast(IV^^'http://terminusdb.com/schema/xdd#dateTimeInterval',
+             'http://www.w3.org/2001/XMLSchema#string', [],
+             "2020-02-01T00:00:00Z/2020-03-01T00:00:00Z"^^'http://www.w3.org/2001/XMLSchema#string').
+
+test(dateTimeInterval_unqualified_end_bumps_to_leap_day, []) :-
+    typecast("2020-02-27/2020-02-28"^^'http://www.w3.org/2001/XMLSchema#string',
+             'http://terminusdb.com/schema/xdd#dateTimeInterval', [],
+             IV^^'http://terminusdb.com/schema/xdd#dateTimeInterval'),
+    typecast(IV^^'http://terminusdb.com/schema/xdd#dateTimeInterval',
+             'http://www.w3.org/2001/XMLSchema#string', [],
+             "2020-02-27T00:00:00Z/2020-02-29T00:00:00Z"^^'http://www.w3.org/2001/XMLSchema#string').
+
+test(dateTimeInterval_datetime_end_is_not_bumped, []) :-
+    typecast("2019-01-01T00:00:00/2020-01-01T00:00:00"^^'http://www.w3.org/2001/XMLSchema#string',
+             'http://terminusdb.com/schema/xdd#dateTimeInterval', [],
+             IV^^'http://terminusdb.com/schema/xdd#dateTimeInterval'),
+    typecast(IV^^'http://terminusdb.com/schema/xdd#dateTimeInterval',
+             'http://www.w3.org/2001/XMLSchema#string', [],
+             "2019-01-01T00:00:00Z/2020-01-01T00:00:00Z"^^'http://www.w3.org/2001/XMLSchema#string').
 
 :- end_tests(typecast).

--- a/src/core/triple/literals.pl
+++ b/src/core/triple/literals.pl
@@ -214,7 +214,7 @@ date_time_stamp_string(Date_Time,String) :-
     !,
     atom_codes(String,Codes),
     phrase(dateTimeStamp(Y,M,D,HH,MM,SS,NS,Offset),Codes),
-    remove_date_time_offset(Y,M,D,HH,MM,SS,Offset,NS,Date_Time).
+    remove_date_time_offset(Y,M,D,HH,MM,SS,NS,Offset,Date_Time).
 
 remove_date_time_offset(Y,M,D,HH,MM,SS,NS,Offset,date_time(Y1,M1,D1,HH1,MM1,SS_Floor,NS)) :-
     date_time_stamp(date(Y, M, D, HH, MM, SS, Offset, -, -), TS),

--- a/src/core/triple/literals.pl
+++ b/src/core/triple/literals.pl
@@ -233,28 +233,32 @@ add_duration_to_component(date(Y,M,D,O), duration(Sign,DY,DMo,DD,DH,DMi,DS), End
     M1 is M + Sign * DMo,
     duration_normalize_year_month(Y1, M1, Y2, M2),
     duration_clamp_day(Y2, M2, D, D2),
-    DaySecs is Sign * (DD * 86400 + DH * 3600 + DMi * 60 + DS),
+    DayNanos is Sign * (DD * 86400 * 1000000000 + DH * 3600 * 1000000000 + DMi * 60 * 1000000000 + round(DS * 1000000000)),
     date_time_stamp(date(Y2,M2,D2,0,0,0,0,-,-), BaseStamp),
-    EndStamp is BaseStamp + DaySecs,
-    stamp_date_time(EndStamp, date(EY,EM,ED,EHH,EMM,ESS,0,'UTC',-), 'UTC'),
-    ESSF is floor(ESS),
+    BaseNanos is floor(BaseStamp * 1000000000),
+    EndNanos is BaseNanos + DayNanos,
+    EndSeconds is EndNanos // 1000000000,
+    EndNanosRem is EndNanos mod 1000000000,
+    stamp_date_time(EndSeconds, date(EY,EM,ED,EHH,EMM,ESS1,0,'UTC',-), 'UTC'),
+    ESSF is floor(ESS1),
     (   DH =:= 0, DMi =:= 0, DS =:= 0
     ->  End = date(EY,EM,ED,O)
-    ;   End = date_time(EY,EM,ED,EHH,EMM,ESSF,0)
+    ;   End = date_time(EY,EM,ED,EHH,EMM,ESSF,EndNanosRem)
     ).
 add_duration_to_component(date_time(Y,M,D,HH,MM,SS,NS), duration(Sign,DY,DMo,DD,DH,DMi,DS), End) :-
     Y1 is Y + Sign * DY,
     M1 is M + Sign * DMo,
     duration_normalize_year_month(Y1, M1, Y2, M2),
     duration_clamp_day(Y2, M2, D, D2),
-    DaySecs is Sign * (DD * 86400 + DH * 3600 + DMi * 60 + DS),
-    S is SS + NS / 1000000000,
-    date_time_stamp(date(Y2,M2,D2,HH,MM,S,0,-,-), BaseStamp),
-    EndStamp is BaseStamp + DaySecs,
-    stamp_date_time(EndStamp, date(EY,EM,ED,EHH,EMM,ESS1,0,'UTC',-), 'UTC'),
+    DayNanos is Sign * (DD * 86400 * 1000000000 + DH * 3600 * 1000000000 + DMi * 60 * 1000000000 + round(DS * 1000000000)),
+    date_time_stamp(date(Y2,M2,D2,HH,MM,SS,0,-,-), BaseStamp),
+    BaseNanos is floor(BaseStamp * 1000000000) + NS,
+    EndNanos is BaseNanos + DayNanos,
+    EndSeconds is EndNanos // 1000000000,
+    EndNanosRem is EndNanos mod 1000000000,
+    stamp_date_time(EndSeconds, date(EY,EM,ED,EHH,EMM,ESS1,0,'UTC',-), 'UTC'),
     ESSF is floor(ESS1),
-    ENS is floor((ESS1 - ESSF) * 1000000000),
-    End = date_time(EY,EM,ED,EHH,EMM,ESSF,ENS).
+    End = date_time(EY,EM,ED,EHH,EMM,ESSF,EndNanosRem).
 
 /*
  * subtract_duration_from_component(+Component, +Duration, -Result) is det.

--- a/src/core/util/xsd_parser.pl
+++ b/src/core/util/xsd_parser.pl
@@ -197,16 +197,16 @@ time_offset(0) -->
 time_offset(S) -->
     "+",
     twoDigitNatural(ZH), ":", twoDigitNatural(ZM), ":", twoDigitNatural(ZS),
-    { S is (ZH * 3600) + (ZM * 60) + ZS }.
+    { S is -((ZH * 3600) + (ZM * 60) + ZS) }.
 time_offset(S) -->
     "+", twoDigitNatural(ZH), ":", twoDigitNatural(ZM),
-    { S is (ZH * 3600) + (ZM * 60) }.
+    { S is -((ZH * 3600) + (ZM * 60)) }.
 time_offset(S) -->
     "-", twoDigitNatural(ZH), ":", twoDigitNatural(ZM), ":", twoDigitNatural(ZS),
-    { S is (-1 * ((ZH * 3600) + (ZM * 60) + ZS)) }.
+    { S is (ZH * 3600) + (ZM * 60) + ZS }.
 time_offset(S) -->
     "-", twoDigitNatural(ZH), ":", twoDigitNatural(ZM),
-    { S is (-1 * ((ZH * 3600) + (ZM * 60))) }.
+    { S is (ZH * 3600) + (ZM * 60) }.
 
 optional_time_offset(Offset) -->
     time_offset(Offset).

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -484,7 +484,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1840,7 +1840,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2107,8 +2107,8 @@ dependencies = [
 
 [[package]]
 name = "tdb-succinct"
-version = "0.1.2"
-source = "git+https://github.com/terminusdb-org/tdb-succinct#91a6096725c7e7031ed1724ea4939041cebe5456"
+version = "0.1.4"
+source = "git+https://github.com/terminusdb-org/tdb-succinct?branch=xbrl-json-iso-intervals#ec1519923e44e73cad17264f21534065855be6e0"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -2139,7 +2139,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -7,7 +7,7 @@ debug = true
 
 [patch.crates-io]
 #tdb-succinct = {path="../../../tdb-succinct"}
-tdb-succinct = {git="https://github.com/terminusdb-org/tdb-succinct"}
+tdb-succinct = {git="https://github.com/terminusdb-org/tdb-succinct", branch="xbrl-json-iso-intervals"}
 #terminus-store = {path="../../../terminusdb-store"}
 terminus-store = {git="https://github.com/terminusdb-org/terminusdb-store"}
 swipl = {git="https://github.com/terminusdb-org/swipl-rs"}

--- a/tests/test/document-interval.js
+++ b/tests/test/document-interval.js
@@ -50,7 +50,7 @@ describe('document-interval', function () {
 
       const r = await document.get(agent, { query: { id: 'Event/Q1-2025', as_list: true } })
       expect(r.body).to.have.lengthOf(1)
-      expect(r.body[0].interval).to.equal('2025-01-01/2025-04-01')
+      expect(r.body[0].interval).to.equal('2025-01-01T00:00:00Z/2025-04-02T00:00:00Z')
     })
   })
 
@@ -65,7 +65,7 @@ describe('document-interval', function () {
 
       const r = await document.get(agent, { query: { id: 'Event/Q1-duration', as_list: true } })
       expect(r.body).to.have.lengthOf(1)
-      expect(r.body[0].interval).to.equal('2025-01-01/P3M')
+      expect(r.body[0].interval).to.equal('2025-01-01T00:00:00Z/P3M')
     })
   })
 
@@ -80,7 +80,7 @@ describe('document-interval', function () {
 
       const r = await document.get(agent, { query: { id: 'Event/Q1-durend', as_list: true } })
       expect(r.body).to.have.lengthOf(1)
-      expect(r.body[0].interval).to.equal('P3M/2025-04-01')
+      expect(r.body[0].interval).to.equal('P3M/2025-04-02T00:00:00Z')
     })
   })
 
@@ -102,7 +102,7 @@ describe('document-interval', function () {
 
       const r = await document.get(agent, { query: { id: 'Event/updatable', as_list: true } })
       expect(r.body).to.have.lengthOf(1)
-      expect(r.body[0].interval).to.equal('2025-06-01/2025-09-01')
+      expect(r.body[0].interval).to.equal('2025-06-01T00:00:00Z/2025-09-02T00:00:00Z')
     })
   })
 
@@ -129,7 +129,7 @@ describe('document-interval', function () {
 
       const r = await document.get(agent, { query: { id: 'MaybeEvent/has-interval', as_list: true } })
       expect(r.body).to.have.lengthOf(1)
-      expect(r.body[0].interval).to.equal('2025-01-01/P1Y')
+      expect(r.body[0].interval).to.equal('2025-01-01T00:00:00Z/P1Y')
     })
   })
 
@@ -159,7 +159,7 @@ describe('document-interval', function () {
 
       const r = await document.get(agent, { query: { id: 'Event/hour-dur', as_list: true } })
       expect(r.body).to.have.lengthOf(1)
-      expect(r.body[0].interval).to.equal('2025-01-01/PT1H')
+      expect(r.body[0].interval).to.equal('2025-01-01T00:00:00Z/PT1H')
     })
   })
 })

--- a/tests/test/memory-mode.js
+++ b/tests/test/memory-mode.js
@@ -40,6 +40,25 @@ describe('In-Memory Mode', function () {
     throw new Error('Server did not start in time')
   }
 
+  async function waitForApi (auth, maxRetries = 20) {
+    for (let i = 0; i < maxRetries; i++) {
+      try {
+        const res = await httpRequest({
+          hostname: '127.0.0.1',
+          port: PORT,
+          path: '/api/',
+          method: 'GET',
+          headers: { Authorization: `Basic ${auth}` },
+        })
+        if (res.status === 200) return res
+      } catch (e) {
+        // Endpoint not ready yet
+      }
+      await new Promise(resolve => setTimeout(resolve, 500))
+    }
+    throw new Error('/api/ did not return 200 in time')
+  }
+
   async function waitForJsonEndpoint (path, auth, maxRetries = 10) {
     for (let i = 0; i < maxRetries; i++) {
       try {
@@ -113,13 +132,7 @@ describe('In-Memory Mode', function () {
 
       // Verify we can authenticate with the custom password
       const auth = Buffer.from(`admin:${PASSWORD}`).toString('base64')
-      const response = await httpRequest({
-        hostname: '127.0.0.1',
-        port: PORT,
-        path: '/api/',
-        method: 'GET',
-        headers: { Authorization: `Basic ${auth}` },
-      })
+      const response = await waitForApi(auth)
 
       expect(response.status).to.equal(200)
     })
@@ -134,13 +147,7 @@ describe('In-Memory Mode', function () {
 
       // Verify we can authenticate with the default password 'root'
       const auth = Buffer.from('admin:root').toString('base64')
-      const response = await httpRequest({
-        hostname: '127.0.0.1',
-        port: PORT,
-        path: '/api/',
-        method: 'GET',
-        headers: { Authorization: `Basic ${auth}` },
-      })
+      const response = await waitForApi(auth)
 
       expect(response.status).to.equal(200)
     })

--- a/tests/test/woql-comparison.js
+++ b/tests/test/woql-comparison.js
@@ -1194,7 +1194,7 @@ describe('woql-comparison', function () {
     }
 
     it('validates meets: Q1 meets Q2', async function () {
-      const r = await woql.post(agent, irtQuery('meets', iv('2024-01-01/2024-04-01'), iv('2024-04-01/2024-07-01')))
+      const r = await woql.post(agent, irtQuery('meets', iv('2024-01-01/2024-03-31'), iv('2024-04-01/2024-06-30')))
       expect(r.body.bindings).to.have.lengthOf(1)
     })
     it('rejects meets when gap exists', async function () {
@@ -1216,7 +1216,7 @@ describe('woql-comparison', function () {
     it('classifies relation as meets', async function () {
       const r = await woql.post(agent, irtQuery(
         { '@type': 'DataValue', variable: 'v:rel' },
-        iv('2024-01-01/2024-04-01'), iv('2024-04-01/2024-07-01')))
+        iv('2024-01-01/2024-03-31'), iv('2024-04-01/2024-06-30')))
       expect(r.body.bindings).to.have.lengthOf(1)
       expect(r.body.bindings[0]['v:rel']['@value']).to.equal('meets')
     })
@@ -1239,6 +1239,7 @@ describe('woql-comparison', function () {
 
   describe('Interval (xdd:dateTimeInterval)', function () {
     function datVal (v) { return { '@type': 'xsd:date', '@value': v } }
+    function dtVal (v) { return { '@type': 'xsd:dateTime', '@value': v } }
     function intervalVal (v) { return { '@type': 'xdd:dateTimeInterval', '@value': v } }
 
     it('constructs interval from start+end dates', async function () {
@@ -1251,7 +1252,7 @@ describe('woql-comparison', function () {
       const r = await woql.post(agent, q)
       expect(r.body.bindings).to.have.lengthOf(1)
       expect(r.body.bindings[0]['v:i']['@type']).to.equal('xdd:dateTimeInterval')
-      expect(r.body.bindings[0]['v:i']['@value']).to.equal('2025-01-01/2025-04-01')
+      expect(r.body.bindings[0]['v:i']['@value']).to.equal('2025-01-01T00:00:00Z/2025-04-02T00:00:00Z')
     })
     it('deconstructs interval into start+end dates', async function () {
       const q = {
@@ -1262,14 +1263,16 @@ describe('woql-comparison', function () {
       }
       const r = await woql.post(agent, q)
       expect(r.body.bindings).to.have.lengthOf(1)
-      expect(r.body.bindings[0]['v:s']['@value']).to.equal('2025-01-01')
-      expect(r.body.bindings[0]['v:e']['@value']).to.equal('2025-04-01')
+      expect(r.body.bindings[0]['v:s']['@type']).to.equal('xsd:dateTime')
+      expect(r.body.bindings[0]['v:s']['@value']).to.equal('2025-01-01T00:00:00Z')
+      expect(r.body.bindings[0]['v:e']['@type']).to.equal('xsd:dateTime')
+      expect(r.body.bindings[0]['v:e']['@value']).to.equal('2025-04-02T00:00:00Z')
     })
     it('validates matching start+end+interval', async function () {
       const q = {
         '@type': 'Interval',
-        start: { '@type': 'DataValue', data: datVal('2025-01-01') },
-        end: { '@type': 'DataValue', data: datVal('2025-04-01') },
+        start: { '@type': 'DataValue', data: dtVal('2025-01-01T00:00:00Z') },
+        end: { '@type': 'DataValue', data: dtVal('2025-04-02T00:00:00Z') },
         interval: { '@type': 'DataValue', data: intervalVal('2025-01-01/2025-04-01') },
       }
       const r = await woql.post(agent, q)
@@ -1278,8 +1281,8 @@ describe('woql-comparison', function () {
     it('rejects mismatched start+end+interval', async function () {
       const q = {
         '@type': 'Interval',
-        start: { '@type': 'DataValue', data: datVal('2025-01-01') },
-        end: { '@type': 'DataValue', data: datVal('2025-06-01') },
+        start: { '@type': 'DataValue', data: dtVal('2025-01-01T00:00:00Z') },
+        end: { '@type': 'DataValue', data: dtVal('2025-06-01T00:00:00Z') },
         interval: { '@type': 'DataValue', data: intervalVal('2025-01-01/2025-04-01') },
       }
       const r = await woql.post(agent, q)
@@ -1307,7 +1310,7 @@ describe('woql-comparison', function () {
       }
       const r = await woql.post(agent, q)
       expect(r.body.bindings).to.have.lengthOf(1)
-      expect(r.body.bindings[0]['v:i']['@value']).to.equal('2025-01-01/2025-04-01T12:00:00Z')
+      expect(r.body.bindings[0]['v:i']['@value']).to.equal('2025-01-01T00:00:00Z/2025-04-01T12:00:00Z')
     })
   })
 
@@ -1321,11 +1324,12 @@ describe('woql-comparison', function () {
         '@type': 'IntervalStartDuration',
         start: { '@type': 'DataValue', variable: 'v:s' },
         duration: { '@type': 'DataValue', variable: 'v:d' },
-        interval: { '@type': 'DataValue', data: intervalVal('2025-01-01/2025-04-01') },
+        interval: { '@type': 'DataValue', data: intervalVal('2025-01-01/2025-03-31') },
       }
       const r = await woql.post(agent, q)
       expect(r.body.bindings).to.have.lengthOf(1)
-      expect(r.body.bindings[0]['v:s']['@value']).to.equal('2025-01-01')
+      expect(r.body.bindings[0]['v:s']['@type']).to.equal('xsd:dateTime')
+      expect(r.body.bindings[0]['v:s']['@value']).to.equal('2025-01-01T00:00:00Z')
       expect(r.body.bindings[0]['v:d']['@value']).to.equal('P90D')
     })
     it('constructs interval from start + P90D duration', async function () {
@@ -1337,7 +1341,7 @@ describe('woql-comparison', function () {
       }
       const r = await woql.post(agent, q)
       expect(r.body.bindings).to.have.lengthOf(1)
-      expect(r.body.bindings[0]['v:i']['@value']).to.equal('2025-01-01/2025-04-01')
+      expect(r.body.bindings[0]['v:i']['@value']).to.equal('2025-01-01T00:00:00Z/2025-04-01T00:00:00Z')
     })
     it('extracts sub-day duration from dateTime interval', async function () {
       const q = {
@@ -1363,23 +1367,24 @@ describe('woql-comparison', function () {
         '@type': 'IntervalDurationEnd',
         duration: { '@type': 'DataValue', variable: 'v:d' },
         end: { '@type': 'DataValue', variable: 'v:e' },
-        interval: { '@type': 'DataValue', data: intervalVal('2025-01-01/2025-04-01') },
+        interval: { '@type': 'DataValue', data: intervalVal('2025-01-01/2025-03-31') },
       }
       const r = await woql.post(agent, q)
       expect(r.body.bindings).to.have.lengthOf(1)
-      expect(r.body.bindings[0]['v:e']['@value']).to.equal('2025-04-01')
+      expect(r.body.bindings[0]['v:e']['@type']).to.equal('xsd:dateTime')
+      expect(r.body.bindings[0]['v:e']['@value']).to.equal('2025-04-01T00:00:00Z')
       expect(r.body.bindings[0]['v:d']['@value']).to.equal('P90D')
     })
     it('constructs interval from P90D duration + end date', async function () {
       const q = {
         '@type': 'IntervalDurationEnd',
         duration: { '@type': 'DataValue', data: durVal('P90D') },
-        end: { '@type': 'DataValue', data: datVal('2025-04-01') },
+        end: { '@type': 'DataValue', data: datVal('2025-03-31') },
         interval: { '@type': 'DataValue', variable: 'v:i' },
       }
       const r = await woql.post(agent, q)
       expect(r.body.bindings).to.have.lengthOf(1)
-      expect(r.body.bindings[0]['v:i']['@value']).to.equal('2025-01-01/2025-04-01')
+      expect(r.body.bindings[0]['v:i']['@value']).to.equal('2025-01-01T00:00:00Z/2025-04-01T00:00:00Z')
     })
   })
 

--- a/tests/test/woql-comparison.js
+++ b/tests/test/woql-comparison.js
@@ -1355,6 +1355,19 @@ describe('woql-comparison', function () {
       expect(r.body.bindings[0]['v:s']['@type']).to.equal('xsd:dateTime')
       expect(r.body.bindings[0]['v:d']['@value']).to.equal('PT8H30M')
     })
+    it('extracts nanosecond duration from timezone-offset interval', async function () {
+      const q = {
+        '@type': 'IntervalStartDuration',
+        start: { '@type': 'DataValue', variable: 'v:s' },
+        duration: { '@type': 'DataValue', variable: 'v:d' },
+        interval: { '@type': 'DataValue', data: intervalVal('2025-01-01T09:00:00.000+02:00/2025-01-01T09:00:00.123456789+02:00') },
+      }
+      const r = await woql.post(agent, q)
+      expect(r.body.bindings).to.have.lengthOf(1)
+      expect(r.body.bindings[0]['v:s']['@type']).to.equal('xsd:dateTime')
+      expect(r.body.bindings[0]['v:s']['@value']).to.equal('2025-01-01T07:00:00Z')
+      expect(r.body.bindings[0]['v:d']['@value']).to.equal('PT0.123456789S')
+    })
   })
 
   describe('IntervalDurationEnd', function () {


### PR DESCRIPTION
This change ensures that `xdd:dateTimeInterval` durations and endpoints can be represented correctly, including with full nanosecond precision without floating-point drift. The work spans both the Rust `tdb-succinct` serialization layer and the Prolog WOQL/casting layer.

## What changed

### tdb-succinct

- `src/tfc/interval.rs` — `compute_duration_from_endpoints` now computes the elapsed interval in nanoseconds on a 128-bit integer before converting to the `Duration` struct. Sub-second explicit intervals now produce exact durations over the nanosecond decimal space, instead of losing their fractional part.
- `src/tfc/datatypes.rs` — `interval_component_to_iso` always renders datetime components as full `YYYY-MM-DDTHH:MM:SSZ` strings (or including `...S.fZ` for fractional seconds where they are present), and midnight endpoints no longer round-trip as plain (and unspecific) dates (cast to xdd:dateRange for inclusive dates)
- `src/tfc/datatypes.rs` — added Rust-level tests for a `PT0.1S` duration, a `0.1s` explicit interval, and a start/duration interval with a `0.1s` duration.
- `terminusdb/src/core/query/woql_compile.pl` — added WOQL-level tests for nanosecond durations covering `PT0.1S`, `PT0.2S`, `PT0.123456789S`, and explicit interval round-trips.
- `src/tfc/interval.rs` — `parse_date_or_datetime` now parses RFC 3339 datetimes (including `Z` and numeric offsets such as `+02:00` / `-05:00`) and converts them to UTC before storing. Naive datetimes without a timezone are interpreted as UTC.
- 
### TerminusDB Prolog layer

- `src/core/triple/casting.pl` — `compute_duration_between` now uses integer nanosecond timestamps. Explicit intervals with fractional seconds, such as `2025-01-01T00:00:00.000Z/2025-01-01T00:00:00.123456789Z`, now produce exactly `PT0.123456789S`.
- `src/core/triple/literals.pl` — `add_duration_to_component` adds durations in integer nanoseconds and rounds the resulting seconds field to the nearest nanosecond. Durations like `PT0.1S` no longer drift to `0.099999904` seconds during addition.
- `src/core/query/woql_compile.pl` — added nanosecond-aware helpers `interval_component_stamp_ns`, `nanoseconds_to_duration`, and `nanoseconds_to_duration_significant`, and wired them into `woql_interval` and `woql_date_duration`.
- `src/core/query/woql_compile.pl` — added nine WOQL-level PLUnit tests covering `PT0.1S`, `PT0.2S`, `PT0.123456789S`, and explicit interval nanosecond round-trips.
- `docs/DATETIME_INTERVAL_SEMANTICS.md` — added an ADR describing the half-open interval semantics and the unqualified date end rule.

### Documentation site

- `terminusdb-docs-static/src/app/docs/datetime-interval-semantics/page.md` — added a public documentation page explaining interval semantics, and included a `xdd:dateTimeInterval` → `xdd:dateRange` example after the string-to-interval example.

## Note on dependency wiring

`terminusdb/src/rust/Cargo.toml` is currently patched to use the `xbrl-json-iso-intervals` git branch of `tdb-succinct`. The tdb-succinct half of this PR must be merged to that branch before the TerminusDB build picks up the Rust serialization fixes. This is a preparation to use tag="" in the future for tdb-succinct for deterministic builds that were not in place before.
