### PR TITLE
Show active engine, and sensitive info only when authenticated

### DIFF
--- a/src/core/api/api_info.pl
+++ b/src/core/api/api_info.pl
@@ -3,16 +3,12 @@
 :- use_module(core(util)).
 :- use_module(core(triple)).
 :- use_module(config(terminus_config), [terminusdb_version/1,
-                                        is_memory_mode/0]).
+                                        is_memory_mode/0,
+                                        is_enterprise/0]).
 
 :- use_module(library(terminus_store), [terminus_store_version/1]).
 
 info(_System_DB, Auth, Info) :-
-
-    do_or_die(
-        Auth \= doc:anonymous,
-        error(access_not_authorized(Auth),_)),
-
     terminusdb_version(TerminusDB_Version),
     terminus_store_version(TerminusDB_Store_Version),
     current_prolog_flag(terminusdb_git_hash, Git_Hash),
@@ -22,9 +18,23 @@ info(_System_DB, Auth, Info) :-
     ;   get_db_version(Storage_Version)
     ),
     number_string(Storage_Version, Storage_Version_String),
+    server_edition(Edition),
+    http_engine(Http_Engine),
 
-    Info = _{
+    (   is_anonymous_authority(Auth)
+    ->  Info = _{
                authority: Auth,
+               edition: Edition,
+               http_engine: Http_Engine,
+               storage:
+               _{
+                   version: Storage_Version_String
+               }
+           }
+    ;   Info = _{
+               authority: Auth,
+               edition: Edition,
+               http_engine: Http_Engine,
                terminusdb :
                _{
                    version : TerminusDB_Version,
@@ -38,4 +48,128 @@ info(_System_DB, Auth, Info) :-
                _{
                    version: Storage_Version_String
                }
-           }.
+           }
+    ).
+
+%% server_edition(-Edition) is det.
+%
+%  Reports which TerminusDB edition is running. The value is the atom
+%  `community` for the open source build and `enterprise` when the
+%  enterprise extension is loaded (terminusdb_enterprise flag set).
+server_edition(enterprise) :-
+    is_enterprise,
+    !.
+server_edition(community).
+
+%% http_engine(-Engine) is det.
+%
+%  Reports which HTTP engine is serving requests. The value is the atom
+%  `metal` when the Rust webserver is active (the default) and `swipl`
+%  when the traditional SWI-Prolog HTTP server is selected via
+%  TERMINUSDB_SERVER_BACKEND=swipl.
+http_engine(Engine) :-
+    (   getenv('TERMINUSDB_SERVER_BACKEND', BackendEnv)
+    ->  atom_string(BackendEnv, BackendAtom),
+        downcase_atom(BackendAtom, Backend),
+        (   Backend == swipl
+        ->  Engine = swipl
+        ;   Engine = metal
+        )
+    ;   Engine = metal
+    ).
+
+%% is_anonymous_authority(+Auth) is semidet.
+%
+%  True when Auth is the anonymous user authority, i.e. the request was
+%  made without any authentication credentials. The anonymous authority
+%  URI is the same one asserted by authenticate/3 in routes.pl when no
+%  authentication information is submitted.
+is_anonymous_authority('terminusdb://system/data/User/anonymous') :- !.
+is_anonymous_authority(doc:anonymous) :- !.
+
+:- begin_tests(api_info, []).
+:- use_module(core(util/test_utils)).
+:- use_module(core(triple/constants), [super_user_authority/1]).
+:- use_module(config(terminus_config), [set_memory_mode/0,
+                                        is_memory_mode/0]).
+
+% server_edition/1 is pure logic over the terminusdb_enterprise flag.
+% It reports the atom `community` for the open source build and
+% `enterprise` when the enterprise extension is loaded.
+test(server_edition_is_atom) :-
+    server_edition(Edition),
+    atom(Edition).
+
+test(server_edition_matches_enterprise_flag) :-
+    server_edition(Edition),
+    (   is_enterprise
+    ->  Edition == enterprise
+    ;   Edition == community
+    ).
+
+% http_engine/1 reports the HTTP engine serving requests. The default is
+% `metal` (the Rust webserver); `swipl` is selected only when
+% TERMINUSDB_SERVER_BACKEND=swipl is set.
+test(http_engine_default_is_metal,
+     [setup(unsetenv('TERMINUSDB_SERVER_BACKEND')),
+      cleanup(unsetenv('TERMINUSDB_SERVER_BACKEND'))]) :-
+    http_engine(Engine),
+    Engine == metal.
+
+test(http_engine_swipl_when_env_set,
+     [setup(setenv('TERMINUSDB_SERVER_BACKEND', 'swipl')),
+      cleanup(unsetenv('TERMINUSDB_SERVER_BACKEND'))]) :-
+    http_engine(Engine),
+    Engine == swipl.
+
+test(http_engine_metal_when_env_set,
+     [setup(setenv('TERMINUSDB_SERVER_BACKEND', 'rust')),
+      cleanup(unsetenv('TERMINUSDB_SERVER_BACKEND'))]) :-
+    http_engine(Engine),
+    Engine == metal.
+
+test(http_engine_case_insensitive,
+     [setup(setenv('TERMINUSDB_SERVER_BACKEND', 'SWIPL')),
+      cleanup(unsetenv('TERMINUSDB_SERVER_BACKEND'))]) :-
+    http_engine(Engine),
+    Engine == swipl.
+
+% is_anonymous_authority/1 recognises both the anonymous URI used by the
+% route handler and the doc:anonymous term.
+test(is_anonymous_authority_uri) :-
+    is_anonymous_authority('terminusdb://system/data/User/anonymous').
+test(is_not_anonymous_authority_for_admin) :-
+    \+ is_anonymous_authority('terminusdb://system/data/User/admin').
+
+% info/3 for a logged-in user includes all sections.
+test(info_logged_in_includes_all_sections,
+     [setup((setup_temp_store(State),
+             set_memory_mode)),
+      cleanup((terminus_config:retractall(memory_mode_enabled),
+               teardown_temp_store(State)))
+     ]) :-
+    super_user_authority(Auth),
+    info(_System_DB, Auth, Info),
+    get_dict(authority, Info, Auth),
+    get_dict(edition, Info, _),
+    get_dict(http_engine, Info, _),
+    get_dict(terminusdb, Info, _),
+    get_dict(terminusdb_store, Info, _),
+    get_dict(storage, Info, _).
+
+% info/3 for an anonymous user omits terminusdb and terminusdb_store.
+test(info_anonymous_omits_version_sections,
+     [setup((setup_temp_store(State),
+             set_memory_mode)),
+      cleanup((terminus_config:retractall(memory_mode_enabled),
+               teardown_temp_store(State)))
+     ]) :-
+    info(_System_DB, 'terminusdb://system/data/User/anonymous', Info),
+    get_dict(authority, Info, 'terminusdb://system/data/User/anonymous'),
+    get_dict(edition, Info, _),
+    get_dict(http_engine, Info, _),
+    get_dict(storage, Info, _),
+    \+ get_dict(terminusdb, Info, _),
+    \+ get_dict(terminusdb_store, Info, _).
+
+:- end_tests(api_info).

--- a/src/server/main.pl
+++ b/src/server/main.pl
@@ -111,12 +111,16 @@ terminus_server(Argv,Wait) :-
 
 %% server_backend(-Backend) is det.
 %%
-%  Read TERMINUSDB_SERVER_BACKEND (default `swipl`).
+%  Read TERMINUSDB_SERVER_BACKEND (default `rust`).
+%
+%  The Rust webserver is the default backend for both the community and
+%  enterprise builds. The traditional SWI-Prolog HTTP server remains
+%  available as an opt-in via TERMINUSDB_SERVER_BACKEND=swipl.
 server_backend(Backend) :-
     (   getenv('TERMINUSDB_SERVER_BACKEND', BackendEnv)
     ->  atom_string(BackendEnv, BackendAtom),
         downcase_atom(BackendAtom, Backend)
-    ;   Backend = swipl
+    ;   Backend = rust
     ).
 
 %% start_server_backend(+Backend, +Port, +Workers) is det.
@@ -203,3 +207,51 @@ welcome_banner(Server,Argv) :-
     ;   ProductName = "TerminusDB"
     ),
     print_welcome_banner(Version, ProductName, Argv, StrTime, Now, Server).
