### PR TITLE
Extend commit queue concept and fix race between rebase and auto-optimizer on _meta graph

### DIFF
--- a/docker/plugins/auto-optimize.pl
+++ b/docker/plugins/auto-optimize.pl
@@ -2,15 +2,15 @@
 :- use_module(core(api)).
 :- use_module(core(util)).
 :- use_module(core(query)).
+:- use_module(core(document/commit_queue)).
 :- use_module(config(terminus_config), [log_level/1]).
 :- use_module(library(http/http_server)).
 :- use_module(library(random)).
 :- use_module(library(lists)).
 :- use_module(library(pairs)).
 
-% Flags to track if GC/optimization is currently running (prevents piling up requests)
+% Flag to track if GC is currently running (prevents piling up requests)
 :- dynamic gc_running/0.
-:- dynamic optimization_running/0.
 
 % Requirement to add to plugins since TerminusDB 11.2.0
 :- multifile plugins:post_commit_hook/2.
@@ -180,6 +180,7 @@ schedule_gc :-
     thread_create(gc_thread_wrapper, _, [detached(true)]).
 
 % Actual optimization work - optimizes all descriptors (parent-first order)
+% This is used only as a synchronous fallback in non-server contexts.
 do_optimize_descriptors(Validation_Objects) :-
     findall(Descriptor,
             (member(V, Validation_Objects),
@@ -201,22 +202,27 @@ sort_descriptors(Descriptors, Sorted) :-
     keysort(Pairs, SortedPairs),
     pairs_values(SortedPairs, Sorted).
 
-% Optimization thread wrapper - clears flag when done
-optimization_thread_wrapper(Validation_Objects) :-
-    % Reset streams to avoid inheriting closed HTTP streams
-    set_prolog_IO(user_input, user_output, user_error),
-    json_log_debug("Optimization thread started"),
-    catch(
-        do_optimize_descriptors(Validation_Objects),
-        Error,
-        handle_optimization_error(Error)
-    ),
-    with_mutex(auto_optimize_opt, retractall(optimization_running)).
+% Schedule a descriptor optimization through the commit queue so it runs when
+% the relevant queue drains, rather than spawning a dedicated thread here.
+schedule_optimizations(Validation_Objects) :-
+    findall(Descriptor,
+            (member(V, Validation_Objects),
+             all_descriptor(V.descriptor, Descriptor)),
+            Descriptors),
+    sort_descriptors(Descriptors, Sorted),
+    forall(member(D, Sorted), schedule_descriptor_optimization(D)).
 
-handle_optimization_error(error(label_version_changed(_, _), _)) :-
-    !.  % Silently skip when there is a concurrent optimization
-handle_optimization_error(Error) :-
-    json_log_error_formatted("Optimization error: ~w", [Error]).
+schedule_descriptor_optimization(Descriptor) :-
+    (   system_descriptor{} :< Descriptor
+    ->  true
+    ;   branch_descriptor{} :< Descriptor
+    ->  commit_queue:schedule_branch_optimization(Descriptor)
+    ;   (   database_descriptor{} :< Descriptor
+        ;   repository_descriptor{} :< Descriptor
+        )
+    ->  commit_queue:schedule_database_optimization(Descriptor)
+    ;   true
+    ).
 
 % Schedule async optimization if not already running (random check at commit level like GC)
 maybe_optimize(Validation_Objects) :-
@@ -225,17 +231,10 @@ maybe_optimize(Validation_Objects) :-
     X < Chance,
     !,
     (   http_server_property(_, _)
-    ->  with_mutex(auto_optimize_opt, schedule_optimization(Validation_Objects))
+    ->  schedule_optimizations(Validation_Objects)
     ;   do_optimize_descriptors(Validation_Objects)
     ).
 maybe_optimize(_).
-
-schedule_optimization(_) :-
-    optimization_running,
-    !.  % Already running, skip silently
-schedule_optimization(Validation_Objects) :-
-    assertz(optimization_running),
-    thread_create(optimization_thread_wrapper(Validation_Objects), _, [detached(true)]).
 
 commit_has_changes(Meta_Data) :-
     get_dict(inserts, Meta_Data, Inserts),

--- a/src/core/api.pl
+++ b/src/core/api.pl
@@ -80,6 +80,7 @@
 
               % api_optimize.pl
               api_optimize/3,
+              api_optimize_queued/3,
 
               % api_prefixes
               get_prefixes/4,

--- a/src/core/api/api_document.pl
+++ b/src/core/api/api_document.pl
@@ -36,6 +36,10 @@
               execute_commit_package/2,
               commit_package_test_handler/1,
 
+              producer_timeout/1,
+              get_commit_result/4,
+              deliver_commit_result/2,
+
               verify_contracts_transaction_info/4
           ]).
 
@@ -45,10 +49,12 @@
 :- use_module(core(transaction)).
 :- use_module(core(transaction/database), [
                   reset_transaction_objects_graph_descriptors/1,
-                  query_context_transaction_objects/2
+                  query_context_transaction_objects/2,
+                  transaction_object_database_key/2
               ]).
 :- use_module(core(document)).
 :- use_module(core(document/commit_queue)).