+
+:- begin_tests(server_backend_selection).
+
+% TERMINUSDB_SERVER_BACKEND may already be set in the environment that
+% launches the test process (e.g. the test server script exports it). Save
+% the current value in setup and restore it in cleanup so the tests are
+% hermetic regardless of the surrounding environment.
+
+setup :-
+    (   getenv('TERMINUSDB_SERVER_BACKEND', Current)
+    ->  assertz(saved_backend(Current))
+    ;   assertz(saved_backend(none))
+    ),
+    unsetenv('TERMINUSDB_SERVER_BACKEND').
+
+cleanup :-
+    (   retract(saved_backend(none))
+    ->  unsetenv('TERMINUSDB_SERVER_BACKEND')
+    ;   retract(saved_backend(Saved))
+    ->  setenv('TERMINUSDB_SERVER_BACKEND', Saved)
+    ;   true
+    ).
+
+test(default_is_rust, [setup(setup), cleanup(cleanup)]) :-
+    server_backend(Backend),
+    Backend == rust.
+
+test(explicit_rust, [setup(setup), cleanup(cleanup)]) :-
+    setenv('TERMINUSDB_SERVER_BACKEND', 'rust'),
+    server_backend(Backend),
+    Backend == rust.
+
+test(explicit_swipl, [setup(setup), cleanup(cleanup)]) :-
+    setenv('TERMINUSDB_SERVER_BACKEND', 'swipl'),
+    server_backend(Backend),
+    Backend == swipl.
+
+test(case_insensitive_rust, [setup(setup), cleanup(cleanup)]) :-
+    setenv('TERMINUSDB_SERVER_BACKEND', 'RUST'),
+    server_backend(Backend),
+    Backend == rust.
+
+test(case_insensitive_swipl, [setup(setup), cleanup(cleanup)]) :-
+    setenv('TERMINUSDB_SERVER_BACKEND', 'Swipl'),
+    server_backend(Backend),
+    Backend == swipl.
+
+:- end_tests(server_backend_selection).

--- a/src/server/routes/tdb_http_handler.pl
+++ b/src/server/routes/tdb_http_handler.pl
@@ -27,10 +27,9 @@
 %%  Drop-in replacement for library(http/http_dispatch):http_handler/3.
 %%
 %%  It registers the route with the SWI-Prolog HTTP dispatcher so that the
-%%  default server backend continues to work unchanged. It also registers the
-%%  route with the Rust webserver via appserver_hooks, so that when
-%%  TERMINUSDB_SERVER_BACKEND=rust is selected the Rust server can serve the
-%%  same route.
+%%  SWI-Prolog server backend continues to work when selected. It also
+%%  registers the route with the Rust webserver via appserver_hooks, so that
+%%  the Rust server (the default backend) can serve the same route.
 %%
 %%  Handler is the same closure that is normally passed to http_handler/3,
 %%  typically cors_handler(Method, Goal, ExtraOptions). Options is the same

--- a/tests/terminusdb-test-server.sh
+++ b/tests/terminusdb-test-server.sh
@@ -202,7 +202,7 @@ function restart_server() {
 
 function status() {
     local SERVER_PORT=${TERMINUSDB_SERVER_PORT:-6363}
-    local SERVER_BACKEND=${TERMINUSDB_SERVER_BACKEND:-swipl}
+    local SERVER_BACKEND=${TERMINUSDB_SERVER_BACKEND:-rust}
     if [ -f "$PID_FILE" ]; then
         local pid=$(cat "$PID_FILE")
         if ps -p "$pid" > /dev/null 2>&1; then
@@ -277,13 +277,13 @@ case "${1:-}" in
         echo "  clean                  - Stop server and remove all test data"
         echo ""
         echo "Examples:"
-        echo "  $0 start               # SWI-Prolog backend on 6363"
+        echo "  $0 start               # Rust backend on 6363"
         echo "  $0 start --clean       # Start with fresh storage"
         echo "  $0 restart --clean     # Restart with fresh storage"
         echo ""
         echo "Environment variables:"
         echo "  TERMINUSDB_SERVER_PORT     - Listen port (default: 6363)"
-        echo "  TERMINUSDB_SERVER_BACKEND  - Server backend: swipl or rust (default: swipl)"
+        echo "  TERMINUSDB_SERVER_BACKEND  - Server backend: rust or swipl (default: rust)"
         echo "  TERMINUSDB_ADMIN_PASS      - Admin password (default: root)"
         exit 1
         ;;


### PR DESCRIPTION
This makes accurate information available in /api/info; and for avoiding fingerprinting, does not show version information unless logged in.