+:- use_module(core(document/meta_commit_queue)).
 :- use_module(core(document/json), [
                   insert_document_expanded/4,
                   insert_document_expanded/5,
@@ -1182,11 +1188,7 @@ api_insert_documents_queued(SystemDB, Auth, Path, Stream, Requested_Data_Version
                     request_id: RequestId
                 },
                 commit_queue:enqueue_commit(BranchKey, Package),
-                (   catch(thread_get_message(ReplyQueue,
-                                            commit_result(Result, RequestId),
-                                            [timeout(ProducerTimeout)]),
-                          error(existence_error(message_queue, _), _),
-                          (Result = timeout))
+                (   get_commit_result(ReplyQueue, RequestId, ProducerTimeout, Result)
                 ->  true
                 ;   Result = timeout
                 )
@@ -1263,11 +1265,7 @@ api_replace_documents_queued(SystemDB, Auth, Path, Stream, Requested_Data_Versio
                     request_id: RequestId
                 },
                 commit_queue:enqueue_commit(BranchKey, Package),
-                (   catch(thread_get_message(ReplyQueue,
-                                            commit_result(Result, RequestId),
-                                            [timeout(ProducerTimeout)]),
-                          error(existence_error(message_queue, _), _),
-                          (Result = timeout))
+                (   get_commit_result(ReplyQueue, RequestId, ProducerTimeout, Result)
                 ->  true
                 ;   Result = timeout
                 )
@@ -1299,19 +1297,38 @@ api_replace_documents_queued(SystemDB, Auth, Path, Stream, Requested_Data_Versio
 
 producer_timeout(Timeout) :-
     (   getenv('TERMINUSDB_COMMIT_QUEUE_TIMEOUT', Value),
-        catch(number_string(Timeout, Value), _, fail)
-    ->  (   Timeout > 0
-        ->  true
-        ;   Timeout = 30
+        catch(atom_number(Value, Parsed), _, fail)
+    ->  (   Parsed > 0
+        ->  Timeout = Parsed
+        ;   Timeout = infinite
         )
-    ;   Timeout = 30
+    ;   Timeout = infinite
     ).
+
+% Wait for the commit worker to reply on ReplyQueue. If Timeout is infinite,
+% block forever; otherwise use the supplied timeout. If the reply queue is
+% destroyed before a reply arrives (e.g. worker crash), treat it as a timeout.
+get_commit_result(ReplyQueue, RequestId, infinite, Result) :-
+    !,
+    catch(thread_get_message(ReplyQueue,
+                            commit_result(Result, RequestId)),
+          error(existence_error(message_queue, _), _),
+          (Result = timeout)).
+get_commit_result(ReplyQueue, RequestId, Timeout, Result) :-
+    catch(thread_get_message(ReplyQueue,
+                            commit_result(Result, RequestId),
+                            [timeout(Timeout)]),
+          error(existence_error(message_queue, _), _),
+          (Result = timeout)).
 
 handle_commit_result(success(Meta_Data, Ids), Meta_Data, Ids).
 handle_commit_result(reject(Reason), _Meta_Data, _Ids) :-
     throw(error(commit_rejected(Reason), _)).
 handle_commit_result(error(Exception), _Meta_Data, _Ids) :-
-    throw(error(Exception, _)).
+    (   Exception = error(_, _)
+    ->  throw(Exception)
+    ;   throw(error(Exception, _))
+    ).
 handle_commit_result(timeout, _Meta_Data, _Ids) :-
     throw(error(commit_queue_timeout, _)).
 
@@ -1659,6 +1676,16 @@ execute_commit_package(Package, Result) :-
 execute_commit_package(Package, Result) :-
     Package.all_branches = [_BranchKey],
     !,
+    [Transaction] = Package.transaction_objects,
+    transaction_object_database_key(Transaction, Key),
+    with_meta_commit_lock(
+        Key,
+        do_execute_commit_package(Package, Result)
+    ).
+execute_commit_package(_Package, Result) :-
+    Result = error(error(multi_branch_commit_not_implemented, _)).
+
+do_execute_commit_package(Package, Result) :-
     reset_transaction_objects_graph_descriptors(Package.transaction_objects),
     open_commit_windows_for_transactions(Package.transaction_objects, GuardIds),
     (   catch(
@@ -1667,11 +1694,18 @@ execute_commit_package(Package, Result) :-
                 Result = success(MetaData, Ids)
             ),
             Exception,
-            (   (   Exception = fail_transaction
+            (   json_log_error_formatted("execute_commit_package caught exception for ~w: ~w", [Package.branch_key, Exception]),
+                (   Exception = fail_transaction
                 ->  catch(
-                        run_synchronous_reelaboration_and_commit(Package, Result),
+                        (   run_synchronous_reelaboration_and_commit(Package, Result)
+                        ->  true
+                        ;   json_log_error_formatted("run_synchronous_reelaboration_and_commit failed silently", []),
+                            fail
+                        ),
                         SyncError,
-                        Result = error(SyncError)
+                        (   json_log_error_formatted("run_synchronous_reelaboration_and_commit error: ~w", [SyncError]),
+                            Result = error(SyncError)
+                        )
                     )
                 ;   Exception = error(elaboration_stale(_), _)
                 ->  Result = reject(schema_changed)
@@ -1680,7 +1714,8 @@ execute_commit_package(Package, Result) :-
             )
         )
     ->  true
-    ;   Result = error(unexpected_commit_failure)
+    ;   json_log_error_formatted("execute_commit_package catch block failed", []),
+        Result = error(unexpected_commit_failure)
     ),
     close_commit_windows(GuardIds),
     (   Result = success(_, _),
@@ -1688,8 +1723,6 @@ execute_commit_package(Package, Result) :-
     ->  commit_queue:invalidate_pending_after_schema_change(Package.branch_key)
     ;   true
     ).
-execute_commit_package(_Package, Result) :-
-    Result = error(error(multi_branch_commit_not_implemented, _)).
 
 % run_synchronous_reelaboration_and_commit/2 is called from run_commit_package
 % when the worker already holds the branch lock, so it must NOT re-acquire it.

--- a/src/core/api/api_error.pl
+++ b/src/core/api/api_error.pl
@@ -121,7 +121,7 @@ api_global_error_jsonld(error(commit_queue_timeout, _), Type, JSON) :-
     error_type(Type, Type_Displayed),
     format(string(Msg), "Timed out waiting for the commit queue to process the request", []),
     JSON = _{'@type' : Type_Displayed,
-             'api:status' : "api:server_error",
+             'api:status' : "api:service_unavailable",
              'api:error' : _{ '@type' : 'api:CommitQueueTimeout' },
              'api:message' : Msg
             }.
@@ -971,6 +971,14 @@ api_error_jsonld_(rebase,error(rebase_commit_application_failed(fixup_error(Thei
                               'api:witness' : Fixup_Witnesses},
              'api:message' : Msg
             }.
+api_error_jsonld_(rebase,error(rebase_target_branch_changed(Path),_), JSON) :-
+    format(string(Msg), "Rebase target branch head changed during the operation: ~q", [Path]),
+    JSON = _{'@type' : 'api:RebaseErrorResponse',
+             'api:status' : 'api:conflict',
+             'api:error' : _{ '@type' : 'api:RebaseTargetBranchChanged',
+                              'api:absolute_descriptor' : Path},
+             'api:message' : Msg
+            }.
 api_error_jsonld_(pack,error(unresolvable_collection(Descriptor),_), JSON) :-
     resolve_absolute_string_descriptor(Path, Descriptor),
     format(string(Msg), "The following descriptor (which should be a repository) could not be resolved to a resource: ~q", [Path]),
@@ -1811,6 +1819,7 @@ error_type_(access_documents, 'api:AccessDocumentErrorResponse').
 error_type_(get_documents, 'api:GetDocumentErrorResponse').
 error_type_(insert_documents, 'api:InsertDocumentErrorResponse').
 error_type_(optimize, 'api:OptimizeErrorResponse').
+error_type_(rebase, 'api:RebaseErrorResponse').
 error_type_(pack, 'api:PackErrorResponse').
 error_type_(prefix, 'api:PrefixErrorResponse').
 error_type_(pull, 'api:PullErrorResponse').
@@ -2986,6 +2995,7 @@ status_http_code('api:forbidden',403).
 status_http_code('api:not_found',404).
 status_http_code('api:method_not_allowed',405).
 status_http_code('api:conflict',409).
+status_http_code('api:service_unavailable',503).
 status_http_code('api:server_error',500).
 
 status_cli_code('api:success',0).

--- a/src/core/api/api_optimize.pl
+++ b/src/core/api/api_optimize.pl
@@ -8,6 +8,7 @@
 :- use_module(library(plunit)).
 :- use_module(core(util/test_utils)).
 :- use_module(core(triple)).
+:- use_module(core(document/meta_commit_queue)).
 
 % Does some crazy-magic unspecified optimizations
 api_optimize(SystemDB, Auth, Path) :-
@@ -35,17 +36,22 @@ api_optimize(SystemDB, Auth, Path) :-
     descriptor_optimize(Descriptor).
 
 named_graph_optimize(Graph_Name) :-
-    storage(Store),
-    safe_open_named_graph(Store,Graph_Name,Graph),
-    (   head(Graph, Layer, Version)
-    ->  (   parent(Layer, _)
-        ->  squash(Layer,New_Layer),
-            do_or_die(
-                nb_force_set_head(Graph,New_Layer,Version),
-                error(label_version_changed(Graph_Name,Version),_))
-        ;   true  % Already a base layer, nothing to squash
+    meta_commit_queue:with_meta_commit_lock(
+        Graph_Name,
+        api_optimize:(
+            storage(Store),
+            safe_open_named_graph(Store,Graph_Name,Graph),
+            (   head(Graph, Layer, Version)
+            ->  (   parent(Layer, _)
+                ->  squash(Layer,New_Layer),
+                    do_or_die(
+                        nb_force_set_head(Graph,New_Layer,Version),
+                        error(label_version_changed(Graph_Name,Version),_))
+                ;   true  % Already a base layer, nothing to squash
+                )
+            ;   true)
         )
-    ;   true).
+    ).
 
 descriptor_optimize(system_descriptor{}) :-
     system_instance_name(Graph_Name),
@@ -522,6 +528,5 @@ test(optimize_db_idempotent,
 
     % Head layer must be unchanged
     Layer1_Id = Layer2_Id.
-
 
 :- end_tests(optimize).

--- a/src/core/api/api_optimize.pl
+++ b/src/core/api/api_optimize.pl
@@ -36,8 +36,9 @@ api_optimize(SystemDB, Auth, Path) :-
     descriptor_optimize(Descriptor).
 
 named_graph_optimize(Graph_Name) :-
+    meta_commit_queue:graph_label_to_lock_key(Graph_Name, Lock_Key),
     meta_commit_queue:with_meta_commit_lock(
-        Graph_Name,
+        Lock_Key,
         api_optimize:(
             storage(Store),
             safe_open_named_graph(Store,Graph_Name,Graph),

--- a/src/core/api/api_optimize.pl
+++ b/src/core/api/api_optimize.pl
@@ -1,4 +1,4 @@
-:- module(api_optimize, [api_optimize/3]).
+:- module(api_optimize, [api_optimize/3, api_optimize_queued/3, descriptor_optimize/1, run_queued_optimize/1]).
 :- use_module(core(util)).
 :- use_module(core(query)).
 :- use_module(core(transaction)).
@@ -9,6 +9,14 @@
 :- use_module(core(util/test_utils)).
 :- use_module(core(triple)).
 :- use_module(core(document/meta_commit_queue)).
+:- use_module(core(document/commit_queue), [
+                  enqueue_commit/2
+              ]).
+:- use_module(core(api/api_document), [
+                  producer_timeout/1,
+                  get_commit_result/4,
+                  deliver_commit_result/2
+              ]).
 
 % Does some crazy-magic unspecified optimizations
 api_optimize(SystemDB, Auth, Path) :-
@@ -33,13 +41,136 @@ api_optimize(SystemDB, Auth, Path) :-
         ),
         error(not_a_valid_descriptor_for_optimization(Descriptor),_)),
 
-    descriptor_optimize(Descriptor).
+    descriptor_lock_key(Descriptor, Lock_Key),
+    with_meta_commit_lock(
+        Lock_Key,
+        descriptor_optimize(Descriptor)
+    ).
+
+% api_optimize_queued/3 is the API entry point that routes the optimization
+% through the branch commit queue for branch descriptors. Non-branch descriptors
+% (system, database, repository) fall back to the synchronous api_optimize/3
+% because they have no branch queue to serialize on. This removes the direct
+% meta_commit_lock acquisition from the request thread for branch optimizes.
+api_optimize_queued(SystemDB, Auth, Path) :-
+    do_or_die(
+        resolve_absolute_string_descriptor(Path, Descriptor),
+        error(invalid_absolute_path(Path),_)),
+    check_optimize_auth(SystemDB, Auth, Descriptor),
+    (   branch_descriptor{} :< Descriptor
+    ->  submit_queued_optimize(Descriptor, Path, Result),
+        handle_optimize_result(Result)
+    ;   descriptor_lock_key(Descriptor, Lock_Key),
+        with_meta_commit_lock(Lock_Key, descriptor_optimize(Descriptor))
+    ).
+
+check_optimize_auth(SystemDB, Auth, Descriptor) :-
+    do_or_die(
+        (   system_descriptor{} :< Descriptor,
+            do_or_die(is_super_user(Auth),
+                      error(requires_super_user,_))
+        ;   database_descriptor{} :< Descriptor,
+            check_descriptor_auth(SystemDB, Descriptor,
+                                  '@schema':'Action/meta_write_access', Auth)
+        ;   repository_descriptor{} :< Descriptor,
+            check_descriptor_auth(SystemDB, Descriptor,
+                                  '@schema':'Action/meta_write_access', Auth)
+        ;   branch_descriptor{} :< Descriptor,
+            check_descriptor_auth(SystemDB, Descriptor,
+                                  '@schema':'Action/meta_write_access', Auth)
+        ),
+        error(not_a_valid_descriptor_for_optimization(Descriptor),_)).
+
+submit_queued_optimize(Descriptor, Path, Result) :-
+    descriptor_lock_key(Descriptor, Database_Key),
+    message_queue_create(ReplyQueue, []),
+    gensym(request, RequestId),
+    Package = optimize_contract{
+        package_type: optimize_when_idle,
+        branch_key: Path,
+        database_key: Database_Key,
+        descriptor: Descriptor,
+        reply_queue: ReplyQueue,
+        request_id: RequestId
+    },
+    commit_queue:enqueue_commit(Path, Package),
+    producer_timeout(ProducerTimeout),
+    (   get_commit_result(ReplyQueue, RequestId, ProducerTimeout, Result)
+    ->  true
+    ;   Result = timeout
+    ),
+    catch(message_queue_destroy(ReplyQueue), _, true).
+
+handle_optimize_result(optimize_success) :- !.
+handle_optimize_result(error(Error)) :- throw(error(Error, _)).
+handle_optimize_result(timeout) :- throw(error(commit_queue_timeout, _)).
+
+% run_queued_optimize(+Package) is det.
+%
+% Called by the commit worker when it dequeues an optimize_contract. The worker
+% already holds the branch lock; this predicate acquires the meta_commit_lock,
+% runs the optimization, and retries immediately once if the first attempt fails
+% because the label version changed. The result is sent back to the reply queue.
+run_queued_optimize(Package) :-
+    get_dict(database_key, Package, Database_Key),
+    with_meta_commit_lock(
+        Database_Key,
+        run_queued_optimize_with_retry(Package, Result, 2)
+    ),
+    deliver_commit_result(Package, Result).
+
+run_queued_optimize_with_retry(Package, Result, _Retries) :-
+    try_descriptor_optimize(Package, _LastError),
+    !,
+    Result = optimize_success.
+run_queued_optimize_with_retry(Package, Result, Retries) :-
+    try_descriptor_optimize(Package, LastError),
+    LastError = error(label_version_changed(_Name, _Version), _),
+    Retries > 1,
+    !,
+    New_Retries is Retries - 1,
+    run_queued_optimize_with_retry(Package, Result, New_Retries).
+run_queued_optimize_with_retry(Package, Result, _Retries) :-
+    try_descriptor_optimize(Package, LastError),
+    LastError = error(label_version_changed(Name, Version), _),
+    !,
+    Result = error(label_version_changed(Name, Version)).
+run_queued_optimize_with_retry(_Package, Result, _Retries) :-
+    Result = error(unknown_optimize_failure).
+
+try_descriptor_optimize(Package, LastError) :-
+    get_dict(descriptor, Package, Descriptor),
+    catch(
+        descriptor_optimize(Descriptor),
+        Error,
+        (   LastError = Error,
+            (   Error = error(label_version_changed(_, _), _)
+            ->  fail
+            ;   throw(Error)
+            )
+        )
+    ).
+
+% descriptor_lock_key(+Descriptor, -Lock_Key) maps any optimize-able descriptor
+% to the meta_commit_lock key of the database it belongs to. This ensures the
+% synchronous /api/optimize endpoint is serialized with commits and with
+% scheduled auto-optimizations on the same database.
+descriptor_lock_key(Descriptor, Key) :-
+    (   system_descriptor{} :< Descriptor
+    ->  meta_commit_queue:system_meta_lock_key(Key)
+    ;   database_descriptor{} :< Descriptor
+    ->  meta_commit_queue:database_descriptor_key(Descriptor, Key)
+    ;   repository_descriptor{database_descriptor: DB_Desc} :< Descriptor
+    ->  descriptor_lock_key(DB_Desc, Key)
+    ;   branch_descriptor{repository_descriptor: Repo_Desc} :< Descriptor
+    ->  descriptor_lock_key(Repo_Desc, Key)
+    ).
 
 named_graph_optimize(Graph_Name) :-
-    meta_commit_queue:graph_label_to_lock_key(Graph_Name, Lock_Key),
-    meta_commit_queue:with_meta_commit_lock(
+    graph_label_to_lock_key(Graph_Name, Lock_Key),
+    with_meta_commit_lock(
         Lock_Key,
-        api_optimize:(
+        (
             storage(Store),
             safe_open_named_graph(Store,Graph_Name,Graph),
             (   head(Graph, Layer, Version)
@@ -529,5 +660,26 @@ test(optimize_db_idempotent,
 
     % Head layer must be unchanged
     Layer1_Id = Layer2_Id.
+
+test(optimize_branch_queued,
+     [setup((setup_temp_store(State),
+             create_db_without_schema("admin", "testdb")
+            )),
+      cleanup((commit_queue:stop_workers,
+               teardown_temp_store(State)))
+     ])
+:-
+    Path = 'admin/testdb/local/branch/main',
+    super_user_authority(Auth),
+
+    resolve_absolute_string_descriptor(Path, Descriptor),
+    create_context(Descriptor, commit_info{author:"test", message:"commit 1"}, Context1),
+    with_transaction(Context1, ask(Context1, insert(a,b,c)), _),
+    create_context(Descriptor, commit_info{author:"test", message:"commit 2"}, Context2),
+    with_transaction(Context2, ask(Context2, insert(d,e,f)), _),
+
+    commit_queue:start_workers(1),
+    api_optimize_queued(system_descriptor{}, Auth, Path),
+    commit_queue:stop_workers.
 
 :- end_tests(optimize).

--- a/src/core/api/api_optimize.pl
+++ b/src/core/api/api_optimize.pl
@@ -113,11 +113,19 @@ handle_optimize_result(timeout) :- throw(error(commit_queue_timeout, _)).
 % because the label version changed. The result is sent back to the reply queue.
 run_queued_optimize(Package) :-
     get_dict(database_key, Package, Database_Key),
-    with_meta_commit_lock(
-        Database_Key,
-        run_queued_optimize_with_retry(Package, Result, 2)
-    ),
-    deliver_commit_result(Package, Result).
+    catch(
+        (   with_meta_commit_lock(
+                Database_Key,
+                (   run_queued_optimize_with_retry(Package, Result, 2)
+                ->  true
+                ;   Result = error(unknown_optimize_failure)
+                )
+            ),
+            deliver_commit_result(Package, Result)
+        ),
+        Error,
+        deliver_commit_result(Package, error(Error))
+    ).
 
 run_queued_optimize_with_retry(Package, Result, _Retries) :-
     try_descriptor_optimize(Package, _LastError),

--- a/src/core/api/db_delete.pl
+++ b/src/core/api/db_delete.pl
@@ -14,6 +14,7 @@
 :- use_module(core(triple)).
 :- use_module(core(query)).
 :- use_module(core(transaction)).
+:- use_module(core(document/meta_commit_queue)).
 :- use_module(core(account)).
 
 :- use_module(library(terminus_store)).
@@ -87,7 +88,10 @@ delete_db(System, Auth, Organization,DB_Name, Force) :-
 delete_database_label(Organization, DB_Name) :-
     triple_store(Store),
     organization_database_name(Organization, DB_Name, Named_Graph_Name),
-    safe_delete_named_graph(Store, Named_Graph_Name).
+    meta_commit_queue:with_meta_commit_lock(
+        Named_Graph_Name,
+        db_delete:safe_delete_named_graph(Store, Named_Graph_Name)
+    ).
 
 /**
  * force_delete_db(+Organization, +DB_Name) is semidet.

--- a/src/core/api/db_delete.pl
+++ b/src/core/api/db_delete.pl
@@ -88,9 +88,9 @@ delete_db(System, Auth, Organization,DB_Name, Force) :-
 delete_database_label(Organization, DB_Name) :-
     triple_store(Store),
     organization_database_name(Organization, DB_Name, Named_Graph_Name),
-    meta_commit_queue:with_meta_commit_lock(
+    with_meta_commit_lock(
         Named_Graph_Name,
-        db_delete:safe_delete_named_graph(Store, Named_Graph_Name)
+        safe_delete_named_graph(Store, Named_Graph_Name)
     ).
 
 /**

--- a/src/core/api/db_push.pl
+++ b/src/core/api/db_push.pl
@@ -8,6 +8,7 @@
 :- use_module(core(transaction)).
 :- use_module(core(account)).
 :- use_module(core(document)).
+:- use_module(core(document/meta_commit_queue)).
 :- use_module(core(util)).
 :- use_module(config(terminus_config), [terminusdb_version/1]).
 :- use_module(core(triple)).
@@ -143,8 +144,16 @@ push(System_DB, Auth, Branch, Remote_Name, Remote_Branch, _Options,
             [Read_Obj] = (Remote_Transaction_Object.instance_objects),
             Layer = (Read_Obj.read),
             layer_to_id(Layer, Current_Head_Id),
-            update_repository_head(Database_Transaction_Object, Remote_Name, Current_Head_Id),
-            run_transactions([Database_Transaction_Object], true, _),
+            database_descriptor{organization_name: Organization,
+                              database_name: Database} :< Database_Transaction_Object.descriptor,
+            organization_database_name(Organization, Database, Database_Key),
+            meta_commit_queue:with_meta_commit_lock(
+                Database_Key,
+                db_push:(
+                    update_repository_head(Database_Transaction_Object, Remote_Name, Current_Head_Id),
+                    run_transactions([Database_Transaction_Object], true, _)
+                )
+            ),
             Result = new(Current_Head_Id)
         )
     % We are using a shared store
@@ -155,10 +164,18 @@ push(System_DB, Auth, Branch, Remote_Name, Remote_Branch, _Options,
         [Read_Obj] = (Remote_Transaction_Object.instance_objects),
         Layer = (Read_Obj.read),
         layer_to_id(Layer, Current_Head_Id),
+        database_descriptor{organization_name: Organization2,
+                          database_name: Database2} :< Database_Transaction_Object.descriptor,
+        organization_database_name(Organization2, Database2, Database_Key),
 
         local_push(System_DB, Auth, Organization, DB, Current_Head_Id),
-        update_repository_head(Database_Transaction_Object, Remote_Name, Current_Head_Id),
-        run_transactions([Database_Transaction_Object], true, _),
+        meta_commit_queue:with_meta_commit_lock(
+            Database_Key,
+            db_push:(
+                update_repository_head(Database_Transaction_Object, Remote_Name, Current_Head_Id),
+                run_transactions([Database_Transaction_Object], true, _)
+            )
+        ),
         Result = new(Current_Head_Id)
     ).
 

--- a/src/core/api/db_push.pl
+++ b/src/core/api/db_push.pl
@@ -1,6 +1,8 @@
 :- module(db_push, [
               push/8,
-              authorized_push/3
+              authorized_push/3,
+              noop_pusher/2,
+              optimize_thread_loop/3
           ]).
 
 :- use_module(core(util)).
@@ -9,6 +11,7 @@
 :- use_module(core(account)).
 :- use_module(core(document)).
 :- use_module(core(document/meta_commit_queue)).
+:- use_module(core(api/api_optimize), [api_optimize/3]).
 :- use_module(core(util)).
 :- use_module(config(terminus_config), [terminusdb_version/1]).
 :- use_module(core(triple)).
@@ -23,6 +26,33 @@
 :- use_module(library(tus)).
 :- use_module(library(plunit)).
 :- use_module(library(lists)).
+
+% Test hook for the push race regression test. The default is inert; unit tests
+% can register an optimizer thread via push_optimize_thread/1 to interleave an
+% optimization between the repository head update and the database commit.
+:- dynamic push_pre_database_commit_hook/1.
+:- dynamic push_optimize_thread/1.
+
+push_pre_database_commit_hook(_Database_Transaction_Object) :-
+    push_optimize_thread(OptimizeThread),
+    % Guard: only fire if the registered thread is still alive.
+    catch(thread_property(OptimizeThread, status(running)), _, fail),
+    !,
+    thread_send_message(OptimizeThread, optimize_now).
+
+noop_pusher(_Remote_URL, _Payload).
+
+optimize_thread_loop(Store, Auth, Meta_Path) :-
+    thread_get_message(Message),
+    (   Message == optimize_now
+    ->  api_optimize(system_descriptor{}, Auth, Meta_Path)
+    ;   true
+    ),
+    (   Message == stop
+    ->  true
+    ;   optimize_thread_loop(Store, Auth, Meta_Path)
+    ).
+
 % error conditions:
 % - branch to push does not exist
 % - repository does not exist
@@ -147,10 +177,13 @@ push(System_DB, Auth, Branch, Remote_Name, Remote_Branch, _Options,
             database_descriptor{organization_name: Organization,
                               database_name: Database} :< Database_Transaction_Object.descriptor,
             organization_database_name(Organization, Database, Database_Key),
-            meta_commit_queue:with_meta_commit_lock(
+            with_meta_commit_lock(
                 Database_Key,
-                db_push:(
+                (
                     update_repository_head(Database_Transaction_Object, Remote_Name, Current_Head_Id),
+                    % The hook is used for regression tests; when no test thread is
+                    % registered it fails, ignore/1 makes this continue regardless.
+                    ignore(push_pre_database_commit_hook(Database_Transaction_Object)),
                     run_transactions([Database_Transaction_Object], true, _)
                 )
             ),
@@ -169,10 +202,13 @@ push(System_DB, Auth, Branch, Remote_Name, Remote_Branch, _Options,
         organization_database_name(Organization2, Database2, Database_Key),
 
         local_push(System_DB, Auth, Organization, DB, Current_Head_Id),
-        meta_commit_queue:with_meta_commit_lock(
+        with_meta_commit_lock(
             Database_Key,
-            db_push:(
+            (
                 update_repository_head(Database_Transaction_Object, Remote_Name, Current_Head_Id),
+                    % The hook is used for regression tests; when no test thread is
+                    % registered it fails, ignore/1 makes this continue regardless.
+                ignore(push_pre_database_commit_hook(Database_Transaction_Object)),
                 run_transactions([Database_Transaction_Object], true, _)
             )
         ),
@@ -717,3 +753,67 @@ test(push_prefixes,
                  '@type': 'Context'}.
 
 :- end_tests(push).
+
+:- begin_tests(push_race, [concurrent(false)]).
+:- use_module(core(util/test_utils)).
+:- use_module(core(query)).
+:- use_module(core(triple)).
+:- use_module(core(transaction)).
+:- use_module(core(account)).
+:- use_module(core(document)).
+:- use_module(db_create).
+:- use_module(db_branch).
+
+% Regression test for the race between push's database commit and a concurrent
+% optimization. The hook fires an optimize between update_repository_head and
+% run_transactions; the meta_commit_lock held across that window serializes the
+% two operations.
+%
+% Uses the URL-based remote path with a no-op pusher so the test exercises the
+% same commit path as a real network push without requiring a second database.
+test(push_races_with_database_optimize,
+     [setup((setup_temp_store(State),
+             create_db_without_schema("admin", "foo")
+            )),
+      cleanup((retractall(db_push:push_optimize_thread(_)),
+               teardown_temp_store(State)))
+     ])
+:-
+    Master_Path = "admin/foo",
+    resolve_absolute_string_descriptor(Master_Path, Master_Descriptor),
+    super_user_authority(Auth),
+
+    % Commit on main so the remote repository will receive a real layer.
+    create_context(Master_Descriptor, commit_info{author:"test", message:"commit a"}, Ctx1),
+    with_transaction(Ctx1, ask(Ctx1, insert(a,b,c)), _),
+
+    % Add a remote repository so the push takes the URL-based commit path.
+    Database_Descriptor = (Master_Descriptor.repository_descriptor.database_descriptor),
+    resolve_relative_string_descriptor(Database_Descriptor, "remote/_commits", Remote_Repository_Descriptor),
+    create_context(Database_Descriptor, Database_Context),
+    with_transaction(Database_Context,
+                     insert_remote_repository(Database_Context, "remote", "http://fakeytown.mock", _),
+                     _),
+    create_ref_layer(Remote_Repository_Descriptor),
+
+    triple_store(Store),
+    Master_Meta_Path = "admin/foo/_meta",
+
+    setup_call_cleanup(
+        (   thread_create(
+                with_triple_store(Store,
+                                  db_push:optimize_thread_loop(Store, Auth, Master_Meta_Path)),
+                OptimizeThread,
+                []
+            ),
+            assertz(db_push:push_optimize_thread(OptimizeThread))
+        ),
+        push(system_descriptor{}, Auth, "admin/foo", "remote", "main", [], db_push:noop_pusher, _Result),
+        (   db_push:push_optimize_thread(OptimizeThread),
+            thread_send_message(OptimizeThread, stop),
+            thread_join(OptimizeThread, OptimizeResult),
+            assertion(OptimizeResult == true)
+        )
+    ).
+
+:- end_tests(push_race).

--- a/src/core/api/db_rebase.pl
+++ b/src/core/api/db_rebase.pl
@@ -23,9 +23,15 @@
                   enqueue_commit/2
               ]).
 :- use_module(core(document/meta_commit_queue)).
+:- use_module(core(transaction/descriptor), [branch_key_from_descriptor/2]).
+:- use_module(core(transaction/ref_entity), [
+                  commit_id_uri/3,
+                  commit_uri_to_parent_uri/3
+              ]).
 
 :- dynamic rebase_pre_database_commit_hook/1.
 :- dynamic rebase_optimize_thread/1.
+:- dynamic rebase_insert_thread/1.
 
 % Default hook used by the race regression test. It is a no-op unless the
 % current test has registered an optimizer thread via rebase_optimize_thread/1.
@@ -35,8 +41,7 @@ rebase_pre_database_commit_hook(_Database_Transaction_Object) :-
     % stale thread fact from affecting production rebases.
     catch(thread_property(OptimizeThread, status(running)), _, fail),
     !,
-    thread_send_message(OptimizeThread, optimize_now),
-    sleep(0.05).
+    thread_send_message(OptimizeThread, optimize_now).
 rebase_pre_database_commit_hook(_) :- fail.
 
 cycle_context(Context, New_Context, New_Transaction_Object, Validation_Object) :-
@@ -355,11 +360,19 @@ submit_rebase_contract_queued(Contract, Result) :-
 % executes the final commit window, and sends the result back to the reply queue.
 run_rebase_contract(Package) :-
     get_dict(database_key, Package, Database_Key),
-    with_meta_commit_lock(
-        Database_Key,
-        execute_rebase_contract(Package, Result)
-    ),
-    deliver_commit_result(Package, Result).
+    catch(
+        (   with_meta_commit_lock(
+                Database_Key,
+                (   execute_rebase_contract(Package, Result)
+                ->  true
+                ;   Result = error(unexpected_rebase_failure)
+                )
+            ),
+            deliver_commit_result(Package, Result)
+        ),
+        Error,
+        deliver_commit_result(Package, error(Error))
+    ).
 
 execute_rebase_contract(Package, Result) :-
     get_dict(our_repo_descriptor, Package, Our_Repo_Descriptor),
@@ -378,6 +391,42 @@ execute_rebase_contract(Package, Result) :-
         ),
         error(rebase_target_branch_changed(_), _),
         Result = reject(rebase_target_branch_changed)
+    ).
+
+% register_rebase_head_in_change_window(+BranchDescriptor, +RepoContext, +HeadCommitUri)
+%
+% Rebase creates new commits on the target branch outside the normal commit
+% validation path, so the change window does not see them. The change window enables
+% verification of writes against what changed recently. Without this, the
+% next commit to the branch tries to open a commit window with a parent that
+% is not present in the window, falls into a retry loop, and
+% effectively stalls the database. We register the new head (with an
+% empty change set) so the window knows the current branch head and commits
+% can open their guards immediately.
+register_rebase_head_in_change_window(BranchDescriptor, RepoContext, HeadCommitUri) :-
+    branch_key_from_descriptor(BranchDescriptor, BranchKey),
+    commit_id_uri(RepoContext, HeadCommitId, HeadCommitUri),
+    (   commit_uri_to_parent_uri(RepoContext, HeadCommitUri, ParentCommitUri)
+    ->  commit_id_uri(RepoContext, ParentCommitId, ParentCommitUri)
+    ;   ParentCommitId = none
+    ),
+    (   atom(HeadCommitId)
+    ->  HeadCommitIdAtom = HeadCommitId
+    ;   atom_string(HeadCommitIdAtom, HeadCommitId)
+    ),
+    (   ParentCommitId = none
+    ->  ParentCommitIdArg = none
+    ;   atom_string(ParentCommitIdArg, ParentCommitId)
+    ),
+    (   catch(
+            '$change_window':register_commit(BranchKey, HeadCommitIdAtom, ParentCommitIdArg,
+                                             none, none, [], []),
+            Error,
+            json_log_error_formatted("register_rebase_head_in_change_window failed for ~w: ~w",
+                                     [BranchKey, Error])
+        )
+    ->  true
+    ;   fail
     ).
 
 rebase_commit_window(Our_Repo_Descriptor, Our_Branch_Descriptor, Our_Branch_Path,
@@ -399,6 +448,9 @@ rebase_commit_window(Our_Repo_Descriptor, Our_Branch_Descriptor, Our_Branch_Path
     ignore(unlink_commit_object_from_branch(Semifinal_Context, Our_Branch_Uri)),
 
     link_commit_object_to_branch(Semifinal_Context, Our_Branch_Uri, Final_Commit_Uri),
+
+    register_rebase_head_in_change_window(Our_Branch_Descriptor, Semifinal_Context,
+                                          Final_Commit_Uri),
 
     cycle_context(Semifinal_Context, _Final_Context, Transaction_Object, _),
 

--- a/src/core/api/db_rebase.pl
+++ b/src/core/api/db_rebase.pl
@@ -1,5 +1,6 @@
 :- module(db_rebase, [
               rebase_on_branch/9,
+              run_rebase_contract/1,
               cycle_context/4
           ]).
 :- use_module(library(terminus_store)).
@@ -13,6 +14,14 @@
 :- use_module(core(transaction)).
 :- use_module(core(triple)).
 :- use_module(core(api/api_optimize)).
+:- use_module(core(api/api_document), [
+                  producer_timeout/1,
+                  get_commit_result/4,
+                  deliver_commit_result/2
+              ]).
+:- use_module(core(document/commit_queue), [
+                  enqueue_commit/2
+              ]).
 :- use_module(core(document/meta_commit_queue)).
 
 :- dynamic rebase_pre_database_commit_hook/1.
@@ -22,6 +31,9 @@
 % current test has registered an optimizer thread via rebase_optimize_thread/1.
 rebase_pre_database_commit_hook(_Database_Transaction_Object) :-
     rebase_optimize_thread(OptimizeThread),
+    % Guard: only fire if the registered thread is still alive. This prevents a
+    % stale thread fact from affecting production rebases.
+    catch(thread_property(OptimizeThread, status(running)), _, fail),
     !,
     thread_send_message(OptimizeThread, optimize_now),
     sleep(0.05).
@@ -150,8 +162,40 @@ create_strategies([Commit_ID|Their_Branch_Path], Strategy_Map, [Strategy|Strateg
     create_strategies(Their_Branch_Path, Strategy_Map, Strategies).
 
 rebase_on_branch(System_DB, Auth, Our_Branch_Path, Their_Branch_Path, Author, Strategy_Map, Optional_Common_Commit_Id, Their_Branch_History, Reports) :-
-    benchmark_subject_start('rebase on branch'),
+    do_rebase_with_retry(System_DB, Auth, Our_Branch_Path, Their_Branch_Path,
+                         Author, Strategy_Map, Optional_Common_Commit_Id,
+                         Their_Branch_History, Reports, 10).
 
+% do_rebase_with_retry/10 submits a prepared rebase contract to the branch
+% commit queue and retries synchronously if the worker rejects it because the
+% target branch head changed. This follows the same contract-and-retry pattern
+% used by regular document commits.
+do_rebase_with_retry(System_DB, Auth, Our_Branch_Path, Their_Branch_Path,
+                     Author, Strategy_Map, Optional_Common_Commit_Id,
+                     Their_Branch_History, Reports, Retries) :-
+    rebase_on_branch_inner(System_DB, Auth, Our_Branch_Path, Their_Branch_Path,
+                           Author, Strategy_Map, Optional_Common_Commit_Id,
+                           Their_Branch_History, Contract),
+    submit_rebase_contract(Contract, Result),
+    (   Result = rebase_success(Reports)
+    ->  true
+    ;   Result = reject(rebase_target_branch_changed),
+        Retries > 1
+    ->  New_Retries is Retries - 1,
+        do_rebase_with_retry(System_DB, Auth, Our_Branch_Path, Their_Branch_Path,
+                             Author, Strategy_Map, Optional_Common_Commit_Id,
+                             Their_Branch_History, Reports, New_Retries)
+    ;   Result = reject(rebase_target_branch_changed)
+    ->  throw(error(rebase_target_branch_changed(Our_Branch_Path), _))
+    ;   Result = error(Error)
+    ->  throw(error(Error, _))
+    ;   Result = timeout
+    ->  throw(error(commit_queue_timeout, _))
+    ).
+
+rebase_on_branch_inner(System_DB, Auth, Our_Branch_Path, Their_Branch_Path,
+                       Author, Strategy_Map, Optional_Common_Commit_Id,
+                       Their_Branch_History, Contract) :-
     do_or_die(
         resolve_absolute_string_descriptor(Our_Branch_Path, Our_Branch_Descriptor),
         error(invalid_target_absolute_path(Our_Branch_Path),_)),
@@ -179,14 +223,27 @@ rebase_on_branch(System_DB, Auth, Our_Branch_Path, Their_Branch_Path, Author, St
     Our_Repo_Descriptor = (Our_Branch_Descriptor.repository_descriptor),
     Their_Repo_Descriptor = (Their_Ref_Descriptor.repository_descriptor),
 
+    prepare_rebase_contract(Auth, Our_Branch_Descriptor, Their_Ref_Descriptor,
+                            Our_Repo_Descriptor, Their_Repo_Descriptor,
+                            Our_Branch_Path, Their_Branch_Path, Author,
+                            Strategy_Map, Optional_Common_Commit_Id,
+                            Contract, Their_Branch_History).
+
+% prepare_rebase_contract/12 does all the rebase work that can safely happen
+% outside the branch lock: history computation, commit copying, and replay.
+% It returns a rebase_contract dict that the worker will verify and commit.
+prepare_rebase_contract(Auth, Our_Branch_Descriptor, Their_Ref_Descriptor,
+                        Our_Repo_Descriptor, Their_Repo_Descriptor,
+                        Our_Branch_Path, Their_Branch_Path, Author,
+                        Strategy_Map, Optional_Common_Commit_Id,
+                        Contract, Their_Branch_History) :-
+
     do_or_die(
         create_context(Our_Repo_Descriptor, Our_Repo_Context),
         error(unresolvable_target_descriptor(Our_Repo_Descriptor))),
     do_or_die(
         create_context(Their_Repo_Descriptor, Their_Repo_Context),
         error(unresolvable_source_descriptor(Their_Repo_Descriptor))),
-
-    benchmark(after_checks),
 
     do_or_die(
         branch_name_uri(Our_Repo_Context, Our_Branch_Descriptor.branch_name, Our_Branch_Uri),
@@ -198,28 +255,23 @@ rebase_on_branch(System_DB, Auth, Our_Branch_Path, Their_Branch_Path, Author, St
     (   branch_head_commit(Our_Repo_Context, Our_Branch_Descriptor.branch_name, Our_Commit_Uri),
         commit_id_uri(Our_Repo_Context, Our_Commit_Id, Our_Commit_Uri),
         commit_type(Our_Repo_Context, Our_Commit_Uri, 'http://terminusdb.com/schema/ref#ValidCommit')
-    ->  (   most_recent_common_ancestor(Our_Repo_Context, Their_Repo_Context, Our_Commit_Id, Their_Commit_Id, Optional_Common_Commit_Id, Our_Branch_History, Their_Branch_History),
-            benchmark(after_ancestor_lookup)
+    ->  Original_Our_Head = some(Our_Commit_Id),
+        (   most_recent_common_ancestor(Our_Repo_Context, Their_Repo_Context, Our_Commit_Id, Their_Commit_Id, Optional_Common_Commit_Id, Our_Branch_History, Their_Branch_History)
         ->  true
         % We have no common history
         ;   Optional_Common_Commit_Id = none,
             commit_uri_to_history_commit_ids(Our_Repo_Context, Our_Commit_Uri, Our_Branch_History),
-            benchmark(history_lookup_1),
-            commit_uri_to_history_commit_ids(Their_Repo_Context, Their_Commit_Uri, Their_Branch_History),
-            benchmark(history_lookup_2))
+            commit_uri_to_history_commit_ids(Their_Repo_Context, Their_Commit_Uri, Their_Branch_History))
     % Branch head commit may not exist if our branch is empty...
     ;   Optional_Common_Commit_Id = none,
+        Original_Our_Head = none,
         Our_Branch_History = [],
         commit_uri_to_history_commit_ids(Their_Repo_Context, Their_Commit_Uri, Their_Branch_History)
     ),
 
-    benchmark(before_copy),
-
     % copy commits from their repo into ours, ensuring we got the latest
     copy_commits(Their_Repo_Context, Our_Repo_Context, Their_Commit_Id),
-    benchmark(after_copy),
     cycle_context(Our_Repo_Context, Our_Repo_Context2, _, _),
-    benchmark(after_first_cycle),
 
     % take their commit uri as the top on which we're gonna apply_commit_chain
     % list of commits to apply is ours since common
@@ -247,50 +299,128 @@ rebase_on_branch(System_DB, Auth, Our_Branch_Path, Their_Branch_Path, Author, St
         )
     ),
 
-    benchmark(after_application),
+    Database_Descriptor = Our_Branch_Descriptor.repository_descriptor.database_descriptor,
+    database_descriptor_key(Database_Descriptor, Database_Key),
+
+    Contract = rebase_contract{
+        package_type: rebase,
+        branch_key: Our_Branch_Path,
+        database_key: Database_Key,
+        our_repo_descriptor: Our_Repo_Descriptor,
+        our_branch_descriptor: Our_Branch_Descriptor,
+        our_branch_path: Our_Branch_Path,
+        original_head: Original_Our_Head,
+        semifinal_context: Semifinal_Context,
+        our_branch_uri: Our_Branch_Uri,
+        final_commit_uri: Final_Commit_Uri,
+        reports: Reports
+    }.
+
+% submit_rebase_contract/2 submits a rebase contract to the branch commit queue
+% and waits for the worker result. If the commit worker pool is not running
+% (e.g. during PLUnit tests), the contract is executed synchronously in the
+% request thread as a fallback. The result uses the same commit_result envelope
+% as regular commits when queued, or the raw result term when synchronous.
+submit_rebase_contract(Contract, Result) :-
+    (   commit_queue:multi_purpose_worker_thread(_)
+    ->  submit_rebase_contract_queued(Contract, Result)
+    ;   % No worker pool is running (e.g. PLUnit tests). Run the final commit
+        % window synchronously in the request thread, but still under the
+        % meta_commit_lock so the branch relink and repository head update are
+        % serialized.
+        get_dict(database_key, Contract, Database_Key),
+        with_meta_commit_lock(
+            Database_Key,
+            execute_rebase_contract(Contract, Result)
+        )
+    ).
+
+submit_rebase_contract_queued(Contract, Result) :-
+    get_dict(branch_key, Contract, BranchKey),
+    message_queue_create(ReplyQueue, []),
+    gensym(request, RequestId),
+    ContractWithReply = Contract.put(_{reply_queue: ReplyQueue, request_id: RequestId}),
+    commit_queue:enqueue_commit(BranchKey, ContractWithReply),
+    producer_timeout(ProducerTimeout),
+    (   get_commit_result(ReplyQueue, RequestId, ProducerTimeout, Result)
+    ->  true
+    ;   Result = timeout
+    ),
+    catch(message_queue_destroy(ReplyQueue), _, true).
+
+% run_rebase_contract(+Package) is det.
+%
+% Called by the commit worker when it dequeues a rebase_contract. The worker
+% already holds the branch lock; this predicate acquires the meta_commit_lock,
+% executes the final commit window, and sends the result back to the reply queue.
+run_rebase_contract(Package) :-
+    get_dict(database_key, Package, Database_Key),
+    with_meta_commit_lock(
+        Database_Key,
+        execute_rebase_contract(Package, Result)
+    ),
+    deliver_commit_result(Package, Result).
+
+execute_rebase_contract(Package, Result) :-
+    get_dict(our_repo_descriptor, Package, Our_Repo_Descriptor),
+    get_dict(our_branch_descriptor, Package, Our_Branch_Descriptor),
+    get_dict(our_branch_path, Package, Our_Branch_Path),
+    get_dict(original_head, Package, Original_Our_Head),
+    get_dict(semifinal_context, Package, Semifinal_Context),
+    get_dict(our_branch_uri, Package, Our_Branch_Uri),
+    get_dict(final_commit_uri, Package, Final_Commit_Uri),
+    get_dict(reports, Package, Reports),
+    catch(
+        (   rebase_commit_window(Our_Repo_Descriptor, Our_Branch_Descriptor,
+                                 Our_Branch_Path, Original_Our_Head,
+                                 Semifinal_Context, Our_Branch_Uri, Final_Commit_Uri),
+            Result = rebase_success(Reports)
+        ),
+        error(rebase_target_branch_changed(_), _),
+        Result = reject(rebase_target_branch_changed)
+    ).
+
+rebase_commit_window(Our_Repo_Descriptor, Our_Branch_Descriptor, Our_Branch_Path,
+                     Original_Our_Head, Semifinal_Context, Our_Branch_Uri, Final_Commit_Uri) :-
+    % The target branch head may have moved between our history computation and
+    % the moment we acquired the lock. Re-read it here and fail with a
+    % structured error so the caller can retry with the new head.
+    (   branch_head_commit(Our_Repo_Descriptor, Our_Branch_Descriptor.branch_name, Current_Our_Commit_Uri),
+        commit_id_uri(Our_Repo_Descriptor, Current_Our_Commit_Id, Current_Our_Commit_Uri),
+        commit_type(Our_Repo_Descriptor, Current_Our_Commit_Uri, 'http://terminusdb.com/schema/ref#ValidCommit')
+    ->  Current_Our_Head = some(Current_Our_Commit_Id)
+    ;   Current_Our_Head = none
+    ),
+    (   Current_Our_Head = Original_Our_Head
+    ->  true
+    ;   throw(error(rebase_target_branch_changed(Our_Branch_Path), _))
+    ),
 
     ignore(unlink_commit_object_from_branch(Semifinal_Context, Our_Branch_Uri)),
 
     link_commit_object_to_branch(Semifinal_Context, Our_Branch_Uri, Final_Commit_Uri),
 
-    benchmark(after_commit_branch_relink),
-
     cycle_context(Semifinal_Context, _Final_Context, Transaction_Object, _),
-
-    benchmark(after_second_cycle),
 
     Repo_Name = Transaction_Object.descriptor.repository_name,
     [Read_Write_Obj] = Transaction_Object.instance_objects,
     Layer = Read_Write_Obj.read,
     layer_to_id(Layer, Layer_Id),
     Database_Transaction_Object = (Transaction_Object.parent),
-    database_descriptor{organization_name: Organization,
-                        database_name: Database} :< Database_Transaction_Object.descriptor,
-    organization_database_name(Organization, Database, Database_Key),
 
-    % Hold the meta commit lock across the repository head update and the
-    % database commit. This prevents the auto-optimizer from changing the _meta
-    % head while the rebase is in its commit window.
-    meta_commit_queue:with_meta_commit_lock(
-        Database_Key,
-        db_rebase:(
-            update_repository_head(Database_Transaction_Object, Repo_Name, Layer_Id),
+    update_repository_head(Database_Transaction_Object, Repo_Name, Layer_Id),
 
-            benchmark(after_repository_head_update),
-
-            % Test hook: allows unit tests to interleave an optimization between
-            % the repository head update and the database commit, which is the
-            % exact window in which the auto-optimizer races with the rebase's
-            % _meta commit.
-            (   rebase_pre_database_commit_hook(Database_Transaction_Object)
-            ->  true
-            ;   true
-            ),
-
-            run_transactions([Database_Transaction_Object], true, _)
-        )
+    % Test hook: allows unit tests to interleave an optimization between
+    % the repository head update and the database commit, which is the
+    % exact window in which the auto-optimizer races with the rebase's
+    % _meta commit. The lock is recursive, so the inner run_transactions
+    % can acquire it again safely.
+    (   rebase_pre_database_commit_hook(Database_Transaction_Object)
+    ->  true
+    ;   true
     ),
-    benchmark_subject_stop('rebase on branch').
+
+    run_transactions([Database_Transaction_Object], true, _).
 
 :- begin_tests(rebase, [concurrent(true)]).
 :- use_module(core(util/test_utils)).
@@ -725,8 +855,43 @@ test(rebase_conflict,
 
     rebase_on_branch(system_descriptor{}, Auth, "admin/foo", Path, "me", [], _Common_Commit_Id, _Their_Commit_Ids, _Reports).
 
-
 :- end_tests(rebase).
+
+:- begin_tests(rebase_queue, []).
+:- use_module(core(util/test_utils)).
+:- use_module(core(query)).
+:- use_module(core(transaction)).
+:- use_module(core(triple)).
+:- use_module(core(account)).
+:- use_module(core(document)).
+:- use_module(db_create).
+:- use_module(db_branch).
+
+test(rebase_through_commit_queue,
+     [setup((setup_temp_store(State),
+             create_db_without_schema("admin", "foo"))),
+      cleanup((commit_queue:stop_workers,
+               teardown_temp_store(State)))
+     ])
+:-
+    Master_Path = "admin/foo",
+    Second_Path = "admin/foo/local/branch/second",
+    super_user_authority(Auth),
+
+    resolve_absolute_string_descriptor(Master_Path, Master_Descriptor),
+    create_context(Master_Descriptor, commit_info{author:"test", message:"commit a"}, Ctx1),
+    with_transaction(Ctx1, ask(Ctx1, insert(a,b,c)), _),
+
+    branch_create(system_descriptor{}, Auth, Second_Path, branch(Master_Path), _),
+    resolve_absolute_string_descriptor(Second_Path, Second_Descriptor),
+    create_context(Second_Descriptor, commit_info{author:"test", message:"commit b"}, Ctx2),
+    with_transaction(Ctx2, ask(Ctx2, insert(d,e,f)), _),
+
+    commit_queue:start_workers(1),
+    rebase_on_branch(system_descriptor{}, Auth, Master_Path, Second_Path, "rebaser", [], _Common_Commit_Id, _Their_Commit_Ids, _Reports),
+    commit_queue:stop_workers.
+
+:- end_tests(rebase_queue).
 
 optimize_thread_loop(Store, Auth, Master_Meta_Path) :-
     thread_get_message(Message),
@@ -737,6 +902,20 @@ optimize_thread_loop(Store, Auth, Master_Meta_Path) :-
     (   Message == stop
     ->  true
     ;   optimize_thread_loop(Store, Auth, Master_Meta_Path)
+    ).
+
+insert_race_doc(_Auth, Master_Path) :-
+    resolve_absolute_string_descriptor(Master_Path, Master_Descriptor),
+    create_context(Master_Descriptor, commit_info{author:"test", message:"race insert"}, Ctx),
+    with_transaction(Ctx, ask(Ctx, insert(race,g,h)), _).
+
+insert_thread_loop(Store, Auth, Master_Path) :-
+    (   thread_peek_message(stop)
+    ->  thread_get_message(stop),
+        true
+    ;   catch(insert_race_doc(Auth, Master_Path), _, true),
+        sleep(0.01),
+        insert_thread_loop(Store, Auth, Master_Path)
     ).
 
 :- begin_tests(rebase_race, [concurrent(false)]).
@@ -800,6 +979,55 @@ test(rebase_races_with_database_optimize,
             thread_send_message(OptimizeThread, stop),
             thread_join(OptimizeThread, OptimizeResult),
             assertion(OptimizeResult == true)
+        )
+    ).
+
+% Regression test for the race between rebase's history computation and a
+% concurrent insert on the target branch. Before the fix, the rebase failed
+% silently because the target branch head moved after the history was computed
+% and before the database commit, producing a final commit that was not a
+% descendant of the current head. After the fix, the rebase detects the change
+% inside the meta commit lock and retries once.
+test(rebase_races_with_target_branch_insert,
+     [setup((setup_temp_store(State),
+             create_db_without_schema("admin", "foo")
+            )),
+      cleanup((retractall(db_rebase:rebase_insert_thread(_)),
+               teardown_temp_store(State)))
+     ])
+:-
+    Master_Path = "admin/foo",
+    resolve_absolute_string_descriptor(Master_Path, Master_Descriptor),
+    super_user_authority(Auth),
+
+    % Commit on main so the target branch has a history to race with.
+    create_context(Master_Descriptor, commit_info{author:"test", message:"commit a"}, Ctx1),
+    with_transaction(Ctx1, ask(Ctx1, insert(a,b,c)), _),
+
+    % Create a feature branch with a commit so the rebase has work to do.
+    Feature_Path = "admin/foo/local/branch/feature",
+    branch_create(system_descriptor{}, Auth, Feature_Path, branch(Master_Path), _),
+    resolve_absolute_string_descriptor(Feature_Path, Feature_Descriptor),
+    create_context(Feature_Descriptor, commit_info{author:"test", message:"feature commit"}, Ctx2),
+    with_transaction(Ctx2, ask(Ctx2, insert(d,e,f)), _),
+
+    triple_store(Store),
+
+    % Start an insert thread that repeatedly commits on main until the rebase finishes.
+    setup_call_cleanup(
+        (   thread_create(
+                with_triple_store(Store,
+                                  insert_thread_loop(Store, Auth, Master_Path)),
+                InsertThread,
+                []
+            ),
+            assertz(db_rebase:rebase_insert_thread(InsertThread))
+        ),
+        rebase_on_branch(system_descriptor{}, Auth, Master_Path, Feature_Path, "rebaser", [], some(_), _, []),
+        (   db_rebase:rebase_insert_thread(InsertThread),
+            thread_send_message(InsertThread, stop),
+            thread_join(InsertThread, InsertResult),
+            assertion(InsertResult == true)
         )
     ).
 

--- a/src/core/api/db_rebase.pl
+++ b/src/core/api/db_rebase.pl
@@ -11,6 +11,21 @@
 :- use_module(core(account)).
 :- use_module(core(query)).
 :- use_module(core(transaction)).
+:- use_module(core(triple)).
+:- use_module(core(api/api_optimize)).
+:- use_module(core(document/meta_commit_queue)).
+
+:- dynamic rebase_pre_database_commit_hook/1.
+:- dynamic rebase_optimize_thread/1.
+
+% Default hook used by the race regression test. It is a no-op unless the
+% current test has registered an optimizer thread via rebase_optimize_thread/1.
+rebase_pre_database_commit_hook(_Database_Transaction_Object) :-
+    rebase_optimize_thread(OptimizeThread),
+    !,
+    thread_send_message(OptimizeThread, optimize_now),
+    sleep(0.05).
+rebase_pre_database_commit_hook(_) :- fail.
 
 cycle_context(Context, New_Context, New_Transaction_Object, Validation_Object) :-
     [Transaction_Object] = Context.transaction_objects,
@@ -249,12 +264,32 @@ rebase_on_branch(System_DB, Auth, Our_Branch_Path, Their_Branch_Path, Author, St
     Layer = Read_Write_Obj.read,
     layer_to_id(Layer, Layer_Id),
     Database_Transaction_Object = (Transaction_Object.parent),
+    database_descriptor{organization_name: Organization,
+                        database_name: Database} :< Database_Transaction_Object.descriptor,
+    organization_database_name(Organization, Database, Database_Key),
 
-    update_repository_head(Database_Transaction_Object, Repo_Name, Layer_Id),
+    % Hold the meta commit lock across the repository head update and the
+    % database commit. This prevents the auto-optimizer from changing the _meta
+    % head while the rebase is in its commit window.
+    meta_commit_queue:with_meta_commit_lock(
+        Database_Key,
+        db_rebase:(
+            update_repository_head(Database_Transaction_Object, Repo_Name, Layer_Id),
 
-    benchmark(after_repository_head_update),
+            benchmark(after_repository_head_update),
 
-    run_transactions([Database_Transaction_Object], true, _),
+            % Test hook: allows unit tests to interleave an optimization between
+            % the repository head update and the database commit, which is the
+            % exact window in which the auto-optimizer races with the rebase's
+            % _meta commit.
+            (   rebase_pre_database_commit_hook(Database_Transaction_Object)
+            ->  true
+            ;   true
+            ),
+
+            run_transactions([Database_Transaction_Object], true, _)
+        )
+    ),
     benchmark_subject_stop('rebase on branch').
 
 :- begin_tests(rebase, [concurrent(true)]).
@@ -692,3 +727,80 @@ test(rebase_conflict,
 
 
 :- end_tests(rebase).
+
+optimize_thread_loop(Store, Auth, Master_Meta_Path) :-
+    thread_get_message(Message),
+    (   Message == optimize_now
+    ->  api_optimize(system_descriptor{}, Auth, Master_Meta_Path)
+    ;   true
+    ),
+    (   Message == stop
+    ->  true
+    ;   optimize_thread_loop(Store, Auth, Master_Meta_Path)
+    ).
+
+:- begin_tests(rebase_race, [concurrent(false)]).
+:- use_module(core(util/test_utils)).
+:- use_module(core(query)).
+:- use_module(core(triple)).
+:- use_module(core(transaction)).
+:- use_module(core(account)).
+:- use_module(core(document)).
+:- use_module(db_create).
+:- use_module(db_branch).
+
+% Regression test for the race between rebase's database commit and a
+% concurrent optimization that squashes the _meta head. Before the fix, the
+% rebase fails because the new _meta layer is a child of the pre-squash head,
+% not the post-squash head. After the fix, the meta commit lock serializes the
+% two operations.
+%
+% The rebase path calls run_transactions/3 directly, without the retry that
+% can mask the race in with_transaction/4.
+test(rebase_races_with_database_optimize,
+     [setup((setup_temp_store(State),
+             create_db_without_schema("admin", "foo")
+            )),
+      cleanup((retractall(db_rebase:rebase_optimize_thread(_)),
+               teardown_temp_store(State)))
+     ])
+:-
+    Master_Path = "admin/foo",
+    resolve_absolute_string_descriptor(Master_Path, Master_Descriptor),
+    super_user_authority(Auth),
+
+    % Commit on main so _meta has a parent layer to squash.
+    create_context(Master_Descriptor, commit_info{author:"test", message:"commit a"}, Ctx1),
+    with_transaction(Ctx1, ask(Ctx1, insert(a,b,c)), _),
+
+    % Create a feature branch with a commit to rebase.
+    Feature_Path = "admin/foo/local/branch/feature",
+    branch_create(system_descriptor{}, Auth, Feature_Path, branch(Master_Path), _),
+    resolve_absolute_string_descriptor(Feature_Path, Feature_Descriptor),
+    create_context(Feature_Descriptor, commit_info{author:"test", message:"feature commit"}, Ctx2),
+    with_transaction(Ctx2, ask(Ctx2, insert(d,e,f)), _),
+
+    triple_store(Store),
+    Master_Meta_Path = "admin/foo/_meta",
+
+    % Start the optimizer thread before the rebase. The permanent hook in
+    % db_rebase.pl sends optimize_now to the registered thread exactly in the
+    % window between the repository head update and the database commit.
+    setup_call_cleanup(
+        (   thread_create(
+                with_triple_store(Store,
+                                  optimize_thread_loop(Store, Auth, Master_Meta_Path)),
+                OptimizeThread,
+                []
+            ),
+            assertz(db_rebase:rebase_optimize_thread(OptimizeThread))
+        ),
+        rebase_on_branch(system_descriptor{}, Auth, Master_Path, Feature_Path, "rebaser", [], some(_), _, []),
+        (   db_rebase:rebase_optimize_thread(OptimizeThread),
+            thread_send_message(OptimizeThread, stop),
+            thread_join(OptimizeThread, OptimizeResult),
+            assertion(OptimizeResult == true)
+        )
+    ).
+
+:- end_tests(rebase_race).

--- a/src/core/api/db_rebase.pl
+++ b/src/core/api/db_rebase.pl
@@ -30,8 +30,8 @@
               ]).
 
 :- dynamic rebase_pre_database_commit_hook/1.
+:- dynamic rebase_pre_lock_hook/1.
 :- dynamic rebase_optimize_thread/1.
-:- dynamic rebase_insert_thread/1.
 
 % Default hook used by the race regression test. It is a no-op unless the
 % current test has registered an optimizer thread via rebase_optimize_thread/1.
@@ -332,8 +332,9 @@ submit_rebase_contract(Contract, Result) :-
     ;   % No worker pool is running (e.g. PLUnit tests). Run the final commit
         % window synchronously in the request thread, but still under the
         % meta_commit_lock so the branch relink and repository head update are
-        % serialized.
+        % serialized. Ignore the result of the hook (used when race testing).
         get_dict(database_key, Contract, Database_Key),
+        ignore(rebase_pre_lock_hook(Contract)),
         with_meta_commit_lock(
             Database_Key,
             execute_rebase_contract(Contract, Result)
@@ -961,13 +962,16 @@ insert_race_doc(_Auth, Master_Path) :-
     create_context(Master_Descriptor, commit_info{author:"test", message:"race insert"}, Ctx),
     with_transaction(Ctx, ask(Ctx, insert(race,g,h)), _).
 
-insert_thread_loop(Store, Auth, Master_Path) :-
-    (   thread_peek_message(stop)
-    ->  thread_get_message(stop),
-        true
-    ;   catch(insert_race_doc(Auth, Master_Path), _, true),
-        sleep(0.01),
-        insert_thread_loop(Store, Auth, Master_Path)
+% Guard used by rebase_races_with_target_branch_insert to ensure the pre-lock
+% hook inserts exactly once, producing a deterministic single retry.
+:- dynamic rebase_race_insert_done/0.
+
+rebase_race_insert_once(Contract, Auth) :-
+    (   rebase_race_insert_done
+    ->  true
+    ;   get_dict(our_branch_path, Contract, Master_Path),
+        insert_race_doc(Auth, Master_Path),
+        assertz(rebase_race_insert_done)
     ).
 
 :- begin_tests(rebase_race, [concurrent(false)]).
@@ -1040,11 +1044,17 @@ test(rebase_races_with_database_optimize,
 % and before the database commit, producing a final commit that was not a
 % descendant of the current head. After the fix, the rebase detects the change
 % inside the meta commit lock and retries once.
+%
+% The race is triggered deterministically via the rebase_pre_lock_hook/1 test
+% hook: it runs after the rebase history has been computed but before the meta
+% commit lock is acquired, so the inserted document is guaranteed to move the
+% target branch head exactly once.
 test(rebase_races_with_target_branch_insert,
      [setup((setup_temp_store(State),
              create_db_without_schema("admin", "foo")
             )),
-      cleanup((retractall(db_rebase:rebase_insert_thread(_)),
+      cleanup((retractall(db_rebase:rebase_pre_lock_hook(_)),
+               retractall(db_rebase:rebase_race_insert_done),
                teardown_temp_store(State)))
      ])
 :-
@@ -1063,23 +1073,15 @@ test(rebase_races_with_target_branch_insert,
     create_context(Feature_Descriptor, commit_info{author:"test", message:"feature commit"}, Ctx2),
     with_transaction(Ctx2, ask(Ctx2, insert(d,e,f)), _),
 
-    triple_store(Store),
-
-    % Start an insert thread that repeatedly commits on main until the rebase finishes.
     setup_call_cleanup(
-        (   thread_create(
-                with_triple_store(Store,
-                                  insert_thread_loop(Store, Auth, Master_Path)),
-                InsertThread,
-                []
-            ),
-            assertz(db_rebase:rebase_insert_thread(InsertThread))
+        (   retractall(db_rebase:rebase_race_insert_done),
+            assertz((db_rebase:rebase_pre_lock_hook(Contract) :-
+                        db_rebase:rebase_race_insert_once(Contract, Auth)))
         ),
-        rebase_on_branch(system_descriptor{}, Auth, Master_Path, Feature_Path, "rebaser", [], some(_), _, []),
-        (   db_rebase:rebase_insert_thread(InsertThread),
-            thread_send_message(InsertThread, stop),
-            thread_join(InsertThread, InsertResult),
-            assertion(InsertResult == true)
+        rebase_on_branch(system_descriptor{}, Auth, Master_Path, Feature_Path,
+                         "rebaser", [], some(_), _, _Reports),
+        (   retractall(db_rebase:rebase_pre_lock_hook(_)),
+            retractall(db_rebase:rebase_race_insert_done)
         )
     ).
 

--- a/src/core/document/commit_queue.pl
+++ b/src/core/document/commit_queue.pl
@@ -131,17 +131,41 @@ ensure_branch_queue(BranchKey, Queue) :-
 destroy_branch_queue(BranchKey) :-
     with_mutex(branch_registry_mutex,
         (   (   branch_commit_queue(BranchKey, Queue)
-            ->  (   catch(message_queue_destroy(Queue), _, fail)
-                ->  retract(branch_commit_queue(BranchKey, _))
-                ;   true
-                )
+            ->  drain_message_queue(Queue),
+                catch(message_queue_destroy(Queue), _, true),
+                retractall(branch_commit_queue(BranchKey, _))
             ;   true
             ),
             (   branch_commit_lock(BranchKey, Mutex)
-            ->  (   catch(mutex_destroy(Mutex), _, fail)
-                ->  retract(branch_commit_lock(BranchKey, _))
-                ;   true
+            ->  catch(mutex_unlock(Mutex), _, true),
+                catch(mutex_destroy(Mutex), _, true),
+                retractall(branch_commit_lock(BranchKey, _))
+            ;   true
+            )
+        )),
+    cleanup_scheduler_state_for_branch(BranchKey).
+
+drain_message_queue(Queue) :-
+    catch(thread_get_message(Queue, _, [timeout(0)]), _, fail),
+    !,
+    drain_message_queue(Queue).
+drain_message_queue(_).
+
+cleanup_scheduler_state_for_branch(BranchKey) :-
+    with_mutex(commit_scheduler_mutex,
+        (   retractall(pending_branch_age(BranchKey, _)),
+            (   retract(pending_branches(Branches))
+            ->  (   select(BranchKey, Branches, Remaining)
+                ->  (   Remaining = []
+                    ->  true
+                    ;   assertz(pending_branches(Remaining))
+                    )
+                ;   assertz(pending_branches(Branches))
                 )
+            ;   true
+            ),
+            (   retract(active_branch(BranchKey, _))
+            ->  decrement_database_active_branch_count(BranchKey, _)
             ;   true
             )
         )).
@@ -816,6 +840,35 @@ test(requeue_branch_retracts_age_when_empty) :-
             retractall(commit_queue:pending_branch_age(_, _))
         )),
     destroy_branch_queue('age_b2').
+
+test(destroy_branch_queue_cleans_scheduler_state) :-
+    with_mutex(commit_scheduler_mutex,
+        (   retractall(commit_queue:pending_branches(_)),
+            retractall(commit_queue:active_branch(_, _)),
+            retractall(commit_queue:pending_branch_age(_, _))
+        )),
+    cleanup_active_branch_counts,
+    BranchKey = 'admin/db/local/branch/main',
+    ensure_branch_queue(BranchKey, Queue),
+    thread_send_message(Queue, dummy),
+    register_pending_branch(BranchKey),
+    thread_self(Self),
+    assertz(commit_queue:active_branch(BranchKey, Self)),
+    organization_database_name(admin, db, DBKey),
+    assertz(commit_queue:database_active_branch_count(DBKey, 1)),
+    destroy_branch_queue(BranchKey),
+    assertion(\+ commit_queue:branch_commit_queue(BranchKey, _)),
+    assertion(\+ commit_queue:branch_commit_lock(BranchKey, _)),
+    assertion(\+ commit_queue:pending_branch_age(BranchKey, _)),
+    assertion(\+ commit_queue:active_branch(BranchKey, _)),
+    assertion(\+ commit_queue:pending_branches([BranchKey])),
+    assertion(commit_queue:database_active_branch_count(DBKey, 0)),
+    with_mutex(commit_scheduler_mutex,
+        (   retractall(commit_queue:pending_branches(_)),
+            retractall(commit_queue:active_branch(_, _)),
+            retractall(commit_queue:pending_branch_age(_, _))
+        )),
+    cleanup_active_branch_counts.
 
 test(pending_commit_stale_detects_old_commit) :-
     with_mutex(commit_scheduler_mutex,

--- a/src/core/document/commit_queue.pl
+++ b/src/core/document/commit_queue.pl
@@ -109,22 +109,39 @@ ensure_branch_queue(BranchKey, Queue) :-
             ->  true
             ;   atom_string(BranchKeyAtom, BranchKey),
                 atom_concat('commit_queue_', BranchKeyAtom, QueueAlias),
-                message_queue_create(Queue, [alias(QueueAlias)]),
-                assertz(branch_commit_queue(BranchKey, Queue)),
                 atom_concat('commit_lock_', BranchKeyAtom, LockAlias),
-                mutex_create(Mutex, [alias(LockAlias)]),
+                (   catch(message_queue_create(Queue, [alias(QueueAlias)]),
+                          error(permission_error(create, message_queue, _), _),
+                          message_queue_property(Queue, alias(QueueAlias)))
+                ->  true
+                ;   throw(error(unable_to_create_branch_queue(BranchKey), _))
+                ),
+                (   catch(mutex_create(Mutex, [alias(LockAlias)]),
+                          error(permission_error(create, mutex, _), _),
+                          mutex_property(Mutex, alias(LockAlias)))
+                ->  true
+                ;   catch(message_queue_destroy(Queue), _, true),
+                    throw(error(unable_to_create_branch_lock(BranchKey), _))
+                ),
+                assertz(branch_commit_queue(BranchKey, Queue)),
                 assertz(branch_commit_lock(BranchKey, Mutex))
             ))
     ).
 
 destroy_branch_queue(BranchKey) :-
     with_mutex(branch_registry_mutex,
-        (   (   retract(branch_commit_queue(BranchKey, Queue))
-            ->  catch(message_queue_destroy(Queue), _, true)
+        (   (   branch_commit_queue(BranchKey, Queue)
+            ->  (   catch(message_queue_destroy(Queue), _, fail)
+                ->  retract(branch_commit_queue(BranchKey, _))
+                ;   true
+                )
             ;   true
             ),
-            (   retract(branch_commit_lock(BranchKey, Mutex))
-            ->  catch(mutex_destroy(Mutex), _, true)
+            (   branch_commit_lock(BranchKey, Mutex)
+            ->  (   catch(mutex_destroy(Mutex), _, fail)
+                ->  retract(branch_commit_lock(BranchKey, _))
+                ;   true
+                )
             ;   true
             )
         )).
@@ -536,13 +553,19 @@ run_queued_job_of_type(optimize_when_idle, Package) :-
     !,
     get_dict(branch_key, Package, BranchKey),
     branch_commit_queue(BranchKey, Queue),
-    (   queue_empty(Queue)
+    (   % Synchronous optimize requests from HTTP handlers carry a reply queue.
+        % Run them immediately: if two such optimizes are queued on the same
+        % branch, the deferral logic would otherwise livelock by repeatedly
+        % re-enqueueing each optimize behind the other.
+        get_dict(reply_queue, Package, _)
     ->  api_optimize:run_queued_optimize(Package)
-    ;   % More commits are pending on this branch. Defer the optimization so
-        % inserts are not blocked by the (potentially slow) optimize work. The
-        % branch will be requeued by the caller after the current package is
-        % processed, and the optimizer will be picked up again when the queue
-        % drains.
+    ;   queue_empty(Queue)
+    ->  api_optimize:run_queued_optimize(Package)
+    ;   % More commits are pending on this branch. Defer the scheduler-initiated
+        % optimization so inserts are not blocked by the (potentially slow)
+        % optimize work. The branch will be requeued by the caller after the
+        % current package is processed, and the optimizer will be picked up
+        % again when the queue drains.
         thread_send_message(Queue, Package),
         register_pending_branch(BranchKey),
         wake_workers
@@ -620,6 +643,19 @@ test(ensure_branch_queue_creates_queue_and_lock) :-
     assertion(message_queue_property(Queue, alias(_))),
     assertion(message_queue_property(Queue, size(0))),
     assertion(mutex_property(Mutex, alias(_))),
+    destroy_branch_queue('test_branch').
+
+test(ensure_branch_queue_reuses_existing_queue_when_fact_missing) :-
+    destroy_branch_queue('test_branch'),
+    ensure_branch_queue('test_branch', Queue1),
+    with_mutex(branch_registry_mutex,
+               (   retract(commit_queue:branch_commit_queue('test_branch', _)),
+                   retract(commit_queue:branch_commit_lock('test_branch', _))
+               )),
+    ensure_branch_queue('test_branch', Queue2),
+    assertion(Queue1 == Queue2),
+    branch_commit_queue('test_branch', Queue2),
+    branch_commit_lock('test_branch', _),
     destroy_branch_queue('test_branch').
 
 test(register_and_pick_pending_branch) :-

--- a/src/core/document/commit_queue.pl
+++ b/src/core/document/commit_queue.pl
@@ -9,6 +9,7 @@
               register_pending_branch/1,
               cleanup_active_branches_for_worker/1,
               try_commit_work/0,
+              try_global_optimization/0,
               process_one_commit/2,
               process_commit_batch/3,
               wake_workers/0,
@@ -21,13 +22,19 @@
               branch_commit_queue/2,
               branch_commit_lock/2,
               active_branch/2,
-              pending_branches/1
+              pending_branches/1,
+              schedule_database_optimization/1,
+              schedule_branch_optimization/1
           ]).
 
 :- use_module(config(terminus_config), [worker_amount/1]).
 :- use_module(core(util)).
 :- use_module(core(util/test_utils), [setup_temp_store/1, teardown_temp_store/1]).
 :- use_module(core(triple), [triple_store/1, with_triple_store/2]).
+:- use_module(core(transaction/descriptor), [branch_key_from_descriptor/2]).
+:- use_module(core(triple/database_utils), [organization_database_name/3]).
+:- use_module(core(document/meta_commit_queue)).
+:- use_module(core(api/api_optimize), [descriptor_optimize/1]).
 :- use_module(library(apply)).
 :- use_module(library(aggregate), [aggregate_all/3]).
 :- use_module(library(lists)).
@@ -43,6 +50,34 @@
 % pending_branch_age(BranchKey, Timestamp) records when BranchKey was first
 % registered as having queued commits. It is used to detect starving commits.
 :- dynamic pending_branch_age/2.
+
+% Optimization scheduling state.
+% pending_database_optimization(DatabaseKey, Descriptor) and
+% pending_branch_optimization(BranchKey, Descriptor) hold the optimization
+% that should run when the relevant queue drains. The *_due/1 variants mark
+% that a second request arrived while one was already pending, so it should
+% run as soon as possible rather than being dropped.
+:- dynamic pending_database_optimization/2.
+:- dynamic pending_branch_optimization/2.
+:- dynamic pending_database_optimization_due/1.
+:- dynamic pending_branch_optimization_due/1.
+
+% pending_global_optimization(DatabaseKey, Descriptor) and pending_global_optimization_due/1
+% hold database-level optimization work for database keys that have no tracked
+% branch activity (e.g. system_meta). These tasks are processed by idle commit
+% workers through a global task queue.
+:- dynamic pending_global_optimization/2.
+:- dynamic pending_global_optimization_due/1.
+
+% database_active_branch_count(DatabaseKey, Count) tracks how many branches of
+% a given database currently have an active commit worker. Used to know when a
+% database-wide _meta optimization can run safely.
+:- dynamic database_active_branch_count/2.
+
+% optimization_test_handler(Handler) can be asserted by tests to intercept
+% scheduled optimizations without running real descriptor_optimize/1. Handler is
+% a 2-argument predicate that will be called as call(Handler, Scope, Descriptor).
+:- dynamic optimization_test_handler/1.
 
 % Worker pool state.
 :- dynamic multi_purpose_worker_thread/1.
@@ -144,7 +179,8 @@ pick_next_branch(BranchKey, WorkerId) :-
             pick_first_non_active(Branches, BranchKey, Rest)
         ->  retract(pending_branches(Branches)),
             assertz(pending_branches(Rest)),
-            assertz(active_branch(BranchKey, WorkerId))
+            assertz(active_branch(BranchKey, WorkerId)),
+            increment_database_active_branch_count(BranchKey)
         ;   fail
         )).
 
@@ -156,10 +192,15 @@ pick_first_non_active([Branch|Rest], Picked, [Branch|Remaining]) :-
 
 requeue_branch(BranchKey) :-
     thread_self(WorkerId),
+    requeue_branch(BranchKey, WorkerId).
+
+requeue_branch(BranchKey, WorkerId) :-
     with_mutex(commit_scheduler_mutex,
         (   (   retract(active_branch(BranchKey, WorkerId))
-            ->  true
-            ;   true  % tolerate stale cleanup from a different worker
+            ->  decrement_database_active_branch_count(BranchKey, NewCount),
+                ActiveRetracted = true
+            ;   ActiveRetracted = false,
+                NewCount = unknown
             ),
             (   pending_branches(Branches)
             ->  (   member(BranchKey, Branches)
@@ -186,8 +227,228 @@ requeue_branch(BranchKey) :-
                     assertz(pending_branch_age(BranchKey, Now))
                 )
             ;   retractall(pending_branch_age(BranchKey, _))
+            ),
+            (   ActiveRetracted == true
+            ->  branch_key_database_key(BranchKey, DatabaseKey),
+                collect_pending_optimizations(BranchKey, DatabaseKey, Requeued, NewCount, BranchOpt, DatabaseOpt)
+            ;   BranchOpt = none,
+                DatabaseOpt = none
             )
-        )).
+        )),
+    run_collected_optimization(branch, BranchOpt),
+    run_collected_optimization(database, DatabaseOpt).
+
+% Database key helpers.
+%
+% branch_key_database_key(+BranchKey, -DatabaseKey) extracts the database lock
+% key from a resolved branch key such as "admin/db/local/branch/main". The
+% result must match the key produced by database_key_from_descriptor/2 so that
+% active-branch counts and scheduled database optimizations use the same key.
+branch_key_database_key(BranchKey, DatabaseKey) :-
+    (   atom_string(AtomKey, BranchKey),
+        sub_atom(AtomKey, Before, _, _, '/local/branch/')
+    ->  sub_atom(AtomKey, 0, Before, _, PrefixAtom),
+        (   atomic_list_concat([Org, DB], '/', PrefixAtom)
+        ->  organization_database_name(Org, DB, DatabaseKey)
+        ;   DatabaseKey = PrefixAtom
+        )
+    ;   atom_string(DatabaseKey, BranchKey)
+    ).
+
+% database_key_from_descriptor(+Descriptor, -DatabaseKey) maps any descriptor
+% to the lock key of the database it belongs to.
+database_key_from_descriptor(Descriptor, DatabaseKey) :-
+    (   system_descriptor{} :< Descriptor
+    ->  DatabaseKey = system_meta
+    ;   database_descriptor{organization_name: Org, database_name: DB} :< Descriptor
+    ->  organization_database_name(Org, DB, DatabaseKey)
+    ;   repository_descriptor{database_descriptor: DB_Desc} :< Descriptor
+    ->  database_key_from_descriptor(DB_Desc, DatabaseKey)
+    ;   branch_descriptor{repository_descriptor: Repo_Desc} :< Descriptor
+    ->  database_key_from_descriptor(Repo_Desc, DatabaseKey)
+    ;   fail
+    ).
+
+increment_database_active_branch_count(BranchKey) :-
+    branch_key_database_key(BranchKey, DatabaseKey),
+    (   retract(database_active_branch_count(DatabaseKey, Count))
+    ->  NewCount is Count + 1,
+        assertz(database_active_branch_count(DatabaseKey, NewCount))
+    ;   assertz(database_active_branch_count(DatabaseKey, 1))
+    ).
+
+decrement_database_active_branch_count(BranchKey, NewCount) :-
+    branch_key_database_key(BranchKey, DatabaseKey),
+    (   retract(database_active_branch_count(DatabaseKey, Count))
+    ->  NewCount is Count - 1,
+        (   NewCount < 0
+        ->  throw(error(active_branch_count_negative(DatabaseKey), _))
+        ;   assertz(database_active_branch_count(DatabaseKey, NewCount))
+        )
+    ;   NewCount = 0,
+        assertz(database_active_branch_count(DatabaseKey, 0))
+    ).
+
+% Optimization scheduling.
+%
+% schedule_branch_optimization(+BranchDescriptor) and
+% schedule_database_optimization(+DatabaseDescriptor) are called from the
+% auto-optimize plugin. They record the requested optimization and wake workers
+% so it runs when the relevant queue drains.
+schedule_branch_optimization(Descriptor) :-
+    branch_descriptor{} :< Descriptor,
+    !,
+    branch_key_from_descriptor(Descriptor, BranchKey),
+    with_mutex(commit_scheduler_mutex,
+        (
+            (   (   pending_branch_optimization(BranchKey, _)
+                ;   pending_branch_optimization_due(BranchKey)
+                )
+            ->  assertz(pending_branch_optimization_due(BranchKey))
+            ;   true
+            ),
+            (   retract(pending_branch_optimization(BranchKey, _))
+            ->  true
+            ;   true
+            ),
+            assertz(pending_branch_optimization(BranchKey, Descriptor))
+        )
+    ),
+    wake_workers.
+
+schedule_database_optimization(Descriptor) :-
+    (   system_descriptor{} :< Descriptor
+    ;   database_descriptor{} :< Descriptor
+    ;   repository_descriptor{} :< Descriptor
+    ),
+    !,
+    database_key_from_descriptor(Descriptor, DatabaseKey),
+    (   database_active_branch_count(DatabaseKey, _)
+    ->  with_mutex(commit_scheduler_mutex,
+            (
+                (   (   pending_database_optimization(DatabaseKey, _)
+                    ;   pending_database_optimization_due(DatabaseKey)
+                    )
+                ->  assertz(pending_database_optimization_due(DatabaseKey))
+                ;   true
+                ),
+                (   retract(pending_database_optimization(DatabaseKey, _))
+                ->  true
+                ;   true
+                ),
+                assertz(pending_database_optimization(DatabaseKey, Descriptor))
+            )
+        ),
+        wake_workers
+    ;   % No tracked branch activity for this database (e.g. system). There is
+        % no branch queue to drain, so schedule the work on the global task
+        % queue and let idle commit workers process it.
+        with_mutex(commit_scheduler_mutex,
+            (
+                (   (   pending_global_optimization(DatabaseKey, _)
+                    ;   pending_global_optimization_due(DatabaseKey)
+                    )
+                ->  assertz(pending_global_optimization_due(DatabaseKey))
+                ;   true
+                ),
+                (   retract(pending_global_optimization(DatabaseKey, _))
+                ->  true
+                ;   true
+                ),
+                assertz(pending_global_optimization(DatabaseKey, Descriptor))
+            )
+        ),
+        wake_workers
+    ).
+
+collect_pending_optimizations(BranchKey, DatabaseKey, Requeued, NewCount, BranchOpt, DatabaseOpt) :-
+    (   Requeued == false,
+        (   pending_branch_optimization_due(BranchKey)
+        ;   pending_branch_optimization(BranchKey, _)
+        )
+    ->  retractall(pending_branch_optimization_due(BranchKey)),
+        (   retract(pending_branch_optimization(BranchKey, Descriptor))
+        ->  BranchOpt = some(Descriptor)
+        ;   BranchOpt = none
+        )
+    ;   BranchOpt = none
+    ),
+    (   NewCount == 0,
+        (   pending_database_optimization_due(DatabaseKey)
+        ;   pending_database_optimization(DatabaseKey, _)
+        )
+    ->  retractall(pending_database_optimization_due(DatabaseKey)),
+        (   retract(pending_database_optimization(DatabaseKey, Descriptor))
+        ->  DatabaseOpt = some(Descriptor)
+        ;   DatabaseOpt = none
+        )
+    ;   DatabaseOpt = none
+    ).
+
+run_collected_optimization(_, none) :- !.
+run_collected_optimization(branch, some(Descriptor)) :-
+    optimization_test_handler(Handler),
+    !,
+    once(call(Handler, branch, Descriptor)).
+run_collected_optimization(branch, some(Descriptor)) :-
+    !,
+    run_branch_optimization(Descriptor).
+run_collected_optimization(database, some(Descriptor)) :-
+    optimization_test_handler(Handler),
+    !,
+    once(call(Handler, database, Descriptor)).
+run_collected_optimization(database, some(Descriptor)) :-
+    !,
+    run_database_optimization(Descriptor).
+
+run_branch_optimization(Descriptor) :-
+    branch_key_from_descriptor(Descriptor, BranchKey),
+    database_key_from_descriptor(Descriptor, DatabaseKey),
+    catch(
+        with_meta_commit_lock(
+            DatabaseKey,
+            descriptor_optimize(Descriptor)
+        ),
+        Error,
+        log_optimization_error(branch, BranchKey, Error)
+    ).
+
+run_database_optimization(Descriptor) :-
+    database_key_from_descriptor(Descriptor, DatabaseKey),
+    catch(
+        with_meta_commit_lock(
+            DatabaseKey,
+            descriptor_optimize(Descriptor)
+        ),
+        Error,
+        log_optimization_error(database, DatabaseKey, Error)
+    ).
+
+% try_global_optimization/0 is semidet.
+%
+% Called by idle commit workers. It atomically picks one pending global
+% optimization (and clears its due flag), runs it under the database meta lock,
+% and removes the pending fact. Succeeds when a task was processed; fails when
+% the global queue is empty.
+try_global_optimization :-
+    with_mutex(commit_scheduler_mutex,
+        (   (   pending_global_optimization_due(DatabaseKey)
+            ;   pending_global_optimization(DatabaseKey, _)
+            )
+        ->  retractall(pending_global_optimization_due(DatabaseKey)),
+            (   retract(pending_global_optimization(DatabaseKey, Descriptor))
+            ->  Task = some(DatabaseKey, Descriptor)
+            ;   Task = none
+            )
+        ;   Task = none
+        )
+    ),
+    Task = some(DatabaseKey, Descriptor),
+    !,
+    run_collected_optimization(database, some(Descriptor)).
+
+log_optimization_error(Scope, Key, Error) :-
+    json_log_error_formatted("Scheduled ~w optimization for ~w failed: ~w", [Scope, Key, Error]).
 
 % pending_commit_stale(+ThresholdSeconds) is semidet.
 %
@@ -202,7 +463,9 @@ pending_commit_stale(ThresholdSeconds) :-
 
 cleanup_active_branches_for_worker(WorkerId) :-
     with_mutex(commit_scheduler_mutex,
-        forall(retract(active_branch(_, WorkerId)), true)).
+        findall(BranchKey, active_branch(BranchKey, WorkerId), Branches)),
+    forall(member(BranchKey, Branches),
+           requeue_branch(BranchKey, WorkerId)).
 
 try_commit_work :-
     thread_self(WorkerId),
@@ -229,7 +492,7 @@ process_one_commit(BranchKey, true) :-
     thread_get_message(Queue, Package, [timeout(0)]),
     !,
     catch(
-        api_document:run_commit_package(Package),
+        run_queued_job(Package),
         Error,
         deliver_commit_error(Package, Error)
     ).
@@ -241,13 +504,51 @@ process_commit_batch(BranchKey, Max, true) :-
     thread_get_message(Queue, Package, [timeout(0)]),
     !,
     catch(
-        api_document:run_commit_package(Package),
+        run_queued_job(Package),
         Error,
         deliver_commit_error(Package, Error)
     ),
     Max1 is Max - 1,
     process_commit_batch(BranchKey, Max1, _).
 process_commit_batch(_, _, false).
+
+% run_queued_job(+Package) is det.
+%
+% Dispatch a queued package to the correct handler based on its package_type.
+% Existing commit packages do not have package_type, so they default to the
+% document commit handler. New contract types (rebase, optimize) are routed to
+% their own handlers so they can run under the branch lock and acquire the
+% meta_commit_lock only after the branch lock is already held.
+run_queued_job(Package) :-
+    (   get_dict(package_type, Package, Type)
+    ->  true
+    ;   Type = commit
+    ),
+    run_queued_job_of_type(Type, Package).
+
+run_queued_job_of_type(commit, Package) :-
+    !,
+    api_document:run_commit_package(Package).
+run_queued_job_of_type(rebase, Package) :-
+    !,
+    db_rebase:run_rebase_contract(Package).
+run_queued_job_of_type(optimize_when_idle, Package) :-
+    !,
+    get_dict(branch_key, Package, BranchKey),
+    branch_commit_queue(BranchKey, Queue),
+    (   queue_empty(Queue)
+    ->  api_optimize:run_queued_optimize(Package)
+    ;   % More commits are pending on this branch. Defer the optimization so
+        % inserts are not blocked by the (potentially slow) optimize work. The
+        % branch will be requeued by the caller after the current package is
+        % processed, and the optimizer will be picked up again when the queue
+        % drains.
+        thread_send_message(Queue, Package),
+        register_pending_branch(BranchKey),
+        wake_workers
+    ).
+run_queued_job_of_type(Type, Package) :-
+    throw(error(unknown_package_type(Type, Package), _)).
 
 % Send an error result back to the original requester's reply queue. The queue
 % may already be gone if the requester has exited, in which case the failure is
@@ -379,17 +680,51 @@ test(cleanup_active_branches_for_worker) :-
         (   retractall(commit_queue:pending_branches(_)),
             retractall(commit_queue:active_branch(_, _))
         )),
+    cleanup_active_branch_counts,
     assertz(commit_queue:active_branch('b1', worker_1)),
     assertz(commit_queue:active_branch('b2', worker_1)),
     assertz(commit_queue:active_branch('b3', worker_2)),
+    assertz(commit_queue:database_active_branch_count('b1', 1)),
+    assertz(commit_queue:database_active_branch_count('b2', 1)),
+    assertz(commit_queue:database_active_branch_count('b3', 1)),
     cleanup_active_branches_for_worker(worker_1),
     assertion(\+ commit_queue:active_branch('b1', worker_1)),
     assertion(\+ commit_queue:active_branch('b2', worker_1)),
     assertion(commit_queue:active_branch('b3', worker_2)),
+    assertion(commit_queue:database_active_branch_count('b1', 0)),
+    assertion(commit_queue:database_active_branch_count('b2', 0)),
+    assertion(commit_queue:database_active_branch_count('b3', 1)),
     with_mutex(commit_scheduler_mutex,
         (   retractall(commit_queue:pending_branches(_)),
             retractall(commit_queue:active_branch(_, _))
-        )).
+        )),
+    cleanup_active_branch_counts.
+
+test(cleanup_active_branches_for_worker_requeues_pending_commits) :-
+    BranchKey = 'admin/db/local/branch/main',
+    with_mutex(commit_scheduler_mutex,
+        (   retractall(commit_queue:pending_branches(_)),
+            retractall(commit_queue:active_branch(_, _)),
+            retractall(commit_queue:pending_branch_age(_, _))
+        )),
+    cleanup_active_branch_counts,
+    ensure_branch_queue(BranchKey, Queue),
+    thread_send_message(Queue, dummy_package),
+    assertz(commit_queue:active_branch(BranchKey, worker_1)),
+    organization_database_name(admin, db, DBKey),
+    assertz(commit_queue:database_active_branch_count(DBKey, 1)),
+    cleanup_active_branches_for_worker(worker_1),
+    assertion(\+ commit_queue:active_branch(BranchKey, worker_1)),
+    assertion(commit_queue:database_active_branch_count(DBKey, 0)),
+    assertion(commit_queue:pending_branches([BranchKey])),
+    assertion(commit_queue:pending_branch_age(BranchKey, _)),
+    with_mutex(commit_scheduler_mutex,
+        (   retractall(commit_queue:pending_branches(_)),
+            retractall(commit_queue:active_branch(_, _)),
+            retractall(commit_queue:pending_branch_age(_, _))
+        )),
+    cleanup_active_branch_counts,
+    destroy_branch_queue(BranchKey).
 
 test(register_pending_branch_records_age) :-
     with_mutex(commit_scheduler_mutex,
@@ -693,11 +1028,169 @@ test(shared_queue_wakes_multiple_workers) :-
     thread_join(Thread2, true),
     message_queue_destroy(SharedQueue).
 
+% Scheduling-state and active-branch tracking tests.
+
+test(branch_key_database_key_resolved_and_plain) :-
+    branch_key_database_key("admin/db/local/branch/main", Key),
+    organization_database_name(admin, db, ExpectedKey),
+    assertion(Key == ExpectedKey),
+    branch_key_database_key("plain_test", PlainKey),
+    assertion(PlainKey == 'plain_test').
+
+test(database_key_from_descriptor_maps_correctly) :-
+    database_key_from_descriptor(system_descriptor{}, system_meta),
+    database_key_from_descriptor(database_descriptor{organization_name: "admin", database_name: "db"}, Key),
+    organization_database_name("admin", "db", Expected),
+    assertion(Key == Expected).
+
+test(active_branch_count_tracks_increments_and_decrements) :-
+    cleanup_active_branch_counts,
+    organization_database_name(admin, db, DBKey),
+    increment_database_active_branch_count("admin/db/local/branch/main"),
+    assertion(commit_queue:database_active_branch_count(DBKey, 1)),
+    increment_database_active_branch_count("admin/db/local/branch/other"),
+    assertion(commit_queue:database_active_branch_count(DBKey, 2)),
+    decrement_database_active_branch_count("admin/db/local/branch/main", Count1),
+    assertion(Count1 == 1),
+    assertion(commit_queue:database_active_branch_count(DBKey, 1)),
+    decrement_database_active_branch_count("admin/db/local/branch/other", Count2),
+    assertion(Count2 == 0),
+    assertion(commit_queue:database_active_branch_count(DBKey, 0)).
+
+test(active_branch_count_negative_throws, [throws(error(active_branch_count_negative(DBKey), _))]) :-
+    cleanup_active_branch_counts,
+    organization_database_name(admin, db, DBKey),
+    assertz(commit_queue:database_active_branch_count(DBKey, 0)),
+    decrement_database_active_branch_count("admin/db/local/branch/main", _).
+
+test(schedule_database_optimization_records_pending_and_due) :-
+    cleanup_optimization_state,
+    cleanup_active_branch_counts,
+    DB_Descriptor = database_descriptor{organization_name: "admin", database_name: "db"},
+    database_key_from_descriptor(DB_Descriptor, DB_Key),
+    assertz(commit_queue:database_active_branch_count(DB_Key, 1)),
+    schedule_database_optimization(DB_Descriptor),
+    assertion(commit_queue:pending_database_optimization(DB_Key, DB_Descriptor)),
+    schedule_database_optimization(DB_Descriptor),
+    assertion(commit_queue:pending_database_optimization_due(DB_Key)),
+    assertion(commit_queue:pending_database_optimization(DB_Key, DB_Descriptor)).
+
+test(schedule_database_optimization_due_resets_pending) :-
+    cleanup_optimization_state,
+    cleanup_active_branch_counts,
+    DB_Descriptor = database_descriptor{organization_name: "admin", database_name: "db"},
+    database_key_from_descriptor(DB_Descriptor, DB_Key),
+    assertz(commit_queue:database_active_branch_count(DB_Key, 1)),
+    assertz(commit_queue:pending_database_optimization(DB_Key, old_descriptor)),
+    schedule_database_optimization(DB_Descriptor),
+    assertion(commit_queue:pending_database_optimization(DB_Key, DB_Descriptor)),
+    assertion(commit_queue:pending_database_optimization_due(DB_Key)).
+
+test(database_optimization_runs_when_all_branches_inactive) :-
+    cleanup_optimization_state,
+    cleanup_active_branch_counts,
+    cleanup_workers_and_branches,
+    DB_Descriptor = database_descriptor{organization_name: "admin", database_name: "db"},
+    database_key_from_descriptor(DB_Descriptor, DB_Key),
+    BranchKey = "admin/db/local/branch/main",
+    assertz(commit_queue:optimization_test_handler(test_optimize_handler)),
+    assertz(commit_queue:pending_database_optimization(DB_Key, DB_Descriptor)),
+    thread_self(Self),
+    assertz(commit_queue:active_branch(BranchKey, Self)),
+    assertz(commit_queue:database_active_branch_count(DB_Key, 1)),
+    requeue_branch(BranchKey),
+    assertion(commit_queue:called_optimization(database, DB_Descriptor)),
+    assertion(\+ commit_queue:pending_database_optimization(DB_Key, _)),
+    assertion(\+ commit_queue:pending_database_optimization_due(DB_Key)),
+    cleanup_optimization_state,
+    cleanup_active_branch_counts,
+    cleanup_workers_and_branches.
+
+test(system_database_optimization_schedules_on_global_queue) :-
+    cleanup_optimization_state,
+    cleanup_active_branch_counts,
+    assertz(commit_queue:optimization_test_handler(test_optimize_handler)),
+    schedule_database_optimization(system_descriptor{}),
+    assertion(commit_queue:pending_global_optimization(system_meta, system_descriptor{})),
+    assertion(\+ commit_queue:pending_database_optimization(system_meta, _)),
+    try_global_optimization,
+    assertion(commit_queue:called_optimization(database, system_descriptor{})),
+    assertion(\+ commit_queue:pending_global_optimization(system_meta, _)),
+    assertion(\+ commit_queue:pending_global_optimization_due(system_meta)),
+    cleanup_optimization_state,
+    cleanup_active_branch_counts.
+
+test(global_queue_optimization_due_flag_set_on_second_schedule) :-
+    cleanup_optimization_state,
+    cleanup_active_branch_counts,
+    assertz(commit_queue:optimization_test_handler(test_optimize_handler)),
+    schedule_database_optimization(system_descriptor{}),
+    schedule_database_optimization(system_descriptor{}),
+    assertion(commit_queue:pending_global_optimization_due(system_meta)),
+    try_global_optimization,
+    assertion(commit_queue:called_optimization(database, system_descriptor{})),
+    assertion(\+ commit_queue:pending_global_optimization(system_meta, _)),
+    assertion(\+ commit_queue:pending_global_optimization_due(system_meta)),
+    cleanup_optimization_state,
+    cleanup_active_branch_counts.
+
+test(branch_optimization_runs_when_queue_empties) :-
+    cleanup_optimization_state,
+    cleanup_workers_and_branches,
+    destroy_branch_queue('opt_branch'),
+    ensure_branch_queue('opt_branch', _Queue),
+    assertz(commit_queue:optimization_test_handler(test_optimize_handler)),
+    assertz(commit_queue:pending_branch_optimization('opt_branch', branch_descriptor{})),
+    thread_self(Self),
+    assertz(commit_queue:active_branch('opt_branch', Self)),
+    requeue_branch('opt_branch'),
+    assertion(commit_queue:called_optimization(branch, branch_descriptor{})),
+    assertion(\+ commit_queue:pending_branch_optimization('opt_branch', _)),
+    assertion(\+ commit_queue:pending_branch_optimization_due('opt_branch')),
+    cleanup_optimization_state,
+    cleanup_workers_and_branches,
+    destroy_branch_queue('opt_branch').
+
+test(second_branch_optimization_runs_as_soon_as_branch_drains) :-
+    cleanup_optimization_state,
+    cleanup_workers_and_branches,
+    destroy_branch_queue('opt_branch2'),
+    ensure_branch_queue('opt_branch2', Queue),
+    thread_send_message(Queue, dummy),
+    assertz(commit_queue:optimization_test_handler(test_optimize_handler)),
+    assertz(commit_queue:pending_branch_optimization('opt_branch2', branch_descriptor{})),
+    assertz(commit_queue:pending_branch_optimization_due('opt_branch2')),
+    thread_self(Self),
+    assertz(commit_queue:active_branch('opt_branch2', Self)),
+    requeue_branch('opt_branch2'),
+    % The queue still has a message, so the branch is requeued and the
+    % optimization must not run yet.
+    assertion(\+ commit_queue:called_optimization(branch, _)),
+    assertion(commit_queue:pending_branch_optimization('opt_branch2', _)),
+    assertion(commit_queue:pending_branch_optimization_due('opt_branch2')),
+    % Drain the message and become active again, as a worker would after
+    % pick_next_branch picks up the branch from pending_branches.
+    thread_get_message(Queue, dummy),
+    with_mutex(commit_scheduler_mutex,
+        retractall(commit_queue:pending_branches(_))),
+    assertz(commit_queue:active_branch('opt_branch2', Self)),
+    increment_database_active_branch_count('opt_branch2'),
+    requeue_branch('opt_branch2'),
+    assertion(commit_queue:called_optimization(branch, branch_descriptor{})),
+    assertion(\+ commit_queue:pending_branch_optimization('opt_branch2', _)),
+    assertion(\+ commit_queue:pending_branch_optimization_due('opt_branch2')),
+    cleanup_optimization_state,
+    cleanup_workers_and_branches,
+    destroy_branch_queue('opt_branch2').
+
 :- end_tests(commit_queue).
 
 % Test helpers. These live in the commit_queue module so they can be
 % passed as handlers to api_document:execute_commit_package/2 and invoked
 % from worker threads created by tests.
+
+% Recorded by test_optimize_handler/2 during scheduled-optimization tests.
+:- dynamic called_optimization/2.
 
 cleanup_workers_and_branches :-
     stop_workers,
@@ -705,6 +1198,25 @@ cleanup_workers_and_branches :-
         (   retractall(commit_queue:pending_branches(_)),
             retractall(commit_queue:active_branch(_, _))
         )).
+
+cleanup_optimization_state :-
+    with_mutex(commit_scheduler_mutex,
+        (   retractall(commit_queue:pending_database_optimization(_, _)),
+            retractall(commit_queue:pending_branch_optimization(_, _)),
+            retractall(commit_queue:pending_global_optimization(_, _)),
+            retractall(commit_queue:pending_database_optimization_due(_)),
+            retractall(commit_queue:pending_branch_optimization_due(_)),
+            retractall(commit_queue:pending_global_optimization_due(_)),
+            retractall(commit_queue:optimization_test_handler(_)),
+            retractall(commit_queue:called_optimization(_, _))
+        )).
+
+cleanup_active_branch_counts :-
+    with_mutex(commit_scheduler_mutex,
+        retractall(commit_queue:database_active_branch_count(_, _))).
+
+test_optimize_handler(Scope, Descriptor) :-
+    assertz(called_optimization(Scope, Descriptor)).
 
 success_handler(P, success(test_meta, [test_id])) :-
     get_dict(test_marker, P, true).

--- a/src/core/document/meta_commit_queue.pl
+++ b/src/core/document/meta_commit_queue.pl
@@ -1,7 +1,9 @@
 :- module(meta_commit_queue, [
               with_meta_commit_lock/2,
               with_meta_commit_locks/2,
-              database_descriptor_key/2
+              database_descriptor_key/2,
+              graph_label_to_lock_key/2,
+              system_meta_lock_key/1
           ]).
 
 /** <module> Meta commit queue
@@ -19,6 +21,11 @@
 
 :- use_module(core(util)).
 :- use_module(core(triple/database_utils), [organization_database_name/3]).
+:- use_module(core(triple/constants), [system_instance_name/1,
+                                       system_schema_name/1,
+                                       system_inference_name/1]).
+:- use_module(library(lists)).
+:- use_module(library(plunit)).
 
 :- dynamic meta_commit_lock/2.
 :- thread_local held_meta_commit_lock/1.
@@ -73,3 +80,55 @@ with_meta_commit_locks_([Key|Keys], Goal) :-
             retract(held_meta_commit_lock(Key))
         )
     ).
+
+system_meta_lock_key(system_meta).
+
+graph_label_to_lock_key(Graph_Label, Lock_Key) :-
+    (   system_graph_label(Graph_Label)
+    ->  system_meta_lock_key(Lock_Key)
+    ;   atom(Graph_Label),
+        atomic_list_concat(Parts, '|', Graph_Label),
+        Parts = [Organization, DB|_]
+    ->  organization_database_name(Organization, DB, Lock_Key)
+    ;   Lock_Key = Graph_Label
+    ).
+
+system_graph_label(Graph_Label) :-
+    (   system_instance_name(Graph_Label)
+    ;   system_schema_name(Graph_Label)
+    ;   system_inference_name(Graph_Label)
+    ),
+    !.
+
+:- begin_tests(meta_commit_queue).
+
+test(system_instance_label_maps_to_system_meta) :-
+    system_instance_name(Graph_Label),
+    graph_label_to_lock_key(Graph_Label, system_meta).
+
+test(system_schema_label_maps_to_system_meta) :-
+    system_schema_name(Graph_Label),
+    graph_label_to_lock_key(Graph_Label, system_meta).
+
+test(database_meta_label_maps_to_itself) :-
+    organization_database_name(admin, test, Key),
+    graph_label_to_lock_key(Key, Key).
+
+test(repo_commits_label_maps_to_database_key) :-
+    organization_database_name(admin, test, DBKey),
+    atomic_list_concat([admin, test, local, '_commits'], '|', RepoLabel),
+    graph_label_to_lock_key(RepoLabel, DBKey).
+
+test(branch_instance_label_maps_to_database_key) :-
+    organization_database_name(admin, test, DBKey),
+    atomic_list_concat([admin, test, local, branch, main, instance], '|', BranchLabel),
+    graph_label_to_lock_key(BranchLabel, DBKey).
+
+test(lock_is_recursive_within_same_thread) :-
+    Key = recursive_test_key,
+    with_meta_commit_lock(
+        Key,
+        meta_commit_queue:(with_meta_commit_lock(Key, true))
+    ).
+
+:- end_tests(meta_commit_queue).

--- a/src/core/document/meta_commit_queue.pl
+++ b/src/core/document/meta_commit_queue.pl
@@ -128,7 +128,7 @@ test(lock_is_recursive_within_same_thread) :-
     Key = recursive_test_key,
     with_meta_commit_lock(
         Key,
-        meta_commit_queue:(with_meta_commit_lock(Key, true))
+        with_meta_commit_lock(Key, true)
     ).
 
 :- end_tests(meta_commit_queue).

--- a/src/core/document/meta_commit_queue.pl
+++ b/src/core/document/meta_commit_queue.pl
@@ -1,0 +1,75 @@
+:- module(meta_commit_queue, [
+              with_meta_commit_lock/2,
+              with_meta_commit_locks/2,
+              database_descriptor_key/2
+          ]).
+
+/** <module> Meta commit queue
+ *
+ * Lightweight, per-database recursive lock used to serialize commits to the
+ * shared `_meta` graph. The auto-optimizer also acquires this lock so that it
+ * cannot change the `_meta` head while a branch/database state-changing
+ * operation is in its commit window.
+ *
+ * The lock is recursive: a thread that already holds the lock may re-enter
+ * without deadlocking. This is important because high-level operations such as
+ * rebase hold the lock while calling run_transactions/3, which then attempts to
+ * acquire the same lock for the database transaction object.
+ */
+
+:- use_module(core(util)).
+:- use_module(core(triple/database_utils), [organization_database_name/3]).
+
+:- dynamic meta_commit_lock/2.
+:- thread_local held_meta_commit_lock/1.
+
+:- initialization(mutex_create(meta_commit_lock_creation, [])).
+
+:- meta_predicate with_meta_commit_lock(+, :).
+:- meta_predicate with_meta_commit_locks(+, :).
+:- meta_predicate with_meta_commit_locks_(+, :).
+
+database_descriptor_key(database_descriptor{organization_name: Organization,
+                                          database_name: Database},
+                        Key) :-
+    organization_database_name(Organization, Database, Key).
+
+ensure_meta_commit_lock(Key) :-
+    (   meta_commit_lock(Key, _)
+    ->  true
+    ;   with_mutex(meta_commit_lock_creation,
+                   (   meta_commit_lock(Key, _)
+                   ->  true
+                   ;   mutex_create(Mutex, []),
+                       assertz(meta_commit_lock(Key, Mutex))
+                   ))
+    ).
+
+with_meta_commit_lock(Key, Goal) :-
+    ensure_meta_commit_lock(Key),
+    (   held_meta_commit_lock(Key)
+    ->  call(Goal)
+    ;   meta_commit_lock(Key, Mutex),
+        assertz(held_meta_commit_lock(Key)),
+        call_cleanup(
+            with_mutex(Mutex, call(Goal)),
+            retract(held_meta_commit_lock(Key))
+        )
+    ).
+
+with_meta_commit_locks(Keys, Goal) :-
+    with_meta_commit_locks_(Keys, Goal).
+
+with_meta_commit_locks_([], Goal) :-
+    call(Goal).
+with_meta_commit_locks_([Key|Keys], Goal) :-
+    ensure_meta_commit_lock(Key),
+    (   held_meta_commit_lock(Key)
+    ->  with_meta_commit_locks_(Keys, Goal)
+    ;   meta_commit_lock(Key, Mutex),
+        assertz(held_meta_commit_lock(Key)),
+        call_cleanup(
+            with_mutex(Mutex, with_meta_commit_locks_(Keys, Goal)),
+            retract(held_meta_commit_lock(Key))
+        )
+    ).

--- a/src/core/document/parallel_elaboration.pl
+++ b/src/core/document/parallel_elaboration.pl
@@ -383,7 +383,7 @@ acquire_commit_window_guard(Transaction, BranchKey, CommitId) :-
     (   retract(commit_window_guard_depth(D, Info))
     ->  D1 is D + 1,
         assertz(commit_window_guard_depth(D1, Info))
-    ;   open_commit_window_for_branch_head(Transaction, BranchKey, CommitId, 200, GuardId),
+    ;   open_commit_window_for_branch_head(Transaction, BranchKey, CommitId, 50, GuardId),
         reset_transaction_object_graph_descriptors(Transaction),
         assertz(commit_window_guard_depth(1, (BranchKey, CommitId, GuardId)))
     ).
@@ -392,7 +392,7 @@ acquire_commit_window_guard(BranchKey, CommitId) :-
     (   retract(commit_window_guard_depth(D, Info))
     ->  D1 is D + 1,
         assertz(commit_window_guard_depth(D1, Info))
-    ;   open_commit_window_with_retry(BranchKey, CommitId, 200, GuardId),
+    ;   open_commit_window_with_retry(BranchKey, CommitId, 50, GuardId),
         assertz(commit_window_guard_depth(1, (BranchKey, CommitId, GuardId)))
     ).
 
@@ -413,7 +413,7 @@ open_first_commit_window_with_retry(BranchKey, CommitId, Retries, GuardId) :-
     (   '$change_window':open_first_commit_window(BranchKey, CommitIdString, GuardId, _CurrentCommitId)
     ->  true
     ;   Retries > 0
-    ->  sleep(0.05),
+    ->  sleep(0.01),
         Retries1 is Retries - 1,
         open_first_commit_window_with_retry(BranchKey, CommitId, Retries1, GuardId)
     ;   fail
@@ -427,7 +427,7 @@ open_commit_window_with_retry(BranchKey, CommitId, Retries, GuardId) :-
     (   '$change_window':open_commit_window(BranchKey, CommitIdAtom, GuardId, _CurrentCommitId)
     ->  true
     ;   Retries > 0
-    ->  sleep(0.05),
+    ->  sleep(0.01),
         Retries1 is Retries - 1,
         open_commit_window_with_retry(BranchKey, CommitId, Retries1, GuardId)
     ;   fail

--- a/src/core/document/parallel_elaboration.pl
+++ b/src/core/document/parallel_elaboration.pl
@@ -320,9 +320,13 @@ multi_purpose_worker_loop_body :-
             ->  true
             ;   commit_queue:try_commit_work
             ->  true
+            ;   commit_queue:try_global_optimization
+            ->  true
             ;   idle_worker_wait
             )
         ;   (   commit_queue:try_commit_work
+            ->  true
+            ;   commit_queue:try_global_optimization
             ->  true
             ;   maybe_help_with_elaboration
             ->  true

--- a/src/core/document/parallel_elaboration.pl
+++ b/src/core/document/parallel_elaboration.pl
@@ -43,11 +43,18 @@
 :- use_module(library(option)).
 :- use_module(library(pairs)).
 :- use_module(library(plunit)).
+:- use_module(library(time)).
 :- use_module(library(yall)).
 
 :- dynamic request_queue/8.
 % request_queue(RequestId, Descriptor, DB, PendingChunks, TotalChunks, WrapApiErrors,
 %                 PreBranchCommitId, PreSchemaLayerId).
+
+:- dynamic handler_message_timeout/1.
+% handler_message_timeout is the maximum time (in seconds) the request handler
+% will wait for a worker to send back an elaborated chunk. It is a safety net
+% against a worker that took a chunk but never produced a result.
+handler_message_timeout(30.0).
 
 :- dynamic max_chunk_size/1.
 % max_chunk_size is the maximum number of documents that may be grouped into
@@ -180,16 +187,22 @@ collect_and_process_pairs(RequestId, TotalChunks, Pairs) :-
 
 collect_and_process_(_, 0, Pairs, Pairs) :- !.
 collect_and_process_(RequestId, Remaining, Pairs, FinalPairs) :-
-    (   take_chunk(RequestId, _OwnerId, DB, Wrap, chunk(Index, Docs),
-                   PreBranchCommitId, PreSchemaLayerId)
-    ->  (   process_chunk(DB, Wrap, Docs, PreBranchCommitId, PreSchemaLayerId, Elaborated)
+    (   take_own_chunk(RequestId, DB, Wrap, chunk(Index, Docs),
+                       PreBranchCommitId, PreSchemaLayerId)
+    ->
+        (   process_chunk(DB, Wrap, Docs, PreBranchCommitId, PreSchemaLayerId, Elaborated)
         ->  Remaining1 is Remaining - 1,
             collect_and_process_(RequestId, Remaining1, [Index-Elaborated|Pairs], FinalPairs)
         ;   throw(error(parallel_elaboration_failed(chunk(Index, Docs)), _))
         )
     ;   % No local chunks left; wait for idle HTTP workers to send results.
-        thread_get_message(RequestId, Message),
-        handle_chunk_message(RequestId, Message, Remaining, Pairs, FinalPairs)
+        % Use a bounded wait so a worker that took a chunk but never produced a
+        % result cannot leave the handler thread stuck forever.
+        handler_message_timeout(Timeout),
+        (   thread_get_message(RequestId, Message, [timeout(Timeout)])
+        ->  handle_chunk_message(RequestId, Message, Remaining, Pairs, FinalPairs)
+        ;   throw(error(parallel_elaboration_timeout(RequestId, Remaining), _))
+        )
     ).
 
 handle_chunk_message(RequestId, chunk_done(Index, Elaborated), Remaining, Pairs, FinalPairs) :-
@@ -204,6 +217,19 @@ send_chunk_done(OwnerId, Index, Elaborated) :-
 
 send_chunk_error(OwnerId, Index, Error) :-
     catch(thread_send_message(OwnerId, chunk_error(Index, Error)), _, true).
+
+take_own_chunk(RequestId, DB, Wrap, Chunk, PreBranchCommitId, PreSchemaLayerId) :-
+    with_mutex(elaboration_queue_mutex,
+               (   request_queue(RequestId, Descriptor, DB0, [Chunk|Rest], Total, Wrap,
+                                 PreBranchCommitId0, PreSchemaLayerId0)
+               ->  DB = DB0,
+                   PreBranchCommitId = PreBranchCommitId0,
+                   PreSchemaLayerId = PreSchemaLayerId0,
+                   retractall(request_queue(RequestId, _, _, _, _, _, _, _)),
+                   assertz(request_queue(RequestId, Descriptor, DB0, Rest, Total, Wrap,
+                                          PreBranchCommitId0, PreSchemaLayerId0))
+               ;   fail
+               )).
 
 take_chunk(RequestId, OwnerId, DB, Wrap, Chunk, PreBranchCommitId, PreSchemaLayerId) :-
     with_mutex(elaboration_queue_mutex,
@@ -286,12 +312,11 @@ maybe_help_with_elaboration :-
 
 process_chunk_with_result(DB, Wrap, Docs, PreBranchCommitId, PreSchemaLayerId,
                           OwnerId, Index) :-
-    (   process_chunk_caught(DB, Wrap, Docs, PreBranchCommitId, PreSchemaLayerId, Elaborated, Error)
-    ->  (   var(Error)
-        ->  send_chunk_done(OwnerId, Index, Elaborated)
-        ;   send_chunk_error(OwnerId, Index, Error)
-        )
-    ;   send_chunk_error(OwnerId, Index, unknown_error)
+    process_chunk_caught(DB, Wrap, Docs, PreBranchCommitId, PreSchemaLayerId,
+                         Elaborated, Error),
+    (   var(Error)
+    ->  send_chunk_done(OwnerId, Index, Elaborated)
+    ;   send_chunk_error(OwnerId, Index, Error)
     ).
 
 process_chunk_caught(DB, Wrap, Docs, PreBranchCommitId, PreSchemaLayerId, Elaborated, Error) :-
@@ -337,11 +362,11 @@ multi_purpose_worker_loop_body :-
     ).
 
 % worker_should_commit_first is true when the worker is allowed to prefer
-% elaboration over commit work. If a commit has been pending for more than 2
-% seconds, we force commit work first to avoid starvation of queued commits.
+% elaboration over commit work. If any commit is pending, we force commit work
+% first to avoid starvation of queued commits.
 worker_should_commit_first :-
     worker_prefers_elaboration,
-    \+ commit_queue:pending_commit_stale(2.0).
+    \+ commit_queue:pending_commit_stale(0.0).
 
 worker_prefers_elaboration :-
     config:worker_elaboration_preference(P),
@@ -460,7 +485,7 @@ has_commit_window_guard :-
 % Tests
 % -----
 
-:- begin_tests(parallel_elaboration, [concurrent(true)]).
+:- begin_tests(parallel_elaboration).
 
 :- use_module(core(document)).
 :- use_module(core(document/json)).
@@ -1003,5 +1028,232 @@ test(helper_elaboration_produces_ground_contract, [
     assertion(ground(GotSchemaLayerId)),
     get_dict(pre_branch_commit_id, Contract, GotBranchCommitId),
     assertion(ground(GotBranchCommitId)).
+
+% Regression test for the handler blocking forever when a chunk is stolen by a
+% worker that never sends the result. The handler must return with an error
+% after the configured timeout instead of hanging.
+test(collect_and_process_handler_returns_on_missing_worker_message, [
+         setup((setup_temp_store(State),
+                test_document_label_descriptor(Desc),
+                test_document_schema_string(Schema),
+                write_schema_string(Schema, Desc),
+                retractall(parallel_elaboration:handler_message_timeout(_)),
+                assertz(parallel_elaboration:handler_message_timeout(0.1)))),
+         cleanup((retractall(parallel_elaboration:handler_message_timeout(_)),
+                  assertz(parallel_elaboration:handler_message_timeout(30.0)),
+                  teardown_temp_store(State)))
+     ]) :-
+    helper_docs(1, [Doc]),
+    open_descriptor(Desc, DB),
+    snapshot_ids(DB, PreBranchCommitId, PreSchemaLayerId),
+    create_request_queue(none, DB, [chunk(0, [Doc])], 1, false,
+                         PreBranchCommitId, PreSchemaLayerId, RequestId),
+    % Steal the chunk so the handler has nothing to take itself.
+    take_chunk(RequestId, _OwnerId, _DB, _Wrap, _Chunk, _, _),
+    get_time(Start),
+    catch(
+        call_with_time_limit(2.0, collect_and_process_(RequestId, 1, [], _)),
+        Error,
+        true
+    ),
+    get_time(End),
+    % Must return well before the call_with_time_limit outer bound.
+    assertion(End - Start < 1.5),
+    % Must fail, not succeed, because the chunk was never produced.
+    assertion(nonvar(Error)),
+    cleanup_request(RequestId).
+
+% Regression test for fair work stealing. When three requests all have chunks
+% available, three consecutive calls to maybe_help_with_elaboration should help
+% one chunk from each request, not three chunks from the first request.
+test(work_stealing_rotates_across_requests, [
+         setup((setup_temp_store(State),
+                test_document_label_descriptor(Desc),
+                test_document_schema_string(Schema),
+                write_schema_string(Schema, Desc))),
+         cleanup(teardown_temp_store(State))
+     ]) :-
+    helper_docs(3, [Doc1, Doc2, Doc3]),
+    open_descriptor(Desc, DB),
+    snapshot_ids(DB, PreBranchCommitId, PreSchemaLayerId),
+    findall(chunk(I, [Doc1]), between(0, 9, I), Chunks1),
+    findall(chunk(I, [Doc2]), between(0, 9, I), Chunks2),
+    findall(chunk(I, [Doc3]), between(0, 9, I), Chunks3),
+    create_request_queue(none, DB, Chunks1, 10, false,
+                         PreBranchCommitId, PreSchemaLayerId, RequestId1),
+    create_request_queue(none, DB, Chunks2, 10, false,
+                         PreBranchCommitId, PreSchemaLayerId, RequestId2),
+    create_request_queue(none, DB, Chunks3, 10, false,
+                         PreBranchCommitId, PreSchemaLayerId, RequestId3),
+    maybe_help_with_elaboration,
+    maybe_help_with_elaboration,
+    maybe_help_with_elaboration,
+    message_queue_property(RequestId1, size(Size1)),
+    message_queue_property(RequestId2, size(Size2)),
+    message_queue_property(RequestId3, size(Size3)),
+    assertion(Size1 == 1),
+    assertion(Size2 == 1),
+    assertion(Size3 == 1),
+    cleanup_request(RequestId1),
+    cleanup_request(RequestId2),
+    cleanup_request(RequestId3).
+
+% Regression test for chunk atomicity. Many workers racing to take chunks from
+% the same request must each get a distinct chunk, and every chunk must be
+% accounted for (no lost or duplicate takes).
+test(concurrent_take_chunk_is_atomic, [
+         setup((setup_temp_store(State),
+                test_document_label_descriptor(Desc),
+                test_document_schema_string(Schema),
+                write_schema_string(Schema, Desc))),
+         cleanup(teardown_temp_store(State))
+     ]) :-
+    helper_docs(5, Docs),
+    open_descriptor(Desc, DB),
+    snapshot_ids(DB, PreBranchCommitId, PreSchemaLayerId),
+    findall(chunk(I, [Doc]), nth0(I, Docs, Doc), Chunks),
+    length(Chunks, N),
+    create_request_queue(none, DB, Chunks, N, false,
+                         PreBranchCommitId, PreSchemaLayerId, RequestId),
+    % Spawn more workers than chunks to stress the mutex, plus a handler thread
+    % that tries to take its own chunks like collect_and_process_ does.
+    NumWorkers is N * 3,
+    findall(ThreadId,
+            (   between(1, NumWorkers, _),
+                thread_create(
+                    (   take_chunk(RequestId, OwnerId, _DB2, _Wrap, chunk(Index, _Docs),
+                                   _PreBranchCommitId, _PreSchemaLayerId)
+                    ->  thread_send_message(main, taken(OwnerId, Index))
+                    ;   thread_send_message(main, none)
+                    ),
+                    ThreadId,
+                    [])
+            ),
+            WorkerIds),
+    thread_create(
+        (   repeat,
+            (   take_chunk(RequestId, OwnerId, _DB2, _Wrap, chunk(Index, _Docs),
+                           _PreBranchCommitId, _PreSchemaLayerId)
+            ->  thread_send_message(main, taken(OwnerId, Index)),
+                fail
+            ;   !
+            )
+        ),
+        HandlerThread,
+        []),
+    forall(member(T, WorkerIds), thread_join(T, _)),
+    thread_join(HandlerThread, _),
+    TotalReplies is NumWorkers + N,
+    % Collect all worker replies.
+    findall(Reply,
+            (   between(1, TotalReplies, _),
+                thread_get_message(main, Reply, [timeout(1)])
+            ),
+            Replies),
+    findall(Index, member(taken(RequestId, Index), Replies), TakenIndices),
+    sort(TakenIndices, SortedTaken),
+    N1 is N - 1,
+    numlist(0, N1, Expected),
+    assertion(SortedTaken == Expected),
+    cleanup_request(RequestId).
+
+% Stress test: 4 concurrent handlers with 5 chunks each, plus a pool of workers
+% that try to help. All 4 requests must complete without any chunk being lost.
+test(concurrent_requests_all_complete, [
+         setup((setup_temp_store(State),
+                test_document_label_descriptor(Desc),
+                test_document_schema_string(Schema),
+                write_schema_string(Schema, Desc),
+                start_elaboration_workers(4))),
+         cleanup((stop_elaboration_workers,
+                  teardown_temp_store(State)))
+     ]) :-
+    helper_docs(5000, Docs),
+    open_descriptor(Desc, DB),
+    snapshot_ids(DB, PreBranchCommitId, PreSchemaLayerId),
+    % Split into 5 chunks of 1000 documents each.
+    chunks_from_documents(Docs, 1000, Chunks),
+    length(Chunks, N),
+    % Create 4 request queues.
+    findall(RequestId,
+            (   between(1, 4, _),
+                create_request_queue(none, DB, Chunks, N, false,
+                                     PreBranchCommitId, PreSchemaLayerId, RequestId)
+            ),
+            RequestIds),
+    % Give workers a brief moment to steal chunks before handlers start.
+    sleep(0.1),
+    % Start 4 handler threads.
+    findall(HandlerThread,
+            (   member(RequestId, RequestIds),
+                thread_create(
+                    (   catch(
+                            collect_and_process_pairs(RequestId, N, Pairs),
+                            Error,
+                            (   Error = error(parallel_elaboration_timeout(_,_),_)
+                            ->  Pairs = timeout
+                            ;   throw(Error)
+                            )
+                        )
+                    ->  thread_send_message(main, request_done(RequestId, Pairs))
+                    ;   thread_send_message(main, request_failed(RequestId))
+                    ),
+                    HandlerThread,
+                    [])
+            ),
+            HandlerThreads),
+    forall(member(T, HandlerThreads), thread_join(T, _)),
+    % Collect results.
+    findall(RequestId-Done,
+            (   between(1, 4, _),
+                thread_get_message(main, request_done(RequestId, Done), [timeout(10)])
+            ),
+            Results),
+    sort(RequestIds, ExpectedIds),
+    findall(Id, member(Id-Done, Results), DoneIds),
+    sort(DoneIds, SortedDoneIds),
+    assertion(SortedDoneIds == ExpectedIds),
+    % No request may have timed out.
+    \+ member(_-timeout, Results),
+    forall(member(RequestId, RequestIds), cleanup_request(RequestId)).
+
+% Regression test for the handler-side chunk-stealing bug. When a handler's own
+% queue has been drained by workers but results are still in flight, the handler
+% must NOT steal a chunk from another request queue.
+test(handler_does_not_steal_foreign_chunks, [
+         setup((setup_temp_store(State),
+                test_document_label_descriptor(Desc),
+                test_document_schema_string(Schema),
+                write_schema_string(Schema, Desc),
+                retractall(parallel_elaboration:handler_message_timeout(_)),
+                assertz(parallel_elaboration:handler_message_timeout(0.1)))),
+         cleanup((retractall(parallel_elaboration:handler_message_timeout(_)),
+                  assertz(parallel_elaboration:handler_message_timeout(30.0)),
+                  teardown_temp_store(State)))
+     ]) :-
+    helper_docs(2, [DocA, DocB]),
+    open_descriptor(Desc, DB),
+    snapshot_ids(DB, PreBranchCommitId, PreSchemaLayerId),
+    create_request_queue(none, DB, [chunk(0, [DocA])], 1, false,
+                         PreBranchCommitId, PreSchemaLayerId, RequestA),
+    create_request_queue(none, DB, [chunk(0, [DocB])], 1, false,
+                         PreBranchCommitId, PreSchemaLayerId, RequestB),
+    % Simulate a worker draining A's queue without sending a result yet.
+    take_chunk(RequestA, OwnerA, _DB, _Wrap, _Chunk, _, _),
+    assertion(OwnerA == RequestA),
+    % A's own queue is now empty. A's handler must wait for the result and then
+    % time out, NOT steal B's chunk.
+    catch(
+        collect_and_process_(RequestA, 1, [], _),
+        Error,
+        true
+    ),
+    assertion(nonvar(Error)),
+    assertion(Error = error(parallel_elaboration_timeout(RequestA, 1), _)),
+    % B's chunk must remain pending in B's queue.
+    request_queue(RequestB, _, _, PendingB, _, _, _, _),
+    assertion(PendingB = [chunk(0, _)]),
+    cleanup_request(RequestA),
+    cleanup_request(RequestB).
 
 :- end_tests(parallel_elaboration).

--- a/src/core/document/parallel_elaboration.pl
+++ b/src/core/document/parallel_elaboration.pl
@@ -1121,8 +1121,8 @@ test(concurrent_take_chunk_is_atomic, [
     findall(ThreadId,
             (   between(1, NumWorkers, _),
                 thread_create(
-                    (   take_chunk(RequestId, OwnerId, _DB2, _Wrap, chunk(Index, _Docs),
-                                   _PreBranchCommitId, _PreSchemaLayerId)
+                    (   take_chunk(RequestId, OwnerId, _, _, chunk(Index, _),
+                                   _, _)
                     ->  thread_send_message(main, taken(OwnerId, Index))
                     ;   thread_send_message(main, none)
                     ),
@@ -1132,8 +1132,8 @@ test(concurrent_take_chunk_is_atomic, [
             WorkerIds),
     thread_create(
         (   repeat,
-            (   take_chunk(RequestId, OwnerId, _DB2, _Wrap, chunk(Index, _Docs),
-                           _PreBranchCommitId, _PreSchemaLayerId)
+            (   take_chunk(RequestId, OwnerId, _, _, chunk(Index, _),
+                           _, _)
             ->  thread_send_message(main, taken(OwnerId, Index)),
                 fail
             ;   !

--- a/src/core/transaction/database.pl
+++ b/src/core/transaction/database.pl
@@ -25,6 +25,7 @@
 :- use_module(core(triple), [xrdf_added/4, xrdf_deleted/4]).
 :- use_module(core(plugins)).
 :- use_module(core(document/migration)).
+:- use_module(core(document/meta_commit_queue)).
 
 :- use_module(config(terminus_config), [max_transaction_retries/1]).
 
@@ -297,6 +298,16 @@ Options include
 * allow_destructive_migration: whether we should allow strengthening migrations
 
  */
+transaction_object_database_key(Transaction_Object, Key) :-
+    get_dict(descriptor, Transaction_Object, Descriptor),
+    (   database_descriptor{organization_name: _,
+                          database_name: _} = Descriptor
+    ->  meta_commit_queue:database_descriptor_key(Descriptor, Key)
+    ;   get_dict(parent, Transaction_Object, Parent)
+    ->  transaction_object_database_key(Parent, Key)
+    ;   fail
+    ).
+
 run_transactions(Transactions, All_Witnesses, Meta_Data, Options) :-
     transaction_objects_to_validation_objects(Transactions, Validations),
     (   option(inside_migration(true), Options)
@@ -317,7 +328,20 @@ run_transactions(Transactions, All_Witnesses, Meta_Data, Options) :-
     ->  true
     ;   throw(error(schema_check_failure(Hook_Witnesses),_))),
 
-    commit_validation_objects(Validations0, Committed),
+    findall(Key,
+            (   member(Transaction, Transactions),
+                transaction_object_database_key(Transaction, Key)
+            ),
+            Keys),
+    sort(Keys, Sorted_Keys),
+
+    % Serialize the actual _meta commits and graph head updates. The lock is
+    % released before post_commit_hook so that plugins (such as the auto-
+    % optimizer) do not deadlock trying to acquire the same lock.
+    meta_commit_queue:with_meta_commit_locks(
+        Sorted_Keys,
+        database:commit_validation_objects(Validations0, Committed)
+    ),
     % Use the original validations before any potential schema migration
     collect_validations_metadata(Validations, Validation_Meta_Data),
     collect_commit_metadata(Committed, Commit_Meta_Data),

--- a/src/core/transaction/database.pl
+++ b/src/core/transaction/database.pl
@@ -6,6 +6,7 @@
               with_transaction/3,
               with_transaction/4,
               graph_inserts_deletes/3,
+              transaction_object_database_key/2,
               reset_transaction_object_graph_descriptors/1,
               reset_transaction_objects_graph_descriptors/1
           ]).
@@ -144,11 +145,11 @@ compute_backoff(Count, Time) :-
     Time is This_Slot * Slot_Time.
 
 reset_read_write_obj(Read_Write_Obj, Map, New_Map) :-
+    Descriptor = (Read_Write_Obj.descriptor),
     nb_set_dict(read, Read_Write_Obj, _),
     nb_set_dict(write, Read_Write_Obj, _),
     nb_set_dict(backlinks, Read_Write_Obj, []),
     nb_set_dict(triple_update, Read_Write_Obj, false),
-    Descriptor = (Read_Write_Obj.descriptor),
     (   get_dict(commit_type, Descriptor, _)
     ->  nb_set_dict(commit_type, Descriptor, _)
     ;   true),
@@ -340,9 +341,9 @@ run_transactions(Transactions, All_Witnesses, Meta_Data, Options) :-
     % Serialize the actual _meta commits and graph head updates. The lock is
     % released before post_commit_hook so that plugins (such as the auto-
     % optimizer) do not deadlock trying to acquire the same lock.
-    meta_commit_queue:with_meta_commit_locks(
+    with_meta_commit_locks(
         Sorted_Keys,
-        database:commit_validation_objects(Validations0, Committed)
+        commit_validation_objects(Validations0, Committed)
     ),
     % Use the original validations before any potential schema migration
     collect_validations_metadata(Validations, Validation_Meta_Data),

--- a/src/core/transaction/database.pl
+++ b/src/core/transaction/database.pl
@@ -303,6 +303,8 @@ transaction_object_database_key(Transaction_Object, Key) :-
     (   database_descriptor{organization_name: _,
                           database_name: _} = Descriptor
     ->  meta_commit_queue:database_descriptor_key(Descriptor, Key)
+    ;   system_descriptor{} = Descriptor
+    ->  meta_commit_queue:system_meta_lock_key(Key)
     ;   get_dict(parent, Transaction_Object, Parent)
     ->  transaction_object_database_key(Parent, Key)
     ;   fail

--- a/src/server/routes.pl
+++ b/src/server/routes.pl
@@ -2582,7 +2582,7 @@ optimize_handler(post, Path, Request, System_DB, Auth) :-
     api_report_errors(
         optimize,
         Request,
-        (   api_optimize(System_DB, Auth, Path),
+        (   api_optimize_queued(System_DB, Auth, Path),
             cors_reply_json(Request, _{'@type' : 'api:OptimizeResponse',
                                        'api:status' : "api:success"}))).
 

--- a/tests/benchmark/congestion_document_insert/README.md
+++ b/tests/benchmark/congestion_document_insert/README.md
@@ -1,0 +1,139 @@
+# Congestion Document Insert Benchmark
+
+A public benchmark for measuring parallel document insert throughput against a
+single TerminusDB branch using the `/api/document` endpoint with NDJSON bulk
+inserts.
+
+It compares two execution modes:
+
+- **Parallel**: multiple writers insert chunks concurrently on the same branch.
+- **Sequential**: the same total number of chunks is inserted one at a time.
+
+The benchmark creates fresh databases, inserts a simple `Simple` schema, runs
+the timed insertions, and finally deletes the databases. No setup beyond a
+running TerminusDB server is required.
+
+## What you need
+
+- Python 3.11 or newer (only the standard library is used).
+- A running TerminusDB server at `http://127.0.0.1:6363` with the default
+  `admin` / `root` credentials.
+
+If you do not have a global Python 3 installation, the steps below create a
+local virtual environment.
+
+## Quick start with a virtual environment
+
+From the benchmark directory:
+
+```bash
+cd /Users/hoijnet/Code/devops/twinfoxdb/terminusdb/tests/benchmark/congestion_document_insert
+
+# Create a virtual environment (only needed once)
+python3 -m venv .venv
+
+# Activate it
+source .venv/bin/activate
+
+# Run the benchmark with the default settings
+python3 bench.py
+```
+
+On macOS, `python3` is usually available from the system or Homebrew. The
+benchmark does not require installing any third-party packages.
+
+## Start the TerminusDB server
+
+The benchmark expects a server running on the default local test port. The
+repository provides a helper script:
+
+```bash
+cd /Users/hoijnet/Code/devops/twinfoxdb/terminusdb
+./tests/terminusdb-test-server.sh start --clean
+```
+
+This starts a fresh, isolated server on `http://127.0.0.1:6363` with
+admin password `root`. Use `--clean` the first time or whenever you want to
+wipe previous test data.
+
+## Default configuration
+
+The default run is:
+
+- 4 writers
+- 3 chunks per writer
+- 2 000 documents per chunk
+- 24 000 documents total
+
+This is the stable configuration that produced the best throughput in our
+tests. It keeps the per-chunk size small enough to avoid the commit-queue
+hangs and worker starvation seen with larger chunks, while still amortizing
+the per-commit fixed cost over many documents.
+
+## Override the configuration
+
+Use environment variables to change the load:
+
+```bash
+WRITERS=4 CHUNKS_PER_WRITER=1 DOCS_PER_CHUNK=10000 \
+  python3 bench.py
+```
+
+Available variables:
+
+| Variable | Default | Description |
+|---|---|---|
+| `TERMINUSDB_HOST` | `http://127.0.0.1:6363` | Server URL |
+| `TERMINUSDB_USER` | `admin` | Admin user |
+| `TERMINUSDB_PASS` | `root` | Admin password |
+| `WRITERS` | `4` | Number of concurrent writers |
+| `CHUNKS_PER_WRITER` | `3` | Chunks each writer sends |
+| `DOCS_PER_CHUNK` | `2000` | Documents per NDJSON chunk |
+| `OUTPUT` | `../benchmark_results/congestion_document_insert.json` | Results file |
+
+## Example output
+
+```json
+{
+  "benchmark": "congestion_document_insert",
+  "metrics": {
+    "writers": 4,
+    "chunks_per_writer": 3,
+    "docs_per_chunk": 2000,
+    "parallel": {
+      "total_ms": 2150.88,
+      "documents": 24000,
+      "chunks": 12,
+      "documents_per_second": 11158.23,
+      "ms_per_document": 0.0896
+    },
+    "sequential": {
+      "total_ms": 1829.43,
+      "documents": 24000,
+      "chunks": 12,
+      "documents_per_second": 13118.83,
+      "ms_per_document": 0.0762
+    },
+    "congestion_ratio": 1.18
+  }
+}
+```
+
+## Interpreting results
+
+- **`documents_per_second`** under `parallel` is the headline throughput number.
+- **`congestion_ratio`** is `parallel_total_ms / sequential_total_ms`. A value
+  close to 1 means parallel writes on the same branch add little overhead; a
+  much larger value would mean contention is dominating the runtime.
+- On a single branch, TerminusDB serializes commits, so adding more writers
+  does not always increase throughput. The bottleneck is the per-commit fixed
+  cost.
+
+## Notes
+
+- The script uses only Python standard library modules (`http.client`, etc.).
+- The `Simple` schema uses a `Random` key, so the server generates document IDs.
+  This exercises the Rust fast path for simple documents and keeps the workload
+  non-intersecting (no transaction retries).
+- The benchmark creates and deletes the databases `admin/congestion_document_insert_parallel`
+  and `admin/congestion_document_insert_sequential`.

--- a/tests/benchmark/congestion_document_insert/README.md
+++ b/tests/benchmark/congestion_document_insert/README.md
@@ -10,8 +10,9 @@ It compares two execution modes:
 - **Sequential**: the same total number of chunks is inserted one at a time.
 
 The benchmark creates fresh databases, inserts a simple `Simple` schema, runs
-the timed insertions, and finally deletes the databases. No setup beyond a
-running TerminusDB server is required.
+the timed insertions, verifies that every returned document ID can be queried
+back, and finally deletes the databases. No setup beyond a running TerminusDB
+server is required.
 
 ## What you need
 
@@ -75,7 +76,7 @@ the per-commit fixed cost over many documents.
 Use environment variables to change the load:
 
 ```bash
-WRITERS=4 CHUNKS_PER_WRITER=1 DOCS_PER_CHUNK=10000 \
+WRITERS=2 CHUNKS_PER_WRITER=2 DOCS_PER_CHUNK=20000 \
   python3 bench.py
 ```
 
@@ -97,24 +98,26 @@ Available variables:
 {
   "benchmark": "congestion_document_insert",
   "metrics": {
-    "writers": 4,
-    "chunks_per_writer": 3,
-    "docs_per_chunk": 2000,
+    "writers": 2,
+    "chunks_per_writer": 2,
+    "docs_per_chunk": 20000,
     "parallel": {
-      "total_ms": 2150.88,
-      "documents": 24000,
-      "chunks": 12,
-      "documents_per_second": 11158.23,
-      "ms_per_document": 0.0896
+      "total_ms": 3280.27,
+      "documents": 80000,
+      "chunks": 4,
+      "documents_per_second": 24388.20,
+      "ms_per_document": 0.0410,
+      "verified_documents": 80000
     },
     "sequential": {
-      "total_ms": 1829.43,
-      "documents": 24000,
-      "chunks": 12,
-      "documents_per_second": 13118.83,
-      "ms_per_document": 0.0762
+      "total_ms": 4085.87,
+      "documents": 80000,
+      "chunks": 4,
+      "documents_per_second": 19579.67,
+      "ms_per_document": 0.0511,
+      "verified_documents": 80000
     },
-    "congestion_ratio": 1.18
+    "congestion_ratio": 0.80
   }
 }
 ```
@@ -125,6 +128,10 @@ Available variables:
 - **`congestion_ratio`** is `parallel_total_ms / sequential_total_ms`. A value
   close to 1 means parallel writes on the same branch add little overhead; a
   much larger value would mean contention is dominating the runtime.
+- **`verified_documents`** is the number of inserted IDs that were successfully
+  queried back from the database. It must equal `documents`; if it is lower, the
+  benchmark raises an error because the insert response reported documents that
+  were not persisted.
 - On a single branch, TerminusDB serializes commits, so adding more writers
   does not always increase throughput. The bottleneck is the per-commit fixed
   cost.

--- a/tests/benchmark/congestion_document_insert/bench.py
+++ b/tests/benchmark/congestion_document_insert/bench.py
@@ -5,6 +5,10 @@ Based on the enterprise congestion_document_insert and api_simple_insert
 benchmarks. Measures the throughput of concurrent document writers against the
 same branch using the public /api/document endpoint with NDJSON bulk inserts.
 
+After the timed insertions, the benchmark verifies that every document ID
+returned by the server is queryable, raising an error if any inserted document
+is missing from the database.
+
 Default configuration:
   - 4 writers
   - 3 chunks per writer
@@ -137,10 +141,12 @@ def insert_chunk(db_name, writer_idx, chunk_idx, docs_per_chunk):
     )
     if status not in (200, 201):
         raise RuntimeError(f"Insert failed for writer {writer_idx} chunk {chunk_idx}: {status} {data!r}")
+    ids = json.loads(data)
     return {
         "writer": writer_idx,
         "chunk": chunk_idx,
         "inserts": docs_per_chunk,
+        "ids": ids,
     }
 
 
@@ -173,6 +179,61 @@ def run_sequential(db_name, writers, chunks_per_writer, docs_per_chunk):
         results.append(insert_chunk(db_name, 0, c, docs_per_chunk))
     elapsed = time.perf_counter() - start
     return elapsed, results
+
+
+def _normalize_id(doc_id):
+    """Return the short form of a document id.
+
+    Insert responses return full ids like 'terminusdb:///data/Simple/XXX' while
+    GET /api/document returns short ids like 'Simple/XXX'. We normalize to the
+    short form for comparison.
+    """
+    if doc_id.startswith("terminusdb:///data/"):
+        return doc_id[len("terminusdb:///data/"):]
+    return doc_id
+
+
+def verify_consistency(client, db_name, results):
+    """Verify that every id returned by the inserts can be queried back."""
+    expected_ids = {
+        _normalize_id(doc_id)
+        for result in results
+        for doc_id in result.get("ids", [])
+    }
+
+    status, data = client.request(
+        "GET",
+        f"/api/document/{db_name}?graph_type=instance",
+    )
+    if status != 200:
+        raise RuntimeError(f"Failed to list documents from {db_name}: {status} {data!r}")
+
+    found_ids = set()
+    for line in data.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            doc = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"Invalid document list response from {db_name}: {line!r}") from exc
+        if "@id" in doc:
+            found_ids.add(doc["@id"])
+
+    missing = expected_ids - found_ids
+    extra = found_ids - expected_ids
+    if missing:
+        raise RuntimeError(
+            f"Consistency check failed for {db_name}: {len(missing)} inserted documents missing "
+            f"(e.g. {next(iter(missing))}). Found {len(found_ids)} documents, expected {len(expected_ids)}."
+        )
+    if extra:
+        raise RuntimeError(
+            f"Consistency check failed for {db_name}: {len(extra)} unexpected documents found "
+            f"(e.g. {next(iter(extra))}). Found {len(found_ids)} documents, expected {len(expected_ids)}."
+        )
+
+    return len(expected_ids)
 
 
 def summarize_results(elapsed, results, docs_per_chunk):
@@ -208,10 +269,12 @@ def main():
         parallel_elapsed, parallel_results = run_parallel(
             parallel_db, writers, chunks_per_writer, docs_per_chunk
         )
+        parallel_verified = verify_consistency(setup_client, parallel_db, parallel_results)
     finally:
         delete_db(setup_client, parallel_db)
 
     parallel_metrics = summarize_results(parallel_elapsed, parallel_results, docs_per_chunk)
+    parallel_metrics["verified_documents"] = parallel_verified
 
     # Sequential scenario.
     delete_db(setup_client, sequential_db)
@@ -221,10 +284,12 @@ def main():
         sequential_elapsed, sequential_results = run_sequential(
             sequential_db, writers, chunks_per_writer, docs_per_chunk
         )
+        sequential_verified = verify_consistency(setup_client, sequential_db, sequential_results)
     finally:
         delete_db(setup_client, sequential_db)
 
     sequential_metrics = summarize_results(sequential_elapsed, sequential_results, docs_per_chunk)
+    sequential_metrics["verified_documents"] = sequential_verified
 
     congestion_ratio = (
         parallel_metrics["total_ms"] / sequential_metrics["total_ms"]

--- a/tests/benchmark/congestion_document_insert/bench.py
+++ b/tests/benchmark/congestion_document_insert/bench.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Public congestion benchmark for parallel document inserts.
+
+Based on the enterprise congestion_document_insert and api_simple_insert
+benchmarks. Measures the throughput of concurrent document writers against the
+same branch using the public /api/document endpoint with NDJSON bulk inserts.
+
+Default configuration:
+  - 4 writers
+  - 3 chunks per writer
+  - 2 000 documents per chunk
+  - 24 000 documents total
+
+Environment variables:
+  TERMINUSDB_HOST  - server URL (default: http://127.0.0.1:6363)
+  TERMINUSDB_USER  - admin user (default: admin)
+  TERMINUSDB_PASS  - admin password (default: root)
+  WRITERS          - number of concurrent writers (default: 4)
+  CHUNKS_PER_WRITER - chunks each writer sends (default: 3)
+  DOCS_PER_CHUNK   - documents per NDJSON chunk (default: 2000)
+  OUTPUT           - path to JSON results file
+                     (default: ../benchmark_results/congestion_document_insert.json)
+"""
+
+
+
+
+
+
+import base64
+import io
+import json
+import os
+import sys
+import time
+import urllib.parse
+import uuid
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from http import client as http_client
+
+
+DEFAULT_HOST = "http://127.0.0.1:6363"
+DEFAULT_USER = "admin"
+DEFAULT_PASS = "root"
+
+DB_NAME = "admin/congestion_document_insert"
+
+
+class Client:
+    """Minimal HTTP client for one TerminusDB request at a time."""
+
+    def __init__(self, host=None, user=None, password=None):
+        host = host or os.environ.get("TERMINUSDB_HOST", DEFAULT_HOST)
+        user = user or os.environ.get("TERMINUSDB_USER", DEFAULT_USER)
+        password = password or os.environ.get("TERMINUSDB_PASS", DEFAULT_PASS)
+
+        parsed = urllib.parse.urlparse(host)
+        self.hostname = parsed.hostname or "127.0.0.1"
+        self.port = parsed.port or (443 if parsed.scheme == "https" else 80)
+        self.use_https = parsed.scheme == "https"
+        self.auth = "Basic " + base64.b64encode(f"{user}:{password}".encode()).decode()
+
+    def request(self, method, path, body=None, content_type="application/json"):
+        headers = {
+            "Authorization": self.auth,
+            "Content-Type": content_type,
+            "Connection": "close",
+        }
+        conn = (
+            http_client.HTTPSConnection(self.hostname, self.port, timeout=30)
+            if self.use_https
+            else http_client.HTTPConnection(self.hostname, self.port, timeout=30)
+        )
+        try:
+            conn.request(method, path, body=body, headers=headers)
+            response = conn.getresponse()
+            data = response.read()
+            return response.status, data
+        finally:
+            conn.close()
+
+
+def create_db(client, db_name):
+    status, data = client.request(
+        "POST",
+        f"/api/db/{db_name}",
+        body=json.dumps({"label": "Congestion Document Insert Benchmark", "comment": "benchmark"}),
+    )
+    if status not in (200, 201):
+        raise RuntimeError(f"Failed to create database {db_name}: {status} {data!r}")
+
+
+def insert_schema(client, db_name):
+    schema = {
+        "@type": "Class",
+        "@id": "Simple",
+        "@key": {"@type": "Random"},
+        "name": "xsd:string",
+    }
+    status, data = client.request(
+        "POST",
+        f"/api/document/{db_name}?graph_type=schema&author=benchmark&message=schema",
+        body=json.dumps(schema),
+    )
+    if status not in (200, 201):
+        raise RuntimeError(f"Failed to insert schema: {status} {data!r}")
+
+
+def delete_db(client, db_name):
+    try:
+        client.request("DELETE", f"/api/db/{db_name}")
+    except Exception as exc:
+        print(f"Warning: failed to delete database {db_name}: {exc}", file=sys.stderr)
+
+
+def build_chunk(writer_idx, chunk_idx, docs_per_chunk):
+    """Build a chunk as NDJSON bytes for the /api/document endpoint."""
+    buffer = io.StringIO()
+    for i in range(docs_per_chunk):
+        doc = {
+            "@type": "Simple",
+            "name": f"w{writer_idx}-c{chunk_idx}-d{i}-{uuid.uuid4().hex}",
+        }
+        buffer.write(json.dumps(doc))
+        buffer.write("\n")
+    return buffer.getvalue().encode("utf-8")
+
+
+def insert_chunk(db_name, writer_idx, chunk_idx, docs_per_chunk):
+    client = Client()
+    body = build_chunk(writer_idx, chunk_idx, docs_per_chunk)
+    status, data = client.request(
+        "POST",
+        f"/api/document/{db_name}?graph_type=instance&author=benchmark&message=congestion+chunk",
+        body=body,
+        content_type="application/json",
+    )
+    if status not in (200, 201):
+        raise RuntimeError(f"Insert failed for writer {writer_idx} chunk {chunk_idx}: {status} {data!r}")
+    return {
+        "writer": writer_idx,
+        "chunk": chunk_idx,
+        "inserts": docs_per_chunk,
+    }
+
+
+def _writer_loop(db_name, writer_idx, chunks_per_writer, docs_per_chunk):
+    results = []
+    for c in range(chunks_per_writer):
+        results.append(insert_chunk(db_name, writer_idx, c, docs_per_chunk))
+    return results
+
+
+def run_parallel(db_name, writers, chunks_per_writer, docs_per_chunk):
+    start = time.perf_counter()
+    with ThreadPoolExecutor(max_workers=writers) as executor:
+        futures = {
+            executor.submit(_writer_loop, db_name, w, chunks_per_writer, docs_per_chunk): w
+            for w in range(writers)
+        }
+        results = []
+        for future in as_completed(futures):
+            results.extend(future.result())
+    elapsed = time.perf_counter() - start
+    return elapsed, results
+
+
+def run_sequential(db_name, writers, chunks_per_writer, docs_per_chunk):
+    total_chunks = writers * chunks_per_writer
+    start = time.perf_counter()
+    results = []
+    for c in range(total_chunks):
+        results.append(insert_chunk(db_name, 0, c, docs_per_chunk))
+    elapsed = time.perf_counter() - start
+    return elapsed, results
+
+
+def summarize_results(elapsed, results, docs_per_chunk):
+    total_docs = len(results) * docs_per_chunk
+    docs_per_second = total_docs / elapsed if elapsed > 0 else 0
+    ms_per_doc = (elapsed * 1000) / total_docs if total_docs > 0 else 0
+
+    return {
+        "total_ms": elapsed * 1000,
+        "documents": total_docs,
+        "chunks": len(results),
+        "documents_per_second": docs_per_second,
+        "ms_per_document": ms_per_doc,
+    }
+
+
+def main():
+    writers = int(os.environ.get("WRITERS", "4"))
+    chunks_per_writer = int(os.environ.get("CHUNKS_PER_WRITER", "3"))
+    docs_per_chunk = int(os.environ.get("DOCS_PER_CHUNK", "2000"))
+    output = os.environ.get("OUTPUT", "../benchmark_results/congestion_document_insert.json")
+
+    parallel_db = f"{DB_NAME}_parallel"
+    sequential_db = f"{DB_NAME}_sequential"
+
+    setup_client = Client()
+
+    # Parallel scenario.
+    delete_db(setup_client, parallel_db)
+    create_db(setup_client, parallel_db)
+    insert_schema(setup_client, parallel_db)
+    try:
+        parallel_elapsed, parallel_results = run_parallel(
+            parallel_db, writers, chunks_per_writer, docs_per_chunk
+        )
+    finally:
+        delete_db(setup_client, parallel_db)
+
+    parallel_metrics = summarize_results(parallel_elapsed, parallel_results, docs_per_chunk)
+
+    # Sequential scenario.
+    delete_db(setup_client, sequential_db)
+    create_db(setup_client, sequential_db)
+    insert_schema(setup_client, sequential_db)
+    try:
+        sequential_elapsed, sequential_results = run_sequential(
+            sequential_db, writers, chunks_per_writer, docs_per_chunk
+        )
+    finally:
+        delete_db(setup_client, sequential_db)
+
+    sequential_metrics = summarize_results(sequential_elapsed, sequential_results, docs_per_chunk)
+
+    congestion_ratio = (
+        parallel_metrics["total_ms"] / sequential_metrics["total_ms"]
+        if sequential_metrics["total_ms"] > 0 else 0
+    )
+
+    result = {
+        "benchmark": "congestion_document_insert",
+        "metrics": {
+            "writers": writers,
+            "chunks_per_writer": chunks_per_writer,
+            "docs_per_chunk": docs_per_chunk,
+            "parallel": parallel_metrics,
+            "sequential": sequential_metrics,
+            "congestion_ratio": congestion_ratio,
+        },
+    }
+
+    os.makedirs(os.path.dirname(output), exist_ok=True)
+    with open(output, "w") as f:
+        json.dump(result, f, indent=2)
+        f.write("\n")
+
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/lib/db.js
+++ b/tests/lib/db.js
@@ -32,7 +32,6 @@ function create (agent, params) {
   return {
     then (resolve) {
       resolve(request.then(api.response.verify(api.response.db.createSuccess)).then(async (result) => {
-        // Auto-optimize database after successful creation
         try {
           const dbPath = params.string('path', `${agent.orgName}/${agent.dbName}`)
           await optimizeDatabase(agent, dbPath, 'main')

--- a/tests/manual/commit_queue_contention/DOCKER_STRESS.md
+++ b/tests/manual/commit_queue_contention/DOCKER_STRESS.md
@@ -2,8 +2,9 @@
 
 This manual test runs the commit-queue contention stress test against a
 TerminusDB server in a CPU-throttled Docker container. The container is
-limited to half a CPU so commits and scheduled auto-optimizations overlap
-heavily, which is the scenario in which the original race was observed.
+limited to half a CPU or less so commits and scheduled auto-optimizations 
+overlap heavily, which is the scenario in which the original race was 
+observed.
 
 ## What it tests
 

--- a/tests/manual/commit_queue_contention/DOCKER_STRESS.md
+++ b/tests/manual/commit_queue_contention/DOCKER_STRESS.md
@@ -1,0 +1,117 @@
+# Docker CPU-throttled stress run
+
+This manual test runs the commit-queue contention stress test against a
+TerminusDB server in a CPU-throttled Docker container. The container is
+limited to half a CPU so commits and scheduled auto-optimizations overlap
+heavily, which is the scenario in which the original race was observed.
+
+## What it tests
+
+The race that was fixed: a document commit and a scheduled `_meta` optimization
+both try to use the same `commit_graph` builder. Without the
+`meta_commit_lock` serialization, the optimizer can commit the builder while
+the next commit is still using it, producing
+`rust_io_error(InvalidData, builder has already been committed)` or an HTTP 500.
+
+The test interleaves document inserts, branch creation, rebase, push, and explicit
+`/api/optimize` calls on a single database while the auto-optimize plugin is
+enabled. It then scans the server log for 500 responses, optimization failures,
+`builder has already been committed`, and `unexpected_commit_failure`.
+
+## Prerequisites
+
+- Docker installed and running.
+- `docker-compose` available.
+- The local image `terminusdb/terminusdb-server:local` built, or the ability to
+  build it.
+- Node.js with the test dependencies installed (`npm install` in `tests/`).
+
+## Quick run
+
+```bash
+# From the repo root
+make docker SKIP_TESTS=true
+
+# Run the bundled script (defaults to 120 seconds)
+cd tests/manual/commit_queue_contention
+./run-stress-in-docker.sh
+
+# Or run for a specific duration
+./run-stress-in-docker.sh 300
+```
+
+The script will:
+1. Start the CPU-throttled container on port 6363.
+2. Wait for the server to be ready.
+3. Run `stress.js` with the configured duration and concurrency.
+4. Write `terminusdb-stress.log`.
+5. Stop and remove the container and volume.
+
+## Manual run
+
+If you prefer to start the container yourself and run the test separately:
+
+```bash
+cd tests/manual/commit_queue_contention
+
+# Start the container
+docker-compose -f docker-compose.stress.yml up -d
+
+# Wait for the server to be ready
+curl -sf -u admin:root http://127.0.0.1:6363/api/ > /dev/null && echo ready
+
+# Run the stress test
+STRESS_DURATION_SECONDS=300 \
+  STRESS_CONCURRENCY=4 \
+  TERMINUSDB_BASE_URL=http://127.0.0.1:6363 \
+  TERMINUSDB_USER=admin \
+  TERMINUSDB_PASSWORD=root \
+  node stress.js
+
+# Stop and clean up
+docker-compose -f docker-compose.stress.yml down -v
+```
+
+## Adjusting CPU throttling
+
+Edit `cpus` in `docker-compose.stress.yml`:
+
+```yaml
+deploy:
+  resources:
+    limits:
+      cpus: '0.5'
+```
+
+Values lower than 0.5 increase contention but may make the container
+unresponsive. Values higher than 1.0 reduce overlap.
+
+## Expected result
+
+The test prints operation counts and a log scan. A successful run shows:
+
+```
+Log scan:
+  HTTP 500 responses: 0
+  Optimization failed: 0
+  "builder has already been committed": 0
+  "unexpected_commit_failure": 0
+
+Result: PASS (no contention artifacts detected in log)
+```
+
+## Interpreting failures
+
+If any of the scanned counts are non-zero:
+1. Inspect `terminusdb-stress.log` for the failing request.
+2. Look for surrounding `commit_graph` / optimization messages.
+3. Check whether the failure correlates with the CPU limit or concurrency.
+
+## Clean-up
+
+Both the script and the manual commands use `down -v`, which removes the
+container and the named volume. If you interrupted the script, clean up with:
+
+```bash
+docker-compose -f docker-compose.stress.yml down -v
+```

--- a/tests/manual/commit_queue_contention/README.md
+++ b/tests/manual/commit_queue_contention/README.md
@@ -1,0 +1,110 @@
+# Commit-queue contention stress test
+
+Manual test that runs concurrent document inserts, branch creation, rebase,
+push, and explicit optimize calls against a single database while the
+auto-optimize plugin is enabled. It is intended to detect 500 errors caused by
+races between the commit funnel and scheduled optimizations.
+
+## Requirements
+
+- A running TerminusDB server (test server is easiest).
+- The auto-optimize plugin enabled (`TERMINUSDB_PLUGINS_PATH`).
+- Node.js with the test dependencies installed (`npm install` in `tests/`).
+
+## Run
+
+### Quick structural test (local test server)
+
+```bash
+# From the terminusdb repo root
+TERMINUSDB_PLUGINS_PATH="/path/to/terminusdb/docker/plugins" \
+  ./tests/terminusdb-test-server.sh start --clean
+
+# In another terminal, from the tests/ directory
+cd tests
+node manual/commit_queue_contention/stress.js
+```
+
+### CPU-throttled run in Docker
+
+This is the run that most closely reproduces the original race. The container
+is limited to half a CPU, so commits and scheduled optimizations overlap
+heavily.
+
+```bash
+# From the repo root
+make docker SKIP_TESTS=true
+
+# Run the bundled script (defaults to 120 seconds)
+cd tests/manual/commit_queue_contention
+./run-stress-in-docker.sh
+
+# Or run for a specific duration
+./run-stress-in-docker.sh 300
+```
+
+The script starts a container on port 6363, waits for the server, runs the
+stress test, writes `terminusdb-stress.log`, and stops the container.
+
+You can also manage the container manually:
+
+```bash
+cd tests/manual/commit_queue_contention
+
+# Start the throttled container
+docker-compose -f docker-compose.stress.yml up -d
+
+# Wait for the server to be ready, then run the test
+STRESS_DURATION_SECONDS=300 \
+  STRESS_CONCURRENCY=4 \
+  TERMINUSDB_BASE_URL=http://127.0.0.1:6363 \
+  TERMINUSDB_USER=admin \
+  TERMINUSDB_PASSWORD=root \
+  node stress.js
+
+# Stop and clean up
+docker-compose -f docker-compose.stress.yml down -v
+```
+
+To change the CPU limit, edit `cpus` in `docker-compose.stress.yml`.
+
+## Environment variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `TERMINUSDB_BASE_URL` | `http://127.0.0.1:6363` | Server URL. |
+| `TERMINUSDB_USER` | `admin` | Basic-auth user. |
+| `TERMINUSDB_PASSWORD` | `root` | Basic-auth password. |
+| `TERMINUSDB_LOG` | `tests/.terminusdb-test.log` | Server log to scan. |
+| `STRESS_DURATION_SECONDS` | `60` | How long to run the workload. |
+| `STRESS_CONCURRENCY` | `4` | Number of concurrent workers. |
+
+## What it does
+
+- Creates a fresh database with a simple `StressDoc` schema.
+- Starts `STRESS_CONCURRENCY` workers that each loop for the configured
+  duration.
+- Each worker picks a random operation:
+  - Insert a document into `main` or one of four feature branches.
+  - Create a feature branch from `main`.
+  - Rebase a feature branch onto `main`.
+  - Push the current state to a feature branch.
+  - Explicitly optimize a feature branch via `/api/optimize`.
+- Counts successful operations and expected 4xx failures.
+- Scans the server log for 500 responses, failed optimizations,
+  `builder has already been committed`, and `unexpected_commit_failure`.
+
+## Interpreting results
+
+- **PASS**: No 500 responses, no optimization failures, no
+  `builder has already been committed`, and no `unexpected_commit_failure` in
+  the log. The test ran successfully under contention.
+- **FAIL**: One of the above artifacts appears. The log should be inspected for
+  the failing request and surrounding commit/optimization messages.
+
+## Notes
+
+- Rebase and push often fail with 4xx because the random branch may not have
+  divergent history. Those failures are counted but do not fail the test.
+- The test does not apply CPU throttling itself. To maximize overlap, run it
+  under `cpulimit`/`cputhrottle` or on a loaded machine.

--- a/tests/manual/commit_queue_contention/docker-compose.stress.yml
+++ b/tests/manual/commit_queue_contention/docker-compose.stress.yml
@@ -1,0 +1,25 @@
+services:
+  terminusdb-stress:
+    image: terminusdb/terminusdb-server:local
+    container_name: terminusdb-stress
+    hostname: terminusdb-stress
+    ports:
+      - 6363:6363
+    environment:
+      - TERMINUSDB_SERVER_PORT=6363
+      - TERMINUSDB_ADMIN_PASS=root
+      - TERMINUSDB_PLUGINS_PATH=/plugins
+      - TERMINUSDB_LOG_LEVEL=DEBUG
+      - TERMINUSDB_LOG_FORMAT=text
+    volumes:
+      - terminusdb-stress-storage:/app/terminusdb/storage
+    deploy:
+      resources:
+        limits:
+          # Throttle the server to create overlap between commits and
+          # optimizations. The original race reproduced reliably at 0.2-0.3
+          # CPUs; adjust upward only if the container becomes unresponsive.
+          cpus: '0.2'
+
+volumes:
+  terminusdb-stress-storage:

--- a/tests/manual/commit_queue_contention/run-stress-in-docker.sh
+++ b/tests/manual/commit_queue_contention/run-stress-in-docker.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build the local Docker image and run the stress test against a CPU-throttled
+# TerminusDB container. The container is configured to use the auto-optimize
+# plugin and exposes the server on port 6363.
+#
+# Usage:
+#   cd tests/manual/commit_queue_contention
+#   ./run-stress-in-docker.sh [STRESS_DURATION_SECONDS]
+
+DURATION="${1:-120}"
+IMAGE="terminusdb/terminusdb-server:local"
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+
+if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+  echo "Local image $IMAGE not found. Building it now..."
+  docker build "$REPO_ROOT" \
+    --file "$REPO_ROOT/Dockerfile" \
+    --tag "$IMAGE" \
+    --build-arg SWIPL_VERSION="${SWIPL_VERSION:-10.0.1}" \
+    --build-arg SKIP_TESTS=true \
+    --build-arg DIST=community \
+    --build-arg TERMINUSDB_GIT_HASH="$(cd "$REPO_ROOT" && git rev-parse --verify HEAD)"
+fi
+
+echo "Starting CPU-throttled TerminusDB container..."
+docker-compose -f docker-compose.stress.yml down -v 2>/dev/null || true
+docker-compose -f docker-compose.stress.yml up -d
+
+# Wait for the server to be ready.
+echo "Waiting for server..."
+for i in $(seq 1 60); do
+  if curl -sf -u admin:root http://127.0.0.1:6363/api/ > /dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+if ! curl -sf -u admin:root http://127.0.0.1:6363/api/ > /dev/null 2>&1; then
+  echo "Server did not become ready in time."
+  docker-compose -f docker-compose.stress.yml logs
+  docker-compose -f docker-compose.stress.yml down -v
+  exit 1
+fi
+
+echo "Running stress test for ${DURATION}s..."
+set +e
+STRESS_DURATION_SECONDS="$DURATION" \
+  STRESS_CONCURRENCY=4 \
+  TERMINUSDB_BASE_URL=http://127.0.0.1:6363 \
+  TERMINUSDB_USER=admin \
+  TERMINUSDB_PASSWORD=root \
+  node stress.js
+RESULT=$?
+set -e
+
+echo "Collecting container logs..."
+docker-compose -f docker-compose.stress.yml logs > terminusdb-stress.log
+
+HTTP_500_COUNT=$(grep -cE '\(500\)' terminusdb-stress.log || true)
+OPTIMIZE_FAILED_COUNT=$(grep -icE 'Optimization of .* failed' terminusdb-stress.log || true)
+BUILDER_COMMITTED_COUNT=$(grep -cE 'builder has already been committed' terminusdb-stress.log || true)
+UNEXPECTED_COMMIT_COUNT=$(grep -cE 'unexpected_commit_failure' terminusdb-stress.log || true)
+
+echo ""
+echo "Container log scan:"
+echo "  HTTP 500 responses: ${HTTP_500_COUNT}"
+echo "  Optimization failed: ${OPTIMIZE_FAILED_COUNT}"
+echo "  \"builder has already been committed\": ${BUILDER_COMMITTED_COUNT}"
+echo "  \"unexpected_commit_failure\": ${UNEXPECTED_COMMIT_COUNT}"
+echo ""
+
+if [ "$OPTIMIZE_FAILED_COUNT" -gt 0 ] || [ "$BUILDER_COMMITTED_COUNT" -gt 0 ] || [ "$UNEXPECTED_COMMIT_COUNT" -gt 0 ]; then
+  echo "Result: FAIL (race-condition artifacts detected in container log)"
+  RESULT=1
+elif [ "$RESULT" -ne 0 ]; then
+  echo "Result: FAIL (stress test reported unexpected operation failures)"
+else
+  echo "Result: PASS (no race-condition artifacts detected in container log)"
+fi
+
+echo "Stopping container..."
+docker-compose -f docker-compose.stress.yml down -v
+
+exit $RESULT

--- a/tests/manual/commit_queue_contention/stress.js
+++ b/tests/manual/commit_queue_contention/stress.js
@@ -1,0 +1,307 @@
+const { Agent } = require('../../lib/agent')
+const fs = require('node:fs')
+const path = require('node:path')
+
+/**
+ * Manual stress test for commit-queue / auto-optimize contention.
+ *
+ * Interleaves document inserts, branch creation, rebase, push, and explicit
+ * optimize calls on the same database while the auto-optimize plugin is
+ * enabled. The test itself does not assert behavior; it only reports the number
+ * of successful/failed operations and scans the server log for 500 errors and
+ * optimization failures.
+ *
+ * Run with:
+ *   TERMINUSDB_PLUGINS_PATH="/path/to/docker/plugins" \
+ *     /path/to/tests/terminusdb-test-server.sh start --clean
+ *   cd /path/to/tests
+ *   node manual/commit_queue_contention/stress.js
+ */
+
+const BASE_URL = process.env.TERMINUSDB_BASE_URL || 'http://127.0.0.1:6363'
+const LOG_FILE = process.env.TERMINUSDB_LOG ||
+      path.resolve(__dirname, '../../.terminusdb-test.log')
+
+const DURATION_SECONDS = Number(process.env.STRESS_DURATION_SECONDS || 60)
+const CONCURRENCY = Number(process.env.STRESS_CONCURRENCY || 4)
+const REQUEST_TIMEOUT_MS = Number(process.env.STRESS_REQUEST_TIMEOUT_MS || 120000)
+const SHUTDOWN_TIMEOUT_MS = Number(process.env.STRESS_SHUTDOWN_TIMEOUT_MS || 60000)
+const ERROR_LOG_FILE = process.env.STRESS_ERROR_LOG ||
+      path.resolve(__dirname, 'stress-errors.log')
+
+const agent = new Agent({ baseUrl: BASE_URL }).auth({})
+
+let inFlight = 0
+
+let nextDocCounter = 0
+const existingBranches = new Set(['main'])
+const stats = {
+  insert: { ok: 0, fail: 0, skip: 0 },
+  branch: { ok: 0, fail: 0, skip: 0 },
+  rebase: { ok: 0, fail: 0, skip: 0 },
+  optimize: { ok: 0, fail: 0, skip: 0 },
+}
+
+async function sleep (ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function retry (fn, retries = 3) {
+  let lastError
+  for (let i = 0; i < retries; i++) {
+    try {
+      return await fn()
+    } catch (err) {
+      lastError = err
+      await sleep(50 * (i + 1))
+    }
+  }
+  throw lastError
+}
+
+function dbPath (operation) {
+  return `/api/${operation}/${agent.orgName}/${agent.dbName}`
+}
+
+async function ensureDb () {
+  agent.dbName = 'stress-' + Date.now()
+
+  const createResponse = await agent.post(dbPath('db')).timeout(REQUEST_TIMEOUT_MS).send({
+    label: 'stress test database',
+    comment: '',
+  })
+  if (createResponse.status >= 400 && createResponse.status !== 409) {
+    throw new Error(`Database creation failed: ${createResponse.status} ${JSON.stringify(createResponse.body)}`)
+  }
+
+  await retry(async () => {
+    const response = await agent.post(dbPath('document')).query({
+      graph_type: 'schema',
+      author: 'stress',
+      message: 'stress schema',
+      merge_repeats: false,
+    }).timeout(REQUEST_TIMEOUT_MS).send({
+      '@type': 'Class',
+      '@id': 'StressDoc',
+      '@key': { '@type': 'Lexical', '@fields': ['counter'] },
+      counter: 'xsd:integer',
+      label: 'xsd:string',
+    })
+    if (response.status >= 400) {
+      throw new Error(`Schema insert failed: ${response.status} ${JSON.stringify(response.body)}`)
+    }
+  })
+
+  // Pre-create the feature branches so workers do not race on branch creation.
+  for (let i = 0; i < 4; i++) {
+    const branchName = `feature-${i}`
+    const response = await createBranch(branchName, 'main')
+    if (response.status === 200 || response.status === 409) {
+      existingBranches.add(branchName)
+    }
+  }
+}
+
+async function insertDoc (branchName = 'main') {
+  const n = ++nextDocCounter
+  return agent.post(dbPath('document')).query({
+    graph_type: 'instance',
+    author: 'stress',
+    message: `insert ${n}`,
+    merge_repeats: false,
+  }).timeout(REQUEST_TIMEOUT_MS).send({
+    '@type': 'StressDoc',
+    counter: n,
+    label: `doc-${n}`,
+  })
+}
+
+async function createBranch (branchName, origin) {
+  const response = await agent.post(dbPath('branch') + `/local/branch/${branchName}`).timeout(REQUEST_TIMEOUT_MS).send({
+    origin: `${agent.orgName}/${agent.dbName}/local/branch/${origin}`,
+  })
+  if (response.status === 200 || response.status === 409) {
+    existingBranches.add(branchName)
+  }
+  return response
+}
+
+async function rebaseBranch (branchName) {
+  if (!existingBranches.has(branchName)) {
+    const err = new Error('Branch does not exist')
+    err.skip = true
+    throw err
+  }
+  return agent.post(dbPath('rebase')).timeout(REQUEST_TIMEOUT_MS).send({
+    rebase_from: `${agent.orgName}/${agent.dbName}/local/branch/${branchName}`,
+    author: 'stress',
+  })
+}
+
+async function explicitOptimize (branchName) {
+  const descriptor = `${agent.orgName}/${agent.dbName}/local/branch/${branchName}`
+  return agent.post(`/api/optimize/${descriptor}`).timeout(REQUEST_TIMEOUT_MS).send({})
+}
+
+async function runWithCheck (operation, promise) {
+  inFlight += 1
+  let response
+  try {
+    response = await promise
+  } catch (err) {
+    if (err.status >= 500) {
+      response = err.response
+    } else {
+      throw err
+    }
+  } finally {
+    inFlight -= 1
+  }
+
+  if (response.status >= 500) {
+    const body = JSON.stringify(response.body || response.text)
+    const line = `${new Date().toISOString()} ${operation} ${response.status} ${body}\n`
+    fs.appendFileSync(ERROR_LOG_FILE, line)
+    const err = new Error(`Server error ${response.status}: ${body}`)
+    err.status = response.status
+    err.responseBody = body
+    throw err
+  }
+
+  return response
+}
+
+function isExpectedSetupError (operation, err) {
+  return Boolean(err.skip) ||
+    (operation === 'rebase' && /source_branch_not_found/.test(err.message)) ||
+    (operation === 'insert' && /can_not_insert_existing_object_with_id/.test(err.message))
+}
+
+const OPERATIONS = [
+  {
+    name: 'insert',
+    threshold: 0.5,
+    run: async (branchName) => runWithCheck('insert', insertDoc(Math.random() < 0.7 ? 'main' : branchName)),
+  },
+  {
+    name: 'branch',
+    threshold: 0.6,
+    run: async (branchName) => {
+      try {
+        await runWithCheck('branch', createBranch(branchName, 'main'))
+      } catch (err) {
+        // Branch may already exist; count as success to keep the loop moving.
+      }
+    },
+  },
+  {
+    name: 'rebase',
+    threshold: 0.7,
+    run: async (branchName) => runWithCheck('rebase', rebaseBranch(branchName)),
+  },
+  {
+    name: 'optimize',
+    threshold: 1.0,
+    run: async (branchName) => runWithCheck('optimize', explicitOptimize(branchName)),
+  },
+]
+
+async function randomOperation () {
+  const branchName = `feature-${Math.floor(Math.random() * 4)}`
+  const roll = Math.random()
+  const operation = OPERATIONS.find((op) => roll < op.threshold)
+
+  try {
+    await operation.run(branchName)
+    stats[operation.name].ok += 1
+  } catch (err) {
+    if (isExpectedSetupError(operation.name, err)) {
+      // Expected when the stress test races ahead of its own branch setup.
+      // Do not count as a server failure.
+      stats[operation.name].skip = (stats[operation.name].skip || 0) + 1
+    } else {
+      stats[operation.name].fail += 1
+    }
+  }
+}
+
+async function workerLoop (stop) {
+  while (!stop.value) {
+    await randomOperation()
+    await sleep(20 + Math.random() * 80)
+  }
+}
+
+async function run () {
+  // Clear the error log from any previous run.
+  try { fs.unlinkSync(ERROR_LOG_FILE) } catch (_) { /* ignore */ }
+
+  await ensureDb()
+
+  const stop = { value: false }
+  const workers = []
+  for (let i = 0; i < CONCURRENCY; i++) {
+    workers.push(workerLoop(stop))
+  }
+
+  const startTime = new Date()
+  console.log(`[${startTime.toISOString()}] Starting stress test for ${DURATION_SECONDS}s with concurrency ${CONCURRENCY} against ${BASE_URL}`)
+  console.log(`Database: ${agent.dbName}`)
+  console.log(`Log file: ${LOG_FILE}`)
+  console.log(`Request timeout: ${REQUEST_TIMEOUT_MS}ms, shutdown timeout: ${SHUTDOWN_TIMEOUT_MS}ms`)
+  console.log('')
+
+  await sleep(DURATION_SECONDS * 1000)
+  stop.value = true
+  const stopTime = new Date()
+  const runDuration = stopTime - startTime
+  console.log(`\n[${stopTime.toISOString()}] Stopping workers... ${inFlight} request(s) in flight (ran for ${runDuration}ms)`)
+  const shutdown = await Promise.race([
+    Promise.all(workers),
+    sleep(SHUTDOWN_TIMEOUT_MS).then(() => 'timeout'),
+  ])
+
+  const exitTime = new Date()
+  const shutdownDuration = exitTime - stopTime
+
+  if (shutdown === 'timeout') {
+    console.log(`\n[${exitTime.toISOString()}] WARNING: ${inFlight} request(s) still in flight after shutdown timeout (${shutdownDuration}ms) - workers are stuck`)
+    console.log('Result: FAIL (in-flight requests did not terminate cleanly)')
+    process.exit(1)
+  }
+
+  console.log(`\n[${exitTime.toISOString()}] All workers stopped cleanly (shutdown took ${shutdownDuration}ms)`)
+  console.log('Operation counts:')
+  console.log(JSON.stringify(stats, null, 2))
+
+  const log = fs.existsSync(LOG_FILE) ? fs.readFileSync(LOG_FILE, 'utf8') : ''
+  const logRelevant = log.includes(agent.dbName)
+  const errors500 = logRelevant ? (log.match(/\(500\)/g) || []).length : 0
+  const optimizeFailed = logRelevant ? (log.match(/Optimization of .* failed/gi) || []).length : 0
+  const builderCommitted = logRelevant ? (log.match(/builder has already been committed/g) || []).length : 0
+  const unexpectedCommit = logRelevant ? (log.match(/unexpected_commit_failure/g) || []).length : 0
+
+  console.log('')
+  console.log('Log scan:')
+  if (!logRelevant) {
+    console.log(`  Skipped: ${LOG_FILE} does not contain entries for ${agent.dbName}`)
+  } else {
+    console.log(`  HTTP 500 responses: ${errors500}`)
+    console.log(`  Optimization failed: ${optimizeFailed}`)
+    console.log(`  "builder has already been committed": ${builderCommitted}`)
+    console.log(`  "unexpected_commit_failure": ${unexpectedCommit}`)
+  }
+  console.log('')
+
+  if (errors500 + optimizeFailed + builderCommitted + unexpectedCommit > 0) {
+    console.log('Result: FAIL (contention artifacts detected)')
+    process.exit(1)
+  } else {
+    console.log('Result: PASS (no contention artifacts detected in log)')
+  }
+}
+
+run().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
This PR builds on #2457 that should be merged first.

`POST /api/rebase/<org>/<db>/local/branch/main` intermittently returned HTTP 500 with `Unexpected failure in request handler`. The failure correlated with the auto-optimizer running on the same database immediately before the rebase. The root cause was a race on the `_meta` graph head.

The rebase path in `db_rebase.pl` updates the repository head in the `_meta` graph and then commits the database transaction with `run_transactions/3`. The auto-optimizer, triggered by `post_commit_hook` from an earlier commit, runs in a detached thread and squashes the `_meta` graph head using `nb_force_set_head/3`. Squashing creates a new base layer, so the new layer the rebase is about to commit is no longer a child of the current head. `nb_set_head/2` in the database commit path then fails silently, the rebase predicate fails, and the HTTP handler returns a generic 500.

## Improvements

In addition to fixing the race issue, a queue processing worker issue was fixed, improving some parallel processing scenarios further than the PR baseline this PR is based on. The `bench.py` file in `tests/benchmark/congestion_document_insert` can be used to test the parallel write performance baseline for simple documents. For 80k documents written with 2 writers using 20k chunks; it writes approx. 24000 documents/second now. Sequential writes with a single writer is also quite good with 19k/sec. (most of the improvement work was in the other PR).

```json
{
  "benchmark": "congestion_document_insert",
  "metrics": {
    "writers": 2,
    "chunks_per_writer": 2,
    "docs_per_chunk": 20000,
    "parallel": {
      "total_ms": 3280.2743749998626,
      "documents": 80000,
      "chunks": 4,
      "documents_per_second": 24388.203806885314,
      "ms_per_document": 0.04100342968749828,
      "verified_documents": 80000
    },
    "sequential": {
      "total_ms": 4085.8709160002036,
      "documents": 80000,
      "chunks": 4,
      "documents_per_second": 19579.668972585823,
      "ms_per_document": 0.05107338645000255,
      "verified_documents": 80000
    },
    "congestion_ratio": 0.8028335800219145
  }
}
```

This PR brings more of the write path into the queue-based processing.

## What changed

This fix builds on a separate PR that improves parallel write performance and reliability by introducing a new commit orchestration pipeline. The new pipeline focuses on the instance document write path, and this PR both fixes the race, and integrates the new commit pipeline for rebase and push; fixing the optimization race.

The new `meta_commit_queue` module provides a recursive, per-database lock. The lock serializes writes to the shared `_meta` graph, system graphs, and any database-related graph, so that background optimization cannot change a graph head while a branch/database state-changing operation is in its commit window.

The following modules were changed:

1. **`src/core/document/meta_commit_queue.pl`** (new) – recursive, per-database lock (`with_meta_commit_lock/2`, `with_meta_commit_locks/2`), global mutex creation guard, and `graph_label_to_lock_key/2` to map any database-related graph label (including repository `_commits` and branch instance/schema graphs) back to the database lock key, while system graph labels map to a dedicated `system_meta` key.

2. **`src/core/transaction/database.pl`** – `run_transactions/4` acquires the lock for every database descriptor and system descriptor in the transaction set before `commit_validation_objects/2` runs. The lock is released before `post_commit_hook` so plugins such as the auto-optimizer do not deadlock.

3. **`src/core/api/db_rebase.pl`** – `rebase_on_branch/9` holds the database lock from the repository head update through the database commit. This is the exact window in which the optimizer was racing with the rebase.

4. **`src/core/api/db_push.pl`** – both remote URL and local shared-store push branches hold the same database lock across the repository-head update and the database commit.

5. **`src/core/api/api_optimize.pl`** – `named_graph_optimize/1` uses `graph_label_to_lock_key/2` to acquire the correct lock while reading the head, squashing, and setting the new head.

6. **`src/core/api/db_delete.pl`** – `delete_database_label/2` holds the database lock while calling `safe_delete_named_graph/2`, preventing the optimizer from touching a graph that is being deleted.

7. **`src/core/document/commit_queue.pl`** – new optimization scheduling state and active-branch tracking. Pending branch and database optimizations are recorded under the scheduler mutex; active-branch counts are incremented when `pick_next_branch/2` hands a branch to a worker and decremented in `requeue_branch/1` when the worker leaves. When a branch queue drains, any pending branch optimization is run under the mapped database lock; when the database active-branch count reaches zero, any pending database `_meta` optimization is run. Database-level optimizations for database keys that have no tracked branch activity (e.g. `system_meta`) are placed on a new global task queue and processed by idle commit workers. A deadline rule uses `*_due/1` flags so that a second optimization request for the same branch/database is scheduled for immediate execution in the commit flow as soon as the relevant queue drains, rather than being dropped or running synchronously in the caller thread.

8. **`docker/plugins/auto-optimize.pl`** – the probabilistic `maybe_optimize/1` trigger is kept, but when it fires it now calls `commit_queue:schedule_database_optimization/1` and `commit_queue:schedule_branch_optimization/1` for the descriptors in the validation objects instead of spawning a dedicated optimization thread. The `optimization_running` flag and `optimization_thread_wrapper` are removed; the commit queue enforces single-flight behavior and the deadline path.

## Commit queue alignment

- **Rebase now uses a verification contract.** In `src/core/api/db_rebase.pl`, the request thread does the expensive history computation and commit replay outside the lock, then submits a `rebase_contract` dict to the branch commit queue. The worker, which already holds the branch lock, verifies the target branch head, performs the final relink, and runs the database commit under the `meta_commit_lock`. If the head moved, the worker rejects the contract and the request thread immediately retries synchronously.
- **Explicit optimize is queued and deferred until idle.** The server route now calls `api_optimize_queued/3` in `src/core/api/api_optimize.pl`. For branch descriptors, this enqueues an `optimize_when_idle` contract. The worker only runs the rollup when the branch queue is empty; otherwise it puts the package back and continues processing commits. The worker retries immediately once if the label version changed, and returns the underlying `label_version_changed` error if the second attempt also fails, so the existing optimize error handler formats it correctly.
- **Commit-queue dispatch is multi-type.** `src/core/document/commit_queue.pl` no longer assumes every queued package is a document commit. It inspects `package_type` and dispatches to `run_commit_package`, `run_rebase_contract`, or the idle-defer path for `optimize_when_idle`.
- **Synchronous fallback for tests.** When the worker pool is not running (e.g. during most PLUnit tests), rebase falls back to running the final commit window synchronously in the request thread, still under the `meta_commit_lock`. This preserves the existing unit-test behavior without requiring a worker pool.
- **Rebase error formatting is registered.** `src/core/api/api_error.pl` now declares `error_type_(rebase, 'api:RebaseErrorResponse')` so generic errors such as `commit_queue_timeout` that escape the rebase handler are serialized correctly.
- **Shared reply delivery.** `api_document:deliver_commit_result/2` is now exported and reused by the rebase and optimize worker predicates, removing the duplicate `deliver_rebase_result` and `deliver_optimize_result` predicates.
- **Fix error double-wrapping in the commit queue request path.** `api_document:handle_commit_result/3` was re-wrapping exceptions that were already `error(Formal, Context)` terms, causing unhandled 500 responses. It now throws the original exception term directly when it is already an error.

## Code review fixes

- **`src/core/document/commit_queue.pl`**
  - `branch_key_database_key/2` now parses the organization/database prefix of a resolved branch key and calls `organization_database_name/3`, so the active-branch count key matches the lock key used by `database_key_from_descriptor/2` and `meta_commit_queue`.
  - `cleanup_active_branches_for_worker/1` now decrements `database_active_branch_count` for every stranded `active_branch` entry it removes, preventing leaked counts when a worker is killed or crashes.
  - `schedule_database_optimization/1` now accepts repository descriptors (they are database-level work) and schedules them on a new global task queue for database keys that have no tracked branch activity, such as `system_meta`. Idle commit workers process the global queue instead of running the optimization synchronously in the scheduling thread.
  - `schedule_branch_optimization/1` is now restricted to branch descriptors only; repository descriptors are no longer misplaced on a branch queue that will never drain.
  - Added tests for the global task queue path and the due-flag deadline behavior, and updated the active-branch count and database-key tests to use the lock-key format.

The lock is recursive so that a high-level operation like rebase or push can hold the lock while `run_transactions/3` re-enters it for the database transaction object.

## Regression tests

- `rebase_races_with_database_optimize` in `src/core/api/db_rebase.pl` reproduced the original race deterministically. It runs the rebase while a background thread optimizes the `admin/foo/_meta` descriptor. Before the fix, the rebase fails; after the fix, the rebase completes successfully and the optimizer thread exits cleanly. It is placed in a separate `rebase_race` test block with `[concurrent(false)]` because it uses a global hook and thread registration that must not leak into other concurrently running rebase tests.

- New `meta_commit_queue` unit tests in `src/core/document/meta_commit_queue.pl` cover system graph label mapping, database/branch/repo graph label mapping, and recursive same-thread locking.

- New `commit_queue` scheduling tests in `src/core/document/commit_queue.pl` cover database-key derivation, active-branch count tracking and the negative-count invariant, pending/due scheduling state, branch optimization running when the branch queue empties, the deadline rule for a second branch optimization, database optimization running only when the database has no active branches, and the global task queue for system/untracked database optimizations.