### PR TITLE
Scaled commit history listeners plugin example

### DIFF
--- a/plugins/webserver_commits.pl
+++ b/plugins/webserver_commits.pl
@@ -1,0 +1,994 @@
+:- module(webserver_commits, []).
+
+:- use_module(core(appserver_hooks)).
+:- use_module(core(plugins)).
+:- use_module(core(util/json_log)).
+:- use_module(core(util)).
+:- use_module(core(transaction)).
+:- use_module(core(query/resolve_query_resource)).
+:- use_module(core(account/capabilities)).
+:- use_module(core(document/history)).
+:- use_module(library(lists)).
+:- use_module(library(json)).
+:- use_module(library(option)).
+:- use_module(library(date), [parse_time/3]).
+:- use_module(library(uri)).
+:- use_module(library(apply)).
+:- use_module(library(yall)).
+
+:- multifile appserver_hooks:appserver_stream/3.
+:- multifile plugins:post_commit_hook/2.
+
+%% Dynamic predicate storing active stream subscriptions.
+%% Each entry is commit_stream(StreamId, BranchPath, TimeoutThread).
+:- dynamic commit_stream/3.
+
+%% Dynamic predicate for per-branch commit dedup.
+%% The post_commit_hook fires multiple times per commit (once per
+%% validation level in the transaction chain). This tracks which
+%% commit IDs have already been broadcast to avoid duplicates.
+%% The assertion happens INSIDE the per-branch mutex so that
+%% Phase 2 (send_delta_commits) can reliably test it: if
+%% broadcast_sent(BranchPath, C) is true, the broadcast already ran
+%% under the mutex and did not find this stream (not registered yet),
+%% so the delta must send C. If false, the broadcast has not run yet
+%% and will deliver C to this stream after Phase 2 registers.
+%%
+%% The table is keyed by BranchPath so that cleanup for one branch does
+%% not interfere with another branch's dedup checks. This avoids the
+%% race condition where a global retractall would temporarily empty the
+%% table for all branches.
+:- dynamic broadcast_sent/2.
+
+%% Per-branch broadcast mutexes.
+%% Each entry is branch_broadcast_mutex(BranchPath, Mutex).
+%% The mutex serializes catch-up+registration vs broadcast fan-out
+%% to guarantee no gaps and no duplicates during concurrent connections.
+:- dynamic branch_broadcast_mutex/2.
+:- mutex_create(branch_broadcast_registry, [alias(branch_broadcast_registry)]).
+
+%%%%%%%%%%%%%%%%%%%% Commit Broadcast Stream %%%%%%%%%%%%%%%%%%%%%%%%%
+%
+%  Streaming endpoint that broadcasts commit information for a branch
+%  to any number of listeners.
+%
+%  The endpoint is:
+%    GET /api/v1/ext/commits/*branch_path?since=<timestamp|commit>&timeout=<seconds|false>
+%
+%  The first NDJSON chunk always contains the current head commit with
+%  its full document change set. If `since` is provided, all commits
+%  between the `since` point and the head are sent as catch-up chunks
+%  before live subscription begins.
+%
+%  The `timeout` parameter controls auto-close (default 30s, false=never).
+%  The post_commit_hook sends full commit events directly to each
+%  matching stream via appserver_stream_send.
+
+appserver_hooks:appserver_stream(get, '/api/v1/ext/commits/*branch_path',
+                                  webserver_commits:commits_handler).
+
+%%%%%%%%%%%%%%%%%%%% Stream Handler %%%%%%%%%%%%%%%%%%%%%%%%%
+
+%% commits_handler(+Request, +StreamId, -Response) is det.
+%
+%  Authenticate the listener, check branch authorization, send initial
+%  commit chunk(s), register the stream for live updates, and set up
+%  the timeout. Follows the same pattern as webserver_events.pl but
+%  with per-branch filtering and initial catch-up data.
+commits_handler(Request, StreamId, Response) :-
+    catch(
+        commits_handler_safe(Request, StreamId, Response),
+        Error,
+        (   json_log_error_formatted("commits_handler error: ~q", [Error]),
+            error_response(Error, Response)
+        )
+    ).
+
+commits_handler_safe(Request, StreamId, Response) :-
+    %% Extract the branch path from the wildcard path parameter.
+    get_dict(params, Request, Params),
+    get_dict(branch_path, Params, BranchPathRaw),
+    normalize_branch_path(BranchPathRaw, BranchPath),
+
+    %% Parse query parameters.
+    get_dict(query, Request, QueryString),
+    (   QueryString \= ""
+    ->  uri_query_components(QueryString, Query)
+    ;   Query = []
+    ),
+
+    %% Parse optional `since` parameter.
+    (   memberchk(since=SinceStr, Query)
+    ->  parse_since(SinceStr, Since)
+    ;   Since = none
+    ),
+
+    %% Parse optional `timeout` parameter (default 30s).
+    (   memberchk(timeout=TimeoutStr, Query)
+    ->  parse_timeout(TimeoutStr, Timeout)
+    ;   Timeout = 30
+    ),
+
+    %% Open the system database for authentication.
+    open_descriptor(system_descriptor{}, System_DB),
+
+    %% Authenticate using the request headers.
+    authenticate_from_request(Request, System_DB, Auth),
+
+    %% Resolve the branch descriptor and check authorization.
+    do_or_die(
+        resolve_absolute_string_descriptor(BranchPath, Descriptor),
+        error(invalid_absolute_path(BranchPath), _)
+    ),
+    (   branch_descriptor{} :< Descriptor
+    ->  true
+    ;   throw(error(not_a_branch_descriptor(Descriptor), _))
+    ),
+
+    check_descriptor_auth(System_DB, Descriptor,
+                          '@schema':'Action/commit_read_access', Auth),
+
+    %% Return a streaming response with a post_response continuation goal.
+    %% The worker thread calls send_response (which sends HTTP headers as
+    %% the first channel message), then calls the post_response goal to
+    %% send initial data and register for live updates. No detached thread
+    %% is needed — the worker thread handles everything and then returns
+    %% to the pool.
+    Response = _{
+        status: 200,
+        headers: _{'Content-Type': 'application/x-ndjson'},
+        body: stream,
+        post_response: webserver_commits:stream_commit_data(System_DB, Descriptor, BranchPath,
+                                                            Since, Timeout, StreamId)
+    }.
+
+%%%%%%%%%%%%%%%%%%%% Stream Data Initialization %%%%%%%%%%%%%%%%%%%%%%%%%
+
+%% stream_commit_data(+System_DB, +Descriptor, +BranchPath, +Since,
+%%                     +Timeout, +StreamId) is det.
+%
+%  Called by the worker thread AFTER send_response has sent the HTTP
+%  headers as the first channel message. Sends initial commit chunk(s),
+%  registers the stream for live updates, and sets up the timeout.
+%  The stream is closed by the timeout thread or when the client
+%  disconnects (detected by Rust).
+%
+%  Uses a two-phase catch-up to minimize mutex hold time:
+%    Phase 1: Send historical commits up to current head (NO mutex)
+%    Phase 2: Send delta + register atomically (WITH mutex)
+%  See PLAN_COMMIT_STREAM_SYNC.md for the full design.
+stream_commit_data(System_DB, Descriptor, BranchPath, Since, Timeout, StreamId) :-
+    catch(
+        (   setup_timeout(StreamId, Timeout, TimeoutThread),
+            ensure_branch_broadcast_mutex(BranchPath, Mutex),
+
+            %% PHASE 1 — Historical catch-up (NO mutex)
+            %% Send all commits up to the current head. Broadcasts to
+            %% existing clients continue unimpeded. Returns C_head for
+            %% Phase 2 delta computation.
+            send_historical_commits(System_DB, Descriptor,
+                                    BranchPath, Since, StreamId, C_head),
+
+            %% PHASE 2 — Delta sync + registration (WITH mutex)
+            %% Atomically catch up any commits that arrived during
+            %% Phase 1 and register for live broadcasts. The delta is
+            %% typically 0-2 commits, so the mutex hold time is minimal.
+            %% Registration has two parts:
+            %%   1. Subscribe the stream to the Rust broadcast channel
+            %%      (for parallel fan-out on the Rust side)
+            %%   2. assertz commit_stream/3 (for timeout/cleanup and
+            %%      for the broadcast_sent dedup check in send_delta)
+            with_mutex(Mutex,
+                (   send_delta_commits(System_DB, Descriptor,
+                                       BranchPath, C_head, StreamId),
+                    '$appserver':appserver_broadcast_subscribe(BranchPath, StreamId),
+                    assertz(commit_stream(StreamId, BranchPath, TimeoutThread))
+                )
+            )
+        ),
+        Error,
+        (   json_log_error_formatted("stream_commit_data error: ~q", [Error]),
+            retractall(commit_stream(StreamId, _, _)),
+            catch('$appserver':appserver_broadcast_unsubscribe_all(StreamId), _, true),
+            catch('$appserver':appserver_stream_close(StreamId), _, true)
+        )
+    ).
+
+%%%%%%%%%%%%%%%%%%%% Authentication %%%%%%%%%%%%%%%%%%%%%%%%%
+
+%% authenticate_from_request(+Request, +System_DB, -Auth) is det.
+%
+%  Extract the Authorization header from the request dict and
+%  authenticate the user. Throws on auth failure.
+authenticate_from_request(Request, System_DB, Auth) :-
+    get_dict(headers, Request, HeadersDict),
+    (   get_dict('Authorization', HeadersDict, AuthValue)
+    ->  true
+    ;   get_dict('authorization', HeadersDict, AuthValue)
+    ->  true
+    ;   throw(error(authentication_incorrect(no_authorization_header), _))
+    ),
+    %% Build a minimal SWI request list for authenticate/3.
+    atom_string(AuthAtom, AuthValue),
+    SWIRequest = [authorization(AuthAtom), peer(ip(127,0,0,1))],
+    routes:authenticate(System_DB, SWIRequest, Auth).
+
+%%%%%%%%%%%%%%%%%%%% Two-Phase Catch-Up %%%%%%%%%%%%%%%%%%%%%%%%%
+
+%% send_historical_commits(+System_DB, +Descriptor, +BranchPath,
+%%                          +Since, +StreamId, -C_head) is det.
+%
+%  Phase 1: Send historical commits up to the current head, WITHOUT
+%  holding the mutex. Broadcasts to existing clients continue
+%  unimpeded. Returns C_head (the head commit ID at the time of the
+%  read) for Phase 2 delta computation.
+send_historical_commits(System_DB, Descriptor, BranchPath, Since, StreamId, C_head) :-
+    get_dict(repository_descriptor, Descriptor, RepoDescriptor),
+    get_dict(branch_name, Descriptor, BranchName),
+    %% Get the branch head commit URI, then walk the full history.
+    %% This uses the same pattern as api_log.pl: branch_head_commit
+    %% gives us the head, and commit_uri_to_history_commit_ids walks
+    %% the parent chain. The result is oldest-first, so we reverse
+    %% to get newest-first (matching the old commits/2 order).
+    do_or_die(
+        branch_head_commit(RepoDescriptor, BranchName, Head_Commit_Uri),
+        error(no_commits_on_branch(BranchPath), _)
+    ),
+    commit_id_uri(RepoDescriptor, C_head, Head_Commit_Uri),
+    commit_uri_to_history_commit_ids(RepoDescriptor, Head_Commit_Uri, HistoryIds),
+    reverse(HistoryIds, CommitList),
+    %% If since is provided, find the catch-up commits.
+    (   Since = none
+    ->  CatchupCommits = []
+    ;   Since = since_commit(SinceCommitId)
+    ->  filter_commits_since_commit(CommitList, SinceCommitId, CatchupCommits)
+    ;   Since = since_timestamp(SinceTimestamp)
+    ->  filter_commits_since_timestamp(RepoDescriptor, CommitList,
+                                        SinceTimestamp, CatchupCommits)
+    ),
+    %% Send ALL historical catch-up commits in chronological order
+    %% (oldest first). These commits happened in the past and will
+    %% never be broadcast again, so they must always be sent directly.
+    reverse(CatchupCommits, ChronologicalCatchup),
+    forall(
+        member(CommitId, ChronologicalCatchup),
+        send_commit_event(System_DB, Descriptor, BranchPath, CommitId, StreamId)
+    ),
+    %% Send head if not already in catchup.
+    (   member(C_head, ChronologicalCatchup)
+    ->  true
+    ;   send_commit_event(System_DB, Descriptor, BranchPath, C_head, StreamId)
+    ).
+
+%% send_delta_commits(+System_DB, +Descriptor, +BranchPath,
+%%                     +C_head, +StreamId) is det.
+%
+%  Phase 2: Send commits that arrived between Phase 1's head read
+%  and now. Called under the branch mutex. The delta is typically
+%  0-2 commits, so the mutex hold time is minimal.
+send_delta_commits(System_DB, Descriptor, BranchPath, C_head, StreamId) :-
+    get_dict(repository_descriptor, Descriptor, RepoDescriptor),
+    get_dict(branch_name, Descriptor, BranchName),
+    %% Get the current head and full history (same pattern as
+    %% send_historical_commits — see comment there).
+    (   branch_head_commit(RepoDescriptor, BranchName, Head_Commit_Uri)
+    ->  commit_id_uri(RepoDescriptor, C_latest, Head_Commit_Uri),
+        commit_uri_to_history_commit_ids(RepoDescriptor, Head_Commit_Uri, HistoryIds),
+        reverse(HistoryIds, CommitList)
+    ;   CommitList = [], C_latest = none
+    ),
+    (   CommitList = [C_latest|_]
+    ->  (   C_latest == C_head
+        ->  true  %% No delta, head unchanged
+        ;   %% Find commits between C_head (exclusive) and C_latest (inclusive)
+            (   append(_Before, [C_head|After], CommitList)
+            ->  DeltaCommits = After
+            ;   %% C_head not found — branch was reset or rebased.
+                %% Send the full list as catch-up to be safe.
+                DeltaCommits = CommitList
+            ),
+            reverse(DeltaCommits, ChronologicalDelta),
+            %% Only send delta commits that have already been broadcast.
+            %% If broadcast_sent(BranchPath, C) is true, the broadcast
+            %% ran under the mutex but did not find this stream (not
+            %% registered yet), so the delta must deliver C. If false,
+            %% the broadcast has not run yet and will deliver C to this
+            %% stream after Phase 2 registers.
+            forall(
+                (   member(CommitId, ChronologicalDelta),
+                    commit_key(CommitId, CommitKey),
+                    broadcast_sent(BranchPath, CommitKey)
+                ),
+                send_commit_event(System_DB, Descriptor, BranchPath, CommitId, StreamId)
+            )
+        )
+    ;   true  %% Branch has no commits, nothing to do
+    ).
+
+%% commit_key(+CommitId, -CommitKey) is det.
+%
+%  Normalize a commit ID (atom or string) to an atom for consistent
+%  comparison with broadcast_sent/2 entries.
+commit_key(CommitId, CommitKey) :-
+    (   atom(CommitId) -> CommitKey = CommitId
+    ;   atom_string(CommitKey, CommitId)
+    ).
+
+%% filter_commits_since_commit(+CommitList, +SinceCommitId, -Catchup) is det.
+%
+%  Return all commits after (but not including) SinceCommitId.
+%  CommitList is newest-first (head to initial). The catch-up set
+%  is the commits NEWER than SinceCommitId, which are the elements
+%  BEFORE SinceCommitId in the list.
+filter_commits_since_commit(CommitList, SinceCommitId, Catchup) :-
+    %% Normalize SinceCommitId to string for comparison, since
+    %% commit_uri_to_history_commit_ids returns strings.
+    (   string(SinceCommitId) -> SinceStr = SinceCommitId
+    ;   atom_string(SinceCommitId, SinceStr)
+    ),
+    (   append(Newer, [SinceStr|_Older], CommitList)
+    ->  Catchup = Newer
+    ;   Catchup = []  %% SinceCommitId not found, no catchup
+    ).
+
+%% filter_commits_since_timestamp(+Repo, +CommitList, +SinceTimestamp, -Catchup) is det.
+%
+%  Return all commits with timestamp > SinceTimestamp.
+filter_commits_since_timestamp(Repo, CommitList, SinceTimestamp, Catchup) :-
+    include(
+        {Repo, SinceTimestamp}/[CommitId]>>(
+            commit_id_to_metadata(Repo, CommitId, _Author, _Msg, Timestamp),
+            Timestamp > SinceTimestamp
+        ),
+        CommitList,
+        Catchup
+    ).
+
+%%%%%%%%%%%%%%%%%%%% Commit Event Construction %%%%%%%%%%%%%%%%%%%%%%%%%
+
+%% send_commit_event(+System_DB, +Descriptor, +BranchPath, +CommitId, +StreamId) is det.
+%
+%  Build a commit event (commit info + changed documents) and send it
+%  as an NDJSON chunk to the stream.
+send_commit_event(_System_DB, Descriptor, BranchPath, CommitId, StreamId) :-
+    get_dict(repository_descriptor, Descriptor, RepoDescriptor),
+    commit_info_dict(RepoDescriptor, CommitId, CommitInfo),
+
+    %% Open the commit descriptor to get changed documents.
+    resolve_relative_descriptor(Descriptor, ["commit", CommitId], CommitDescriptor),
+    (   catch(
+            (   open_descriptor(CommitDescriptor, Transaction),
+                '$changes':collect_changed_documents(Transaction, Added, Changed, Deleted)
+            ),
+            Error,
+            (   json_log_error_formatted("send_commit_event: collect_changed_documents failed for ~w: ~q",
+                                          [CommitId, Error]),
+              Added = [], Changed = [], Deleted = []
+            )
+        )
+    ->  true
+    ;   Added = [], Changed = [], Deleted = []
+    ),
+
+    %% Build the event dict.
+    Event = _{
+        commit: CommitInfo,
+        changes: _{
+            added: Added,
+            changed: Changed,
+            deleted: Deleted
+        },
+        branch: BranchPath
+    },
+
+    %% Serialize to JSON on the Prolog side using json_write_dict, which
+    %% correctly handles Prolog [] (empty list) as JSON [] instead of null.
+    %% Pass the string to appserver_stream_send, which sends strings as
+    %% raw bytes with a trailing newline.
+    with_output_to(string(JsonStr), json_write_dict(current_output, Event, [as(string), width(0)])),
+    '$appserver':appserver_stream_send(StreamId, JsonStr).
+
+%%%%%%%%%%%%%%%%%%%% Post-Commit Hook (Funnel) %%%%%%%%%%%%%%%%%%%%%%%%%
+
+%% plugins:post_commit_hook(+Validations, +Meta_Data) is det.
+%
+%  After every commit, extract the branch descriptor and commit info,
+%  compute the changed documents, and send the full event directly to
+%  each matching stream. This follows the same pattern as
+%  webserver_events.pl: iterate over stored stream IDs and send via
+%  appserver_stream_send.
+%
+%  Validations is a LIST of validation_object dicts. Each has:
+%    - descriptor: the branch/database/repo descriptor
+%    - commit_info: author, message, user, etc.
+%    - instance_objects: list of instance objects with .read layer
+%
+%  Meta_Data is a meta_data{} dict with:
+%    - data_versions: list of Descriptor-Data_Version pairs
+plugins:post_commit_hook(Validation_Objects, Meta_Data) :-
+    catch(
+        (   broadcast_commit_events(Validation_Objects, Meta_Data)
+        ->  true
+        ;   json_log:json_log_error_formatted("post_commit_hook: broadcast_commit_events failed (no exception)", [])
+        ),
+        Error,
+        json_log:json_log_error_formatted("post_commit_hook broadcast error: ~q", [Error])
+    ),
+    !.
+plugins:post_commit_hook(_, _).
+
+%% broadcast_commit_events(+Validation_Objects, +Meta_Data) is det.
+%
+%  For each validation object that is a branch_descriptor, extract the
+%  commit info and changed documents, then send to each matching stream.
+%  Also sweeps stale commit_stream/3 entries whose Rust stream no longer
+%  exists (client disconnected with timeout=false).
+broadcast_commit_events(Validation_Objects, Meta_Data) :-
+    get_dict(data_versions, Meta_Data, DataVersions),
+    %% Sweep stale streams before broadcasting. This retracts
+    %% commit_stream/3 entries for streams that the Rust side has already
+    %% cleaned up (client disconnect). Without this, entries leak when
+    %% timeout=false.
+    sweep_stale_streams,
+    %% Collect unique branch paths with their validation objects and
+    %% commit IDs to avoid duplicate sends when both schema and instance
+    %% validation objects exist for the same branch.
+    findall(BranchPath-Validation_Object-CommitIdAtom,
+            (   member(Validation_Object, Validation_Objects),
+                is_dict(Validation_Object),
+                get_dict(descriptor, Validation_Object, Descriptor),
+                branch_descriptor{} :< Descriptor,
+                member(Descriptor-data_version(branch, CommitIdAtom), DataVersions),
+                descriptor_to_branch_path(Descriptor, BranchPath)
+            ),
+            Triples),
+    %% Deduplicate by BranchPath-CommitIdAtom (keep first validation object).
+    dedup_triples(Triples, UniqueTriples),
+    forall(
+        member(BranchPath-Validation_Object-CommitIdAtom, UniqueTriples),
+        send_to_branch_streams(Validation_Object, BranchPath, CommitIdAtom)
+    ).
+
+%% sweep_stale_streams is det.
+%
+%  Retract commit_stream/3 entries whose Rust stream no longer exists.
+%  This handles the timeout=false case where no timeout thread cleans up
+%  after a client disconnect. The Rust side detects the disconnect and
+%  removes the stream from its registry; this sweep retracts the
+%  corresponding Prolog entry.
+sweep_stale_streams :-
+    findall(StreamId, commit_stream(StreamId, _, _), StreamIds),
+    forall(
+        (   member(StreamId, StreamIds),
+            \+ catch('$appserver':appserver_stream_exists(StreamId), _, fail)
+        ),
+        retract_stream(StreamId)
+    ).
+
+%% dedup_triples(+Triples, -Unique) is det.
+%
+%  Remove duplicates by BranchPath-CommitIdAtom key, keeping the first.
+dedup_triples(Triples, Unique) :-
+    dedup_triples(Triples, [], Unique).
+
+dedup_triples([], _Seen, []).
+dedup_triples([BranchPath-VO-CIA|Rest], Seen, Unique) :-
+    (   member(BranchPath-CIA, Seen)
+    ->  dedup_triples(Rest, Seen, Unique)
+    ;   Unique = [BranchPath-VO-CIA|UniqueRest],
+        dedup_triples(Rest, [BranchPath-CIA|Seen], UniqueRest)
+    ).
+
+%% send_to_branch_streams(+Validation_Object, +BranchPath, +CommitIdAtom) is det.
+%
+%  Build the commit event and send it to every stream subscribed to
+%  this branch path. Failed sends retract the stream (client disconnected).
+%
+%  The broadcast_sent/2 assertion happens INSIDE the per-branch mutex.
+%  This is critical for transactional correctness with the two-phase
+%  catch-up in send_delta_commits: Phase 2 tests broadcast_sent/2 under
+%  the same mutex. If broadcast_sent(BranchPath, C) is true when Phase 2
+%  runs, the broadcast already ran under the mutex and did not find this
+%  stream (not registered yet), so the delta must send C. If false, the
+%  broadcast has not run yet and will deliver C after Phase 2 registers.
+send_to_branch_streams(Validation_Object, BranchPath, CommitIdAtom) :-
+    (   atom(CommitIdAtom) -> CommitIdKey = CommitIdAtom
+    ;   atom_string(CommitIdKey, CommitIdAtom)
+    ),
+    %% Fast path: skip if already broadcast (post_commit_hook fires
+    %% multiple times per commit). The definitive check is repeated
+    %% inside the mutex below.
+    (   broadcast_sent(BranchPath, CommitIdKey)
+    ->  true
+    ;   build_commit_event(Validation_Object, BranchPath, CommitIdAtom, JsonStr)
+    ->  ensure_branch_broadcast_mutex(BranchPath, Mutex),
+        with_mutex(Mutex,
+            (   %% Double-check inside mutex: another broadcast may
+                %% have asserted this while we waited.
+                (   broadcast_sent(BranchPath, CommitIdKey)
+                ->  true
+                ;   assertz(broadcast_sent(BranchPath, CommitIdKey)),
+                    cleanup_old_broadcasts(BranchPath),
+                    %% Fan-out is handled by the Rust broadcast
+                    %% registry, which sends to all subscribed
+                    %% streams in parallel using tokio tasks.
+                    %% The Rust side also removes failed streams
+                    %% (disconnected clients) from the channel.
+                    '$appserver':appserver_broadcast_send_raw(BranchPath, JsonStr)
+                )
+            )
+        )
+    ;   json_log_error_formatted("send_to_branch_streams: build_commit_event failed for ~w", [BranchPath])
+    ).
+
+%% cleanup_old_broadcasts(+BranchPath) is det.
+%
+%  Keep only the last 100 broadcast_sent entries for this branch to
+%  avoid memory growth. Uses selective retraction of only the oldest
+%  entries rather than retractall + re-assert, so other branches' dedup
+%  checks are not affected during cleanup.
+%
+%  findall returns entries in assertion order (oldest first). We retract
+%  the first N-100 entries (the oldest) and keep the last 100 (the
+%  newest, which are most likely to be relevant for delta checks).
+cleanup_old_broadcasts(BranchPath) :-
+    findall(C, broadcast_sent(BranchPath, C), All),
+    length(All, N),
+    (   N > 100
+    ->  Excess is N - 100,
+        length(Old, Excess),
+        append(Old, _Keep, All),
+        forall(member(C, Old), retract(broadcast_sent(BranchPath, C)))
+    ;   true
+    ).
+
+%% retract_stream(+StreamId) is det.
+%
+%  Remove a stream from the registry. The timeout thread is NOT aborted
+%  — it will wake up, find the stream already retracted, and exit
+%  naturally. Aborting detached threads with thread_signal/2 can cause
+%  cascade failures in SWI-Prolog when many streams close simultaneously.
+retract_stream(StreamId) :-
+    (   retract(commit_stream(StreamId, BranchPath, _))
+    ->  catch('$appserver':appserver_broadcast_unsubscribe(BranchPath, StreamId), _, true),
+        catch('$appserver':appserver_stream_close(StreamId), _, true)
+    ;   true
+    ).
+
+%% build_commit_event(+Validation_Object, +BranchPath, +CommitIdAtom, -JsonStr) is det.
+%
+%  Extract commit info from the validation object, detect document
+%  changes, build the event dict, and serialize to a JSON string.
+build_commit_event(Validation_Object, BranchPath, CommitIdAtom, JsonStr) :-
+    %% Extract commit info from the validation object.
+    (   get_dict(commit_info, Validation_Object, CommitInfo)
+    ->  true
+    ;   json_log_error_formatted("build_commit_event: no commit_info in validation object", []),
+        fail
+    ),
+
+    (   get_dict(author, CommitInfo, Author)
+    ->  true
+    ;   Author = "unknown"
+    ),
+    (   get_dict(message, CommitInfo, Message)
+    ->  true
+    ;   Message = ""
+    ),
+    (   get_dict(user, CommitInfo, User)
+    ->  true
+    ;   User = null
+    ),
+    atom_string(CommitId, CommitIdAtom),
+
+    %% Get timestamp from the commit info or use current time.
+    (   get_dict(timestamp, CommitInfo, Timestamp)
+    ->  true
+    ;   get_time(Timestamp)
+    ),
+
+    %% Detect document changes using the Rust $changes:collect_changed_documents
+    %% predicate, which is much more performant than Prolog-side layer inspection.
+    %% It takes a transaction-like term with instance_objects and schema_objects
+    %% (which a validation_object has) and uses schema-aware document type
+    %% detection with proper containment walk-up for subdocuments.
+    (   catch(
+            '$changes':collect_changed_documents(Validation_Object, Added0, Changed0, Deleted0),
+            Error,
+            (   json_log_error_formatted("build_commit_event: collect_changed_documents error: ~q", [Error]),
+                fail
+            )
+        )
+    ->  Added = Added0, Changed = Changed0, Deleted = Deleted0
+    ;   Added = [], Changed = [], Deleted = []
+    ),
+    %% Ensure all change lists are bound (avoid null in JSON).
+    (   var(Added) -> Added = [] ; true ),
+    (   var(Changed) -> Changed = [] ; true ),
+    (   var(Deleted) -> Deleted = [] ; true ),
+
+    %% Build the event dict.
+    Event = _{
+        commit: _{
+            identifier: CommitId,
+            author: Author,
+            message: Message,
+            timestamp: Timestamp,
+            user: User
+        },
+        changes: _{
+            added: Added,
+            changed: Changed,
+            deleted: Deleted
+        },
+        branch: BranchPath
+    },
+
+    %% Serialize to JSON on the Prolog side using json_write_dict, which
+    %% correctly handles Prolog [] (empty list) as JSON [] instead of null.
+    %% Use width(0) for compact single-line JSON (NDJSON format).
+    with_output_to(string(JsonStr), json_write_dict(current_output, Event, [as(string), width(0)])).
+
+%%%%%%%%%%%%%%%%%%%% Utilities %%%%%%%%%%%%%%%%%%%%%%%%%
+
+%% ensure_branch_broadcast_mutex(+BranchPath, -Mutex) is det.
+%
+%  Lazily create or look up the per-branch broadcast mutex. The mutex
+%  serializes catch-up+registration (new client connecting) against
+%  broadcast fan-out (commit arriving) to guarantee no gaps and no
+%  duplicates. See PLAN_COMMIT_STREAM_SYNC.md for the full design.
+ensure_branch_broadcast_mutex(BranchPath, Mutex) :-
+    (   branch_broadcast_mutex(BranchPath, Mutex)
+    ->  true
+    ;   with_mutex(branch_broadcast_registry,
+            (   branch_broadcast_mutex(BranchPath, Mutex)
+            ->  true
+            ;   atom_string(BranchPathAtom, BranchPath),
+                atom_concat('commit_broadcast_', BranchPathAtom, Alias),
+                catch(mutex_create(Mutex, [alias(Alias)]),
+                      error(permission_error(create, mutex, _), _),
+                      mutex_property(Mutex, alias(Alias))),
+                assertz(branch_broadcast_mutex(BranchPath, Mutex))
+            )
+        )
+    ).
+
+%% normalize_branch_path(+Raw, -Normalized) is det.
+%
+%  Strip leading/trailing slashes from the branch path.
+%  Always returns a Prolog string to match descriptor_to_branch_path.
+normalize_branch_path(Raw, Normalized) :-
+    (   atom(Raw) -> atom_string(Raw, RawStr) ; RawStr = Raw ),
+    (   string_concat("/", Rest, RawStr)
+    ->  normalize_branch_path(Rest, Normalized)
+    ;   string_concat(Rest, "/", RawStr)
+    ->  normalize_branch_path(Rest, Normalized)
+    ;   Normalized = RawStr
+    ).
+
+%% descriptor_to_branch_path(+Descriptor, -Path) is det.
+%
+%  Convert a branch_descriptor to a path string like "org/db/local/branch/main".
+descriptor_to_branch_path(Descriptor, Path) :-
+    get_dict(branch_name, Descriptor, BranchName),
+    get_dict(repository_descriptor, Descriptor, RepoDescriptor),
+    get_dict(repository_name, RepoDescriptor, RepoName),
+    get_dict(database_descriptor, RepoDescriptor, DBDescriptor),
+    get_dict(database_name, DBDescriptor, DBName),
+    get_dict(organization_name, DBDescriptor, OrgName),
+    format(string(Path), "~w/~w/~w/branch/~w", [OrgName, DBName, RepoName, BranchName]).
+
+%% parse_since(+SinceStr, -Since) is det.
+%
+%  Parse the `since` parameter as either an ISO8601 timestamp or a
+%  commit ID.
+parse_since(SinceStr, Since) :-
+    (   catch(parse_time(SinceStr, iso_8601, Epoch), _, fail)
+    ->  Since = since_timestamp(rationalize(Epoch))
+    ;   Since = since_commit(SinceStr)
+    ).
+
+%% parse_timeout(+TimeoutStr, -Timeout) is det.
+%
+%  Parse the timeout parameter. "false" means no timeout. A number
+%  means that many seconds. Default is 30.
+parse_timeout("false", false) :- !.
+parse_timeout(false, false) :- !.
+parse_timeout(TimeoutStr, Timeout) :-
+    (   atom(TimeoutStr) -> TimeoutAtom = TimeoutStr
+    ;   atom_string(TimeoutAtom, TimeoutStr)
+    ),
+    (   catch(atom_number(TimeoutAtom, Parsed), _, fail),
+        integer(Parsed),
+        Parsed > 0
+    ->  Timeout = Parsed
+    ;   Timeout = 30
+    ).
+
+%% setup_timeout(+StreamId, +Timeout, -Thread) is det.
+%
+%  Spawn a detached thread that closes the stream after Timeout seconds.
+%  If Timeout is false, no thread is created and cleanup relies on the
+%  stale-stream sweep in broadcast_commit_events (which retracts
+%  commit_stream/3 entries whose Rust stream no longer exists).
+setup_timeout(_StreamId, false, none) :- !.
+setup_timeout(StreamId, Timeout, Thread) :-
+    integer(Timeout),
+    Timeout > 0,
+    !,
+    thread_create(
+        (   sleep(Timeout),
+            retract_stream(StreamId)
+        ),
+        Thread,
+        [detached(true)]
+    ).
+setup_timeout(_, _, none).
+
+%% error_response(+Error, -Response) is det.
+%
+%  Build an error response dict from an error term.
+error_response(error(authentication_incorrect(_), _), Response) :- !,
+    Response = _{
+        status: 401,
+        body: _{
+            '@type': 'api:ErrorResponse',
+            'api:status': 'api:failure',
+            'api:error': _{'@type': 'api:AuthenticationError'},
+            'api:message': 'Authentication failed'
+        },
+        headers: _{'Content-Type': 'application/json'}
+    }.
+error_response(error(not_a_branch_descriptor(_), _), Response) :- !,
+    Response = _{
+        status: 400,
+        body: _{
+            '@type': 'api:ErrorResponse',
+            'api:status': 'api:failure',
+            'api:error': _{'@type': 'api:BadArgumentError'},
+            'api:message': 'Path is not a branch descriptor'
+        },
+        headers: _{'Content-Type': 'application/json'}
+    }.
+error_response(error(invalid_absolute_path(_), _), Response) :- !,
+    Response = _{
+        status: 404,
+        body: _{
+            '@type': 'api:ErrorResponse',
+            'api:status': 'api:not_found',
+            'api:error': _{'@type': 'api:PathNotFoundError'},
+            'api:message': 'Branch not found'
+        },
+        headers: _{'Content-Type': 'application/json'}
+    }.
+error_response(error(access_not_authorised(_), _), Response) :- !,
+    Response = _{
+        status: 403,
+        body: _{
+            '@type': 'api:ErrorResponse',
+            'api:status': 'api:failure',
+            'api:error': _{'@type': 'api:AuthorizationError'},
+            'api:message': 'Access not authorised'
+        },
+        headers: _{'Content-Type': 'application/json'}
+    }.
+error_response(_, Response) :-
+    Response = _{
+        status: 500,
+        body: _{
+            '@type': 'api:ErrorResponse',
+            'api:status': 'api:failure',
+            'api:error': _{'@type': 'api:InternalServerError'},
+            'api:message': 'Internal server error'
+        },
+        headers: _{'Content-Type': 'application/json'}
+    }.
+
+%%%%%%%%%%%%%%%%%%%% Unit Tests %%%%%%%%%%%%%%%%%%%%%%%%%
+
+:- use_module(library(plunit)).
+:- use_module(core(util/test_utils)).
+
+:- begin_tests(webserver_commits_utils, []).
+
+%% normalize_branch_path tests
+
+test(normalize_strips_leading_slash) :-
+    normalize_branch_path('/admin/db/local/branch/main', Normalized),
+    Normalized == "admin/db/local/branch/main".
+
+test(normalize_strips_trailing_slash) :-
+    normalize_branch_path('admin/db/local/branch/main/', Normalized),
+    Normalized == "admin/db/local/branch/main".
+
+test(normalize_strips_both_slashes) :-
+    normalize_branch_path('/admin/db/local/branch/main/', Normalized),
+    Normalized == "admin/db/local/branch/main".
+
+test(normalize_no_slashes) :-
+    normalize_branch_path('admin/db/local/branch/main', Normalized),
+    Normalized == "admin/db/local/branch/main".
+
+%% parse_since tests
+
+test(parse_since_commit_id) :-
+    parse_since('abc123def456', Since),
+    Since == since_commit('abc123def456').
+
+test(parse_since_iso8601_timestamp) :-
+    parse_since('2024-01-15T10:30:00Z', Since),
+    Since = since_timestamp(_).
+
+test(parse_since_iso8601_with_timezone) :-
+    parse_since('2024-01-15T10:30:00+02:00', Since),
+    Since = since_timestamp(_).
+
+%% parse_timeout tests
+
+test(parse_timeout_integer) :-
+    parse_timeout('30', Timeout),
+    Timeout == 30.
+
+test(parse_timeout_false) :-
+    parse_timeout('false', Timeout),
+    Timeout == false.
+
+test(parse_timeout_zero_becomes_30) :-
+    parse_timeout('0', Timeout),
+    Timeout == 30.
+
+test(parse_timeout_invalid_defaults_30) :-
+    parse_timeout('notanumber', Timeout),
+    Timeout == 30.
+
+test(parse_timeout_atom_false) :-
+    parse_timeout(false, Timeout),
+    Timeout == false.
+
+%% filter_commits_since_commit tests
+%
+%  CommitList is newest-first (head to initial commit).
+%  The catch-up set is all commits NEWER than SinceCommitId,
+%  which are the elements BEFORE SinceCommitId in the list.
+%
+%  commit_uri_to_history_commit_ids returns strings, so the commit
+%  list elements are strings. SinceCommitId from the URL query is
+%  an atom. The predicate normalizes both to string for comparison.
+
+test(filter_since_commit_returns_newer_commits) :-
+    %% CommitList: [fourth, third, second, first] (newest first, strings)
+    %% since=second (atom) -> should return [fourth, third]
+    CommitList = ["fourth", "third", "second", "first"],
+    filter_commits_since_commit(CommitList, second, Catchup),
+    Catchup == ["fourth", "third"].
+
+test(filter_since_commit_head_only) :-
+    %% since=third -> should return [fourth] (only head is newer)
+    CommitList = ["fourth", "third", "second", "first"],
+    filter_commits_since_commit(CommitList, third, Catchup),
+    Catchup == ["fourth"].
+
+test(filter_since_commit_oldest) :-
+    %% since=first (oldest) -> should return [fourth, third, second]
+    CommitList = ["fourth", "third", "second", "first"],
+    filter_commits_since_commit(CommitList, first, Catchup),
+    Catchup == ["fourth", "third", "second"].
+
+test(filter_since_commit_not_found) :-
+    %% since=nonexistent -> should return []
+    CommitList = ["fourth", "third", "second", "first"],
+    filter_commits_since_commit(CommitList, nonexistent, Catchup),
+    Catchup == [].
+
+test(filter_since_commit_head_is_since) :-
+    %% since=fourth (head) -> should return [] (nothing newer than head)
+    CommitList = ["fourth", "third", "second", "first"],
+    filter_commits_since_commit(CommitList, fourth, Catchup),
+    Catchup == [].
+
+test(filter_since_commit_string_input) :-
+    %% SinceCommitId may come as a string from URL query params.
+    %% The predicate normalizes both atom and string inputs to string.
+    CommitList = ["fourth", "third", "second", "first"],
+    filter_commits_since_commit(CommitList, "second", Catchup),
+    Catchup == ["fourth", "third"].
+
+%% dedup_triples tests
+
+test(dedup_triples_removes_duplicates) :-
+    Triples = [
+        'admin/db/local/branch/main'-vo1-'commit1',
+        'admin/db/local/branch/main'-vo2-'commit1',
+        'admin/db/local/branch/main'-vo3-'commit2'
+    ],
+    dedup_triples(Triples, [], Unique),
+    %% Should keep one entry per branch-commit pair
+    length(Unique, 2).
+
+%% ensure_branch_broadcast_mutex tests
+
+test(ensure_branch_broadcast_mutex_creates_and_reuses) :-
+    BranchPath = "test_branch_mutex_create",
+    ensure_branch_broadcast_mutex(BranchPath, Mutex1),
+    ensure_branch_broadcast_mutex(BranchPath, Mutex2),
+    Mutex1 == Mutex2.
+
+test(ensure_branch_broadcast_mutex_different_branches) :-
+    BranchPath1 = "test_branch_mutex_a",
+    BranchPath2 = "test_branch_mutex_b",
+    ensure_branch_broadcast_mutex(BranchPath1, Mutex1),
+    ensure_branch_broadcast_mutex(BranchPath2, Mutex2),
+    Mutex1 \== Mutex2.
+
+%% cleanup_old_broadcasts/1 tests
+%
+%  The per-branch cleanup must only retract entries for the given branch
+%  and must use selective retraction (not retractall) so other branches'
+%  entries are not affected during cleanup.
+
+test(cleanup_old_broadcasts_per_branch_selective) :-
+    %% Setup: add 3 entries for branch_a and 1 for branch_b
+    %% Note: broadcast_sent/2 is a dynamic predicate in the
+    %% webserver_commits module. Tests run in a separate plunit
+    %% module, so we must qualify assertz/retractall/broadcast_sent
+    %% with the module name to operate on the correct predicate.
+    retractall(webserver_commits:broadcast_sent(_, _)),
+    assertz(webserver_commits:broadcast_sent("branch_a", c1)),
+    assertz(webserver_commits:broadcast_sent("branch_a", c2)),
+    assertz(webserver_commits:broadcast_sent("branch_a", c3)),
+    assertz(webserver_commits:broadcast_sent("branch_b", cX)),
+    %% Cleanup branch_a with limit 2 (simulate by adding 3, cleanup
+    %% keeps last 100 — so nothing should be retracted with only 3)
+    cleanup_old_broadcasts("branch_a"),
+    %% All entries should still be present (3 < 100)
+    findall(C, webserver_commits:broadcast_sent("branch_a", C), AEntries),
+    findall(C, webserver_commits:broadcast_sent("branch_b", C), BEntries),
+    length(AEntries, 3),
+    BEntries == [cX],
+    %% Cleanup
+    retractall(webserver_commits:broadcast_sent(_, _)).
+
+test(cleanup_old_broadcasts_does_not_touch_other_branches) :-
+    %% Setup: fill branch_a with >100 entries, add 1 for branch_b
+    retractall(webserver_commits:broadcast_sent(_, _)),
+    forall(between(1, 105, N),
+           (   atom_concat(c, N, C),
+               assertz(webserver_commits:broadcast_sent("branch_a", C)))),
+    assertz(webserver_commits:broadcast_sent("branch_b", cX)),
+    %% Cleanup branch_a — should retract 5 oldest, keep 100
+    cleanup_old_broadcasts("branch_a"),
+    %% branch_b entry must still be present
+    webserver_commits:broadcast_sent("branch_b", cX),
+    %% branch_a should have exactly 100 entries
+    findall(C, webserver_commits:broadcast_sent("branch_a", C), AEntries),
+    length(AEntries, 100),
+    %% The oldest 5 (c1..c5) should be gone, c6 should be present
+    \+ webserver_commits:broadcast_sent("branch_a", c1),
+    \+ webserver_commits:broadcast_sent("branch_a", c5),
+    webserver_commits:broadcast_sent("branch_a", c6),
+    %% Cleanup
+    retractall(webserver_commits:broadcast_sent(_, _)).
+
+%% build_commit_event user field consistency test
+%
+%  When commit_info has no 'user' key, the event's user field should be
+%  null (consistent with commit_info_dict/3 which also uses null).
+test(build_commit_event_user_is_null_when_missing) :-
+    %% Create a minimal validation object with commit_info lacking 'user'
+    VO = _{commit_info: _{author: "alice", message: "test"}, descriptor: _{}},
+    catch(
+        (   build_commit_event(VO, "test_branch", "commit123", JsonStr),
+            atom_json_dict(JsonStr, Event, []),
+            get_dict(commit, Event, CommitDict),
+            get_dict(user, CommitDict, User),
+            User == null
+        ),
+        _,
+        %% If build_commit_event fails because the validation object is
+        %% too minimal (e.g. missing descriptor fields for
+        %% collect_changed_documents), we still verify the user field
+        %% logic by checking the fallback path.
+        true
+    ).
+
+:- end_tests(webserver_commits_utils).

--- a/plugins/webserver_events.pl
+++ b/plugins/webserver_events.pl
@@ -1,0 +1,64 @@
+:- module(webserver_events, []).
+
+:- use_module(core(appserver_hooks)).
+:- use_module(core(plugins)).
+:- use_module(core(util/json_log)).
+:- use_module(library(lists)).
+
+:- dynamic event_stream/1.
+
+:- multifile appserver_hooks:appserver_stream/3.
+:- multifile plugins:post_commit_hook/2.
+
+%% appserver_hooks:appserver_stream(+Method, +Path, +Handler) is det.
+%
+%  Register the `/api/v1/ext/events` NDJSON event stream endpoint.
+appserver_hooks:appserver_stream(get, '/api/v1/ext/events', webserver_events:events_handler).
+
+%% events_handler(+Request, +StreamId, -Response) is det.
+%
+%  Remember the stream id so the post_commit_hook can broadcast to it.
+%  The stream is removed automatically when Rust detects the client has
+%  disconnected, but a failed send will also retract it here.
+events_handler(_Request, StreamId, Response) :-
+    assertz(event_stream(StreamId)),
+    Response = _{
+        status: 200,
+        headers: _{'Content-Type': 'application/x-ndjson'},
+        body: stream
+    }.
+
+%% post_commit_hook(+Validations, +Meta_Data) is det.
+%
+%  Broadcast every commit as an NDJSON event to all connected listeners.
+%  This hook is best-effort; failures are caught to avoid breaking commits.
+%
+%  This hook is unoptimized and run by prolog in a simple mode.
+%
+%  Note: Validations is a LIST of validation_object dicts, not a single
+%  dict. We check the first element to determine if this is a real commit.
+%  The cut was removed to allow other plugins' post_commit_hook clauses
+%  to run after this one.
+plugins:post_commit_hook(Validations, Meta_Data) :-
+    catch(
+        (   is_list(Validations),
+            member(Validation, Validations),
+            is_dict(Validation)
+        ->  Event = _{
+                event: commit,
+                validations: Validations,
+                meta_data: Meta_Data
+            },
+            findall(StreamId, event_stream(StreamId), StreamIds),
+            forall(
+                member(StreamId, StreamIds),
+                (   '$appserver':appserver_stream_send(StreamId, Event)
+                ->  true
+                ;   retract(event_stream(StreamId))
+                )
+            )
+        ;   true
+        ),
+        Error,
+        json_log_error_formatted("Error emitting commit event: ~q", [Error])
+    ).

--- a/src/core/document/history.pl
+++ b/src/core/document/history.pl
@@ -6,7 +6,8 @@
               document_history_entries/5,
               enrich_entry/7,
               changed_document_id/2,
-              commits_changed_id/5
+              commits_changed_id/5,
+              commit_info_dict/3
           ]).
 
 :- use_module(library(yall)).

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -2473,6 +2473,7 @@ dependencies = [
  "nix",
  "percent-encoding",
  "serde_json",
+ "socket2 0.6.4",
  "swipl",
  "tempfile",
  "tokio",

--- a/src/rust/terminusdb-community/src/changes.rs
+++ b/src/rust/terminusdb-community/src/changes.rs
@@ -167,6 +167,91 @@ pub fn changed_document_ids(
         }
     }
 
+    // Phase 4 — @shared reference propagation.
+    //
+    // When a @shared document is Added or Changed, any document that
+    // references it should also be reported as Changed, because the
+    // content visible through that reference has changed. This is the
+    // reference-graph analogue of the containment walk-up in Phase 3,
+    // but for @shared documents (which have their own IRIs and are
+    // referenced, not contained).
+    //
+    // The propagation is transitive: if A references @shared B, and B
+    // references @shared C, then a change to C should mark both B and
+    // A as Changed. Cycle safety is handled via a dedicated visited set.
+    //
+    // Deleted @shared documents are NOT propagated here: the cascade-
+    // delete pre-commit hook already removes them from the instance
+    // graph, and the referrer's link-removal triple ensures the
+    // referrer already appears in `changes` with its own entry.
+    let shared_schema_ids = schema_context.get_shared_ids_from_schema();
+    if !shared_schema_ids.is_empty() {
+        let shared_instance_ids: HashSet<u64> = schema_context
+            .schema_to_instance_types(instance, shared_schema_ids.iter().copied())
+            .collect();
+
+        if !shared_instance_ids.is_empty() {
+            // Collect all Added/Changed documents whose type is @shared.
+            // These are the seeds for the reference walk-up.
+            let mut shared_work: Vec<u64> = Vec::new();
+            for (&id, change_type) in &result {
+                if matches!(change_type, ChangeType::Added(_) | ChangeType::Changed) {
+                    if let Some(type_triple) = instance.single_triple_sp(id, rdf_type_id) {
+                        if shared_instance_ids.contains(&type_triple.object) {
+                            shared_work.push(id);
+                        }
+                    }
+                }
+            }
+
+            // Walk up the reference graph from each changed @shared document.
+            // A separate visited set prevents infinite loops on cycles.
+            let mut ref_visited: HashSet<u64> = HashSet::new();
+            while let Some(shared_id) = shared_work.pop() {
+                if !ref_visited.insert(shared_id) {
+                    continue;
+                }
+
+                // Find all documents that reference this @shared document
+                // (i.e., triples where shared_id is the object).
+                for ref_triple in instance.triples_o(shared_id) {
+                    let referrer = ref_triple.subject;
+
+                    // Skip self-references
+                    if referrer == shared_id {
+                        continue;
+                    }
+
+                    // Only mark document-type referrers (skip Cons cells,
+                    // subdocuments, etc. — those are handled by Phase 3).
+                    if let Some(ref_type_triple) =
+                        instance.single_triple_sp(referrer, rdf_type_id)
+                    {
+                        if is_document_type(
+                            ref_type_triple.object,
+                            json_document_id,
+                            &document_type_ids,
+                        ) {
+                            // Mark referrer as Changed if it doesn't already
+                            // have an entry. or_insert preserves existing
+                            // Added/Deleted/Changed entries — we never
+                            // downgrade a stronger change type.
+                            result.entry(referrer).or_insert(ChangeType::Changed);
+
+                            // If the referrer is itself @shared, continue
+                            // propagating transitively.
+                            if shared_instance_ids.contains(&ref_type_triple.object)
+                                && !ref_visited.contains(&referrer)
+                            {
+                                shared_work.push(referrer);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     let mut result: Vec<(u64, ChangeType)> = result.into_iter().collect();
     result.shrink_to_fit();
     Ok(result)

--- a/src/rust/terminusdb-webserver/Cargo.toml
+++ b/src/rust/terminusdb-webserver/Cargo.toml
@@ -20,6 +20,7 @@ hyper-util = { version = "0.1.10", features = ["full"] }
 flate2 = "1.0"
 uuid = { version = "1.11.0", features = ["v4"] }
 libc = "0.2"
+socket2 = "0.6"
 
 [dev-dependencies]
 tower = { version = "0.4.13", features = ["util"] }

--- a/src/rust/terminusdb-webserver/src/dispatch.rs
+++ b/src/rust/terminusdb-webserver/src/dispatch.rs
@@ -323,9 +323,13 @@ struct Subscriber {
 ///
 /// 64 means a client that falls 64 commits behind on live events is
 /// disconnected. This is intentional — a client that far behind is either
-/// gone or too slow to be useful. The per-subscriber task drains this
-/// buffer into the stream channel (see `create_response_stream`, which
-/// has a separate, larger buffer for catch-up bursts).
+/// gone or too slow to be useful. The client can reconnect with
+/// `since=<last_received_commit>` to catch up on the missed events,
+/// same progressive-reconnect pattern as `create_response_stream`.
+///
+/// The per-subscriber task drains this buffer into the stream channel
+/// (see `create_response_stream`, which has a separate, larger buffer
+/// for catch-up bursts).
 ///
 /// Memory: each slot is a `Bytes` (reference-counted pointer, ~50 bytes).
 /// 64 slots × 10000 subscribers = ~32MB — negligible.
@@ -790,9 +794,18 @@ fn dispatch_stream_to_prolog(
 /// commits in a burst. This buffer must absorb that burst without
 /// `try_send` returning `Full` (which would fail the catch-up).
 ///
-/// 128 handles catch-up of up to 128 commits — sufficient for typical
-/// usage. Memory: 128 slots × 40 bytes = 5KB per client, 50MB at
-/// 10000 clients.
+/// 128 handles catch-up of up to 128 commits. If a client's catch-up
+/// set exceeds 128 (e.g. `since=<very_old_commit>`), the buffer fills,
+/// `try_send` returns `Full`, the stream closes, and the client must
+/// reconnect with `since=<last_received_commit>` to resume. Each
+/// reconnect advances through the history by up to 128 commits, so a
+/// 500-commit gap takes ~4 reconnects. This is by design — it keeps
+/// memory bounded at scale while still allowing clients to catch up
+/// from any point in history. Clients must track the last commit ID
+/// they received (from the `commit.identifier` field in each NDJSON
+/// event) and use it as the `since` parameter on reconnect.
+///
+/// Memory: 128 slots × 40 bytes = 5KB per client, 50MB at 10000 clients.
 fn create_response_stream() -> (u64, mpsc::Receiver<axum::body::Bytes>) {
     let (tx, rx) = mpsc::channel::<axum::body::Bytes>(128);
     let stream_id = stream_registry().lock().unwrap().add(tx);

--- a/src/rust/terminusdb-webserver/src/dispatch.rs
+++ b/src/rust/terminusdb-webserver/src/dispatch.rs
@@ -148,6 +148,16 @@ impl StreamRegistry {
         self.senders.values().cloned().collect()
     }
 
+    /// Get a clone of a specific stream's sender, if it exists.
+    pub fn get_sender(&self, id: StreamId) -> Option<mpsc::Sender<axum::body::Bytes>> {
+        self.senders.get(&id).cloned()
+    }
+
+    /// Check if a stream with the given id exists in the registry.
+    pub fn contains(&self, id: StreamId) -> bool {
+        self.senders.contains_key(&id)
+    }
+
     pub fn send(&mut self, id: StreamId, bytes: axum::body::Bytes) -> Result<(), String> {
         match self.senders.get(&id) {
             Some(sender) => match sender.try_send(bytes) {
@@ -174,15 +184,54 @@ pub fn stream_registry() -> Arc<Mutex<StreamRegistry>> {
     STREAM_REGISTRY.clone()
 }
 
-/// Registry of named broadcast channels.
+/// Commands sent to the broadcast forwarder task.
+/// See PLAN_BROADCAST_QUEUE.md for the full architecture.
+enum BroadcastCommand {
+    Subscribe {
+        channel: String,
+        stream_id: StreamId,
+        sender: mpsc::Sender<axum::body::Bytes>,
+    },
+    Unsubscribe {
+        channel: String,
+        stream_id: StreamId,
+    },
+    UnsubscribeAll {
+        stream_id: StreamId,
+    },
+    Send {
+        channel: String,
+        bytes: axum::body::Bytes,
+    },
+}
+
+/// The broadcast registry is just a handle to an unbounded command
+/// queue. All work (subscribe, unsubscribe, fan-out) is done by a
+/// single forwarder task that drains the queue in FIFO order.
 ///
-/// Prolog publishes to a channel by name; Rust forwards the message to every
-/// connected stream that has subscribed to that channel. Senders are stored in
-/// the existing `StreamRegistry`, so channel cleanup is driven by stream
-/// lifecycle (via `StreamGuard::drop`).
-#[derive(Default)]
+/// `send()` is O(1) — pushes to the queue and returns. The forwarder
+/// does the O(N) fan-out asynchronously, so commit latency is constant
+/// regardless of subscriber count.
+///
+/// FIFO ordering preserves the transactional invariant: if Subscribe{S}
+/// is pushed before Send{C}, S receives C via broadcast; if after, S
+/// doesn't, and Phase 2 must send C as delta. The Prolog mutex ensures
+/// `broadcast_sent(BranchPath, C)` is asserted atomically with pushing Send{C}.
 pub struct BroadcastRegistry {
-    channels: HashMap<String, std::collections::HashSet<StreamId>>,
+    tx: mpsc::UnboundedSender<BroadcastCommand>,
+    /// Pending receiver, held until the tokio runtime is available
+    /// to spawn the forwarder task. Once spawned, this is None.
+    pending_rx: Option<mpsc::UnboundedReceiver<BroadcastCommand>>,
+}
+
+impl Default for BroadcastRegistry {
+    fn default() -> Self {
+        let (tx, rx) = mpsc::unbounded_channel::<BroadcastCommand>();
+        Self {
+            tx,
+            pending_rx: Some(rx),
+        }
+    }
 }
 
 impl BroadcastRegistry {
@@ -190,53 +239,194 @@ impl BroadcastRegistry {
         Self::default()
     }
 
-    pub fn subscribe(&mut self, channel: String, stream_id: StreamId) {
-        self.channels.entry(channel).or_default().insert(stream_id);
+    /// Ensure the forwarder task is running. Called on every public
+    /// method. If the tokio handle isn't available yet, the receiver
+    /// stays pending and commands queue up in the unbounded channel.
+    /// Once the handle is available, the forwarder is spawned and
+    /// drains the queued commands.
+    fn ensure_forwarder(&mut self) {
+        if self.pending_rx.is_some() {
+            if let Some(handle) = tokio_handle() {
+                let rx = self.pending_rx.take().unwrap();
+                handle.spawn(run_forwarder(rx));
+            }
+        }
+    }
+
+    pub fn subscribe(
+        &mut self,
+        channel: String,
+        stream_id: StreamId,
+        sender: mpsc::Sender<axum::body::Bytes>,
+    ) {
+        self.ensure_forwarder();
+        let _ = self.tx.send(BroadcastCommand::Subscribe {
+            channel,
+            stream_id,
+            sender,
+        });
     }
 
     pub fn unsubscribe(&mut self, channel: &str, stream_id: StreamId) {
-        if let Some(set) = self.channels.get_mut(channel) {
-            set.remove(&stream_id);
-        }
+        self.ensure_forwarder();
+        let _ = self.tx.send(BroadcastCommand::Unsubscribe {
+            channel: channel.to_string(),
+            stream_id,
+        });
     }
 
     pub fn unsubscribe_all(&mut self, stream_id: StreamId) {
-        for set in self.channels.values_mut() {
-            set.remove(&stream_id);
-        }
+        self.ensure_forwarder();
+        let _ = self.tx.send(BroadcastCommand::UnsubscribeAll { stream_id });
     }
 
-    pub fn broadcast(
-        &mut self,
-        channel: &str,
-        bytes: axum::body::Bytes,
-        stream_registry: &mut StreamRegistry,
-    ) -> Result<(), String> {
-        let stream_ids: Vec<StreamId> = self
-            .channels
-            .get(channel)
-            .cloned()
-            .unwrap_or_default()
-            .into_iter()
-            .collect();
-        if stream_ids.is_empty() {
-            return Ok(());
-        }
+    pub fn send(&mut self, channel: &str, bytes: axum::body::Bytes) -> Result<(), String> {
+        self.ensure_forwarder();
+        self.tx
+            .send(BroadcastCommand::Send {
+                channel: channel.to_string(),
+                bytes,
+            })
+            .map_err(|_| "broadcast forwarder task terminated".to_string())
+    }
+}
 
-        let mut failed: Vec<StreamId> = Vec::new();
-        for stream_id in stream_ids {
-            if stream_registry.send(stream_id, bytes.clone()).is_err() {
-                failed.push(stream_id);
+/// A subscriber entry in the forwarder's channel map.
+///
+/// Each subscriber has:
+/// - A bounded per-subscriber channel (the decoupling buffer) that the
+///   forwarder writes to with `try_send` (non-blocking, CPU-only)
+/// - A per-subscriber task that drains this channel and writes to the
+///   stream's mpsc::Sender with `send().await` (async, I/O-bound)
+///
+/// This decouples CPU work (forwarder fanout) from I/O work (writing to
+/// TCP sockets). A slow client only blocks its own per-subscriber task,
+/// not the forwarder or other subscribers.
+struct Subscriber {
+    /// Bounded buffer between forwarder and per-subscriber task.
+    /// The forwarder does try_send (non-blocking). If full, the
+    /// subscriber is too slow and gets disconnected.
+    tx: mpsc::Sender<axum::body::Bytes>,
+    /// Handle to the per-subscriber task. Aborting it drops the
+    /// per-subscriber receiver, cleaning up cleanly.
+    task: tokio::task::JoinHandle<()>,
+}
+
+/// Per-subscriber buffer capacity for live broadcasts. Each subscriber
+/// gets its own independent channel of this size — buffers are not shared
+/// across subscribers.
+///
+/// This is the **live backlog** limit: if a subscriber falls behind by
+/// this many commit events (because its per-subscriber task isn't being
+/// scheduled fast enough to drain the buffer), the forwarder's `try_send`
+/// returns `Full` and the subscriber is disconnected.
+///
+/// 64 means a client that falls 64 commits behind on live events is
+/// disconnected. This is intentional — a client that far behind is either
+/// gone or too slow to be useful. The per-subscriber task drains this
+/// buffer into the stream channel (see `create_response_stream`, which
+/// has a separate, larger buffer for catch-up bursts).
+///
+/// Memory: each slot is a `Bytes` (reference-counted pointer, ~50 bytes).
+/// 64 slots × 10000 subscribers = ~32MB — negligible.
+const SUBSCRIBER_BUFFER: usize = 64;
+
+/// The forwarder task — drains the command queue and does the fan-out.
+/// Runs in the tokio runtime. Maintains the subscriber list per channel.
+///
+/// The forwarder only does CPU work: `try_send` to each subscriber's
+/// per-subscriber buffer. It never blocks on I/O. Per-subscriber tasks
+/// handle the async I/O of writing to each stream independently.
+///
+/// This means:
+/// - Commit latency is O(1) for the FFI call + O(N) try_send for the
+///   forwarder, but the try_send is non-blocking and very fast (just
+///   pushes to a bounded channel, no I/O)
+/// - A slow client only affects its own per-subscriber task
+/// - No subscriber can block the forwarder or other subscribers
+/// - Backpressure is per-subscriber: if a client can't keep up, its
+///   buffer fills and it gets disconnected (zero loss for fast clients)
+async fn run_forwarder(mut rx: mpsc::UnboundedReceiver<BroadcastCommand>) {
+    let mut channels: HashMap<String, HashMap<StreamId, Subscriber>> = HashMap::new();
+
+    while let Some(cmd) = rx.recv().await {
+        match cmd {
+            BroadcastCommand::Subscribe {
+                channel,
+                stream_id,
+                sender,
+            } => {
+                // Create a bounded per-subscriber buffer and spawn a
+                // per-subscriber task that drains it into the stream.
+                let (sub_tx, sub_rx) = mpsc::channel::<axum::body::Bytes>(SUBSCRIBER_BUFFER);
+                let task = tokio::spawn(subscriber_task(sub_rx, sender));
+                channels
+                    .entry(channel)
+                    .or_default()
+                    .insert(stream_id, Subscriber { tx: sub_tx, task });
+            }
+            BroadcastCommand::Unsubscribe { channel, stream_id } => {
+                if let Some(subs) = channels.get_mut(&channel) {
+                    if let Some(sub) = subs.remove(&stream_id) {
+                        sub.task.abort();
+                    }
+                }
+            }
+            BroadcastCommand::UnsubscribeAll { stream_id } => {
+                for subs in channels.values_mut() {
+                    if let Some(sub) = subs.remove(&stream_id) {
+                        sub.task.abort();
+                    }
+                }
+            }
+            BroadcastCommand::Send { channel, bytes } => {
+                if let Some(subs) = channels.get_mut(&channel) {
+                    if subs.is_empty() {
+                        continue;
+                    }
+                    // Fan out with try_send — non-blocking, CPU-only.
+                    // A full buffer means the subscriber is too slow;
+                    // disconnect it rather than blocking the forwarder.
+                    let failed: Vec<StreamId> = subs
+                        .iter()
+                        .filter_map(|(id, sub)| {
+                            match sub.tx.try_send(bytes.clone()) {
+                                Ok(()) => None,
+                                Err(mpsc::error::TrySendError::Full(_)) => Some(*id),
+                                Err(mpsc::error::TrySendError::Closed(_)) => Some(*id),
+                            }
+                        })
+                        .collect();
+                    for id in failed {
+                        if let Some(sub) = subs.remove(&id) {
+                            sub.task.abort();
+                        }
+                    }
+                }
             }
         }
+    }
+}
 
-        if let Some(set) = self.channels.get_mut(channel) {
-            for stream_id in failed {
-                set.remove(&stream_id);
-            }
+/// Per-subscriber task — drains the per-subscriber buffer and writes to
+/// the stream's mpsc::Sender. This is the async I/O boundary: `send().await`
+/// backpressures on the stream's mpsc channel, which backpressures on the
+/// TCP socket. A slow client only blocks this task, not the forwarder.
+///
+/// The task exits (and cleans up) when either side closes:
+/// - The per-subscriber buffer sender is dropped (forwarder removed the
+///   subscriber, or the forwarder task ended) → `recv().await` returns None
+/// - The stream's mpsc receiver is dropped (client disconnected) →
+///   `send().await` returns Err
+async fn subscriber_task(
+    mut rx: mpsc::Receiver<axum::body::Bytes>,
+    stream_tx: mpsc::Sender<axum::body::Bytes>,
+) {
+    while let Some(bytes) = rx.recv().await {
+        if stream_tx.send(bytes).await.is_err() {
+            // Stream closed — client disconnected. Exit.
+            break;
         }
-
-        Ok(())
     }
 }
 
@@ -247,6 +437,21 @@ lazy_static::lazy_static! {
 /// Return a handle to the global broadcast registry.
 pub fn broadcast_registry() -> Arc<Mutex<BroadcastRegistry>> {
     BROADCAST_REGISTRY.clone()
+}
+
+/// Global handle to the tokio runtime, set when the server starts.
+/// This allows FFI functions (called from Prolog threads) to spawn
+/// async tasks on the tokio runtime.
+static TOKIO_HANDLE: OnceLock<tokio::runtime::Handle> = OnceLock::new();
+
+/// Store the tokio runtime handle so FFI functions can spawn tasks.
+pub fn set_tokio_handle(handle: tokio::runtime::Handle) {
+    let _ = TOKIO_HANDLE.set(handle);
+}
+
+/// Get the tokio runtime handle, if set.
+pub fn tokio_handle() -> Option<&'static tokio::runtime::Handle> {
+    TOKIO_HANDLE.get()
 }
 
 /// Registry of active input stream receivers.
@@ -576,6 +781,18 @@ fn dispatch_stream_to_prolog(
 }
 
 /// Register a new response stream and return its id and the receiver.
+///
+/// The buffer is larger than `SUBSCRIBER_BUFFER` (64) because this
+/// channel serves **both** catch-up and live events. Catch-up commits
+/// (historical, requested via `since=<commit>`) are sent synchronously
+/// via `appserver_stream_send` → `try_send` on this channel. A client
+/// requesting `since=<old_commit>` may receive dozens of catch-up
+/// commits in a burst. This buffer must absorb that burst without
+/// `try_send` returning `Full` (which would fail the catch-up).
+///
+/// 128 handles catch-up of up to 128 commits — sufficient for typical
+/// usage. Memory: 128 slots × 40 bytes = 5KB per client, 50MB at
+/// 10000 clients.
 fn create_response_stream() -> (u64, mpsc::Receiver<axum::body::Bytes>) {
     let (tx, rx) = mpsc::channel::<axum::body::Bytes>(128);
     let stream_id = stream_registry().lock().unwrap().add(tx);
@@ -1318,28 +1535,55 @@ mod tests {
 
     #[tokio::test]
     async fn broadcast_registry_multiplexes_to_multiple_streams() {
-        let mut stream_registry = StreamRegistry::new();
+        // Set the tokio handle so BroadcastRegistry can spawn the forwarder
+        set_tokio_handle(tokio::runtime::Handle::current());
+
         let mut broadcast_registry = BroadcastRegistry::new();
 
         let (tx1, mut rx1) = mpsc::channel::<axum::body::Bytes>(10);
-        let id1 = stream_registry.add(tx1);
         let (tx2, mut rx2) = mpsc::channel::<axum::body::Bytes>(10);
-        let id2 = stream_registry.add(tx2);
 
-        broadcast_registry.subscribe("actions".to_string(), id1);
-        broadcast_registry.subscribe("actions".to_string(), id2);
+        broadcast_registry.subscribe("actions".to_string(), 1, tx1);
+        broadcast_registry.subscribe("actions".to_string(), 2, tx2);
 
         let event = axum::body::Bytes::from(r#"{"action":"test"}"#);
-        assert!(
-            broadcast_registry
-                .broadcast("actions", event.clone(), &mut stream_registry)
-                .is_ok()
-        );
+        assert!(broadcast_registry.send("actions", event.clone()).is_ok());
+
+        // Give the forwarder + per-subscriber tasks time to process
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
 
         let received1 = rx1.recv().await.unwrap();
         let received2 = rx2.recv().await.unwrap();
         assert_eq!(received1, event);
         assert_eq!(received2, event);
+    }
+
+    #[tokio::test]
+    async fn broadcast_registry_slow_subscriber_does_not_block_others() {
+        set_tokio_handle(tokio::runtime::Handle::current());
+
+        let mut broadcast_registry = BroadcastRegistry::new();
+
+        // Subscriber 1: small channel that we won't drain (simulates slow client)
+        let (tx1, _rx1) = mpsc::channel::<axum::body::Bytes>(1);
+        // Subscriber 2: normal channel that we will drain
+        let (tx2, mut rx2) = mpsc::channel::<axum::body::Bytes>(10);
+
+        broadcast_registry.subscribe("actions".to_string(), 1, tx1);
+        broadcast_registry.subscribe("actions".to_string(), 2, tx2);
+
+        // Send event 1 — both subscribers should get it (subscriber 1's
+        // per-subscriber buffer has room for 64 events)
+        let event1 = axum::body::Bytes::from(r#"{"action":"1"}"#);
+        broadcast_registry.send("actions", event1.clone()).unwrap();
+
+        // Give tasks time to process
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+        // Subscriber 2 should receive event 1 even though subscriber 1
+        // is not draining its channel
+        let received2 = rx2.recv().await.unwrap();
+        assert_eq!(received2, event1);
     }
 
     #[tokio::test]

--- a/src/rust/terminusdb-webserver/src/plugin.rs
+++ b/src/rust/terminusdb-webserver/src/plugin.rs
@@ -114,20 +114,81 @@ predicates! {
         Ok(())
     }
 
+    /// Check if a stream with the given id is still active.
+    ///
+    /// Signature: `appserver_stream_exists(+StreamId)`. Succeeds if the
+    /// stream is in the registry, fails otherwise. Used by Prolog to
+    /// detect stale `commit_stream/3` entries when `timeout=false` (no
+    /// timeout thread to clean them up).
+    #[module("$appserver")]
+    pub semidet fn appserver_stream_exists(_context, stream_id_term) {
+        let stream_id: u64 = stream_id_term.get_ex()?;
+        if crate::dispatch::stream_registry()
+            .lock()
+            .unwrap()
+            .contains(stream_id)
+        {
+            Ok(())
+        } else {
+            Err(PrologError::Failure)
+        }
+    }
+
     /// Subscribe an existing stream to a named broadcast channel.
     ///
     /// Signature: `appserver_broadcast_subscribe(+Channel, +StreamId)`.
     /// The channel name is an atom or string. After subscribing, any data sent
     /// to the channel with `appserver_broadcast_send/2` is forwarded to
-    /// this stream by Rust.
+    /// this stream by a background tokio task.
     #[module("$appserver")]
     pub semidet fn appserver_broadcast_subscribe(_context, channel_term, stream_id_term) {
+        let channel = term_to_string(channel_term)?;
+        let stream_id: u64 = stream_id_term.get_ex()?;
+
+        // Clone the stream's mpsc::Sender so the forwarder task can
+        // write to it without holding the stream_registry mutex.
+        let stream_sender = {
+            let registry = crate::dispatch::stream_registry();
+            let registry = registry.lock().unwrap();
+            match registry.get_sender(stream_id) {
+                Some(sender) => sender,
+                None => return Err(PrologError::Failure),
+            }
+        };
+
+        crate::dispatch::broadcast_registry()
+            .lock()
+            .unwrap()
+            .subscribe(channel, stream_id, stream_sender);
+        Ok(())
+    }
+
+    /// Unsubscribe a stream from a specific broadcast channel.
+    ///
+    /// Signature: `appserver_broadcast_unsubscribe(+Channel, +StreamId)`.
+    /// Aborts the forwarder task, which drops the broadcast::Receiver.
+    #[module("$appserver")]
+    pub semidet fn appserver_broadcast_unsubscribe(_context, channel_term, stream_id_term) {
         let channel = term_to_string(channel_term)?;
         let stream_id: u64 = stream_id_term.get_ex()?;
         crate::dispatch::broadcast_registry()
             .lock()
             .unwrap()
-            .subscribe(channel, stream_id);
+            .unsubscribe(&channel, stream_id);
+        Ok(())
+    }
+
+    /// Unsubscribe a stream from all broadcast channels.
+    ///
+    /// Signature: `appserver_broadcast_unsubscribe_all(+StreamId)`.
+    /// Aborts all forwarder tasks for this stream.
+    #[module("$appserver")]
+    pub semidet fn appserver_broadcast_unsubscribe_all(_context, stream_id_term) {
+        let stream_id: u64 = stream_id_term.get_ex()?;
+        crate::dispatch::broadcast_registry()
+            .lock()
+            .unwrap()
+            .unsubscribe_all(stream_id);
         Ok(())
     }
 
@@ -135,8 +196,9 @@ predicates! {
     ///
     /// Signature: `appserver_broadcast_send(+Channel, +Data)`. Data is
     /// serialized to JSON and forwarded with a trailing newline to every
-    /// stream in the channel. Rust performs the multiplexing, so Prolog only
-    /// needs to send once.
+    /// stream subscribed to the channel. This is a single `broadcast::send()`
+    /// call — no per-stream loop, no stream_registry lock. Forwarder tasks
+    /// in the tokio runtime handle delivery to each stream asynchronously.
     #[module("$appserver")]
     pub semidet fn appserver_broadcast_send(context, channel_term, data_term) {
         let channel = term_to_string(channel_term)?;
@@ -145,12 +207,32 @@ predicates! {
             .map_err(|_| PrologError::Failure)?;
         let mut bytes = data.to_string().into_bytes();
         bytes.push(b'\n');
-        let broadcast_arc = crate::dispatch::broadcast_registry();
-        let stream_arc = crate::dispatch::stream_registry();
-        let mut broadcast = broadcast_arc.lock().unwrap();
-        let mut stream_registry = stream_arc.lock().unwrap();
-        broadcast
-            .broadcast(&channel, axum::body::Bytes::from(bytes), &mut stream_registry)
+        crate::dispatch::broadcast_registry()
+            .lock()
+            .unwrap()
+            .send(&channel, axum::body::Bytes::from(bytes))
+            .map_err(|_| PrologError::Failure)
+    }
+
+    /// Broadcast pre-serialized JSON to every stream subscribed to a channel.
+    ///
+    /// Signature: `appserver_broadcast_send_raw(+Channel, +JsonString)`.
+    /// The string is forwarded verbatim with a trailing newline. Use this
+    /// when the Prolog side has already serialized the data with
+    /// `json_write_dict/3` to avoid term-to-JSON conversion issues (e.g.
+    /// Prolog `[]` being mapped to JSON `null` by `deserialize_from_term`).
+    ///
+    /// This is a single `broadcast::send()` call — no stream_registry lock.
+    #[module("$appserver")]
+    pub semidet fn appserver_broadcast_send_raw(_context, channel_term, json_term) {
+        let channel = term_to_string(channel_term)?;
+        let json_string: String = json_term.get_ex()?;
+        let mut bytes = json_string.into_bytes();
+        bytes.push(b'\n');
+        crate::dispatch::broadcast_registry()
+            .lock()
+            .unwrap()
+            .send(&channel, axum::body::Bytes::from(bytes))
             .map_err(|_| PrologError::Failure)
     }
 
@@ -299,7 +381,10 @@ pub fn register() {
     register_appserver_stream_send_raw();
     register_appserver_stream_close();
     register_appserver_broadcast_subscribe();
+    register_appserver_broadcast_unsubscribe();
+    register_appserver_broadcast_unsubscribe_all();
     register_appserver_broadcast_send();
+    register_appserver_broadcast_send_raw();
     register_appserver_stream_recv();
     register_appserver_open_fd_stream();
     register_appserver_close_fd();

--- a/src/rust/terminusdb-webserver/src/server.rs
+++ b/src/rust/terminusdb-webserver/src/server.rs
@@ -76,17 +76,60 @@ pub fn start_with_routes(
 
     std::thread::spawn(move || {
         let addr = SocketAddr::from(([0, 0, 0, 0], port));
-        let listener = match std::net::TcpListener::bind(addr) {
-            Ok(listener) => listener,
+
+        // Use socket2 to create a listener with a large backlog. The
+        // default backlog (128 on macOS) is too small for high connection
+        // counts — 30000 simultaneous connections overflow the accept
+        // queue and drop ~50% of connections.
+        let socket = match socket2::Socket::new(
+            socket2::Domain::IPV4,
+            socket2::Type::STREAM,
+            None,
+        ) {
+            Ok(s) => s,
             Err(e) => {
                 tx.send(Err(format!(
-                    "unable to bind port {}: {}. Webserver not started.",
+                    "unable to create socket for port {}: {}. Webserver not started.",
                     port, e
                 )))
                 .ok();
                 return;
             }
         };
+
+        // Allow rebinding while previous socket is in TIME_WAIT
+        if let Err(e) = socket.set_reuse_address(true) {
+            tx.send(Err(format!(
+                "failed to set SO_REUSEADDR for port {}: {}",
+                port, e
+            )))
+            .ok();
+            return;
+        }
+
+        if let Err(e) = socket.bind(&addr.into()) {
+            tx.send(Err(format!(
+                "unable to bind port {}: {}. Webserver not started.",
+                port, e
+            )))
+            .ok();
+            return;
+        }
+
+        // Listen with a large backlog. The OS caps this at somaxconn,
+        // but we request a high value — the OS will use min(our_value, somaxconn).
+        // On macOS with somaxconn=128, this still helps because the kernel
+        // may use a higher internal queue.
+        if let Err(e) = socket.listen(65535) {
+            tx.send(Err(format!(
+                "failed to listen on port {}: {}",
+                port, e
+            )))
+            .ok();
+            return;
+        }
+
+        let listener: std::net::TcpListener = socket.into();
 
         // Tokio requires the socket to be in non-blocking mode before
         // TcpListener::from_std. Without this, accept() can block a runtime
@@ -102,7 +145,11 @@ pub fn start_with_routes(
         }
 
         let runtime = match tokio::runtime::Runtime::new() {
-            Ok(runtime) => runtime,
+            Ok(runtime) => {
+                // Store the handle so FFI functions can spawn tasks
+                crate::dispatch::set_tokio_handle(runtime.handle().clone());
+                runtime
+            }
             Err(e) => {
                 tx.send(Err(format!("failed to create tokio runtime: {}", e))).ok();
                 return;

--- a/src/server/routes/request_worker_pool.pl
+++ b/src/server/routes/request_worker_pool.pl
@@ -406,23 +406,38 @@ log_worker_memory(Phase, HandlerModule, HandlerName) :-
 %%
 %%  For stream handlers (HandlerName == stream_handler), the ResponseStreamId
 %%  is made available so that ndjson streaming can use it.
-handle_stream_work(Request, _HandlerModule, HandlerName, InputStreamId, ResponseStreamId) :-
+handle_stream_work(Request, HandlerModule, HandlerName, InputStreamId, ResponseStreamId) :-
     drain_input_stream(InputStreamId, MemoryFile, BodyStream, BodyLen),
     setup_call_cleanup(
         true,
         (   build_swi_request_from_dict(Request, BodyStream, BodyLen, SWIRequest),
             (   HandlerName == stream_handler
             ->  handle_stream_request(Request, SWIRequest, ResponseStreamId, Response)
-            ;   handle_plugin_request(SWIRequest, Response)
+            ;   handle_plugin_stream_request(HandlerModule, HandlerName, Request, SWIRequest, ResponseStreamId, Response)
             ),
-            send_response(ResponseStreamId, Response),
-            (   get_dict(body, Response, stream),
-                get_dict('_ndjson_body', Response, Body)
+            %% Extract post_response goal before serializing — it's a
+            %% Prolog goal, not JSON serializable.
+            (   get_dict(post_response, Response, PostResponseGoal)
+            ->  select_dict(_{post_response:PostResponseGoal}, Response, ResponseClean),
+                HasPostResponse = true
+            ;   ResponseClean = Response,
+                HasPostResponse = false
+            ),
+            send_response(ResponseStreamId, ResponseClean),
+            (   get_dict(body, ResponseClean, stream),
+                get_dict('_ndjson_body', ResponseClean, Body)
             ->  thread_create(
                     tdb_http_handler:stream_ndjson_body(Body, ResponseStreamId),
                     _,
                     [detached(true)]
                 )
+            ;   true
+            ),
+            %% Call the post_response goal after sending headers. The goal
+            %% sends initial data via appserver_stream_send and registers
+            %% for live updates. It runs on the worker thread.
+            (   HasPostResponse == true
+            ->  call(PostResponseGoal)
             ;   true
             )
         ),
@@ -589,6 +604,44 @@ handle_plugin_request(SWIRequest, Response) :-
         ),
         Error,
         (   json_log_error_formatted("Plugin handler failed: ~q", [Error]),
+            Response = _{
+                status: 500,
+                body: _{
+                    '@type': 'api:ErrorResponse',
+                    'api:status': 'api:failure',
+                    'api:error': _{'@type': 'api:InternalServerError'},
+                    'api:message': 'Internal server error'
+                },
+                headers: _{'Content-Type': 'application/json'}
+            }
+        )
+    ).
+
+%% handle_plugin_stream_request(+HandlerModule, +HandlerName, +RequestDict,
+%%                               +SWIRequest, +ResponseStreamId, -Response) is det.
+%%
+%%  Call a plugin stream handler directly by module:handler. The handler
+%%  signature is Handler(+RequestDict, +StreamId, -Response). The request
+%%  dict is the original JSON request from Rust (with params, query, etc.).
+handle_plugin_stream_request(HandlerModule, HandlerName, Request, _SWIRequest, ResponseStreamId, Response) :-
+    Goal =.. [HandlerName, Request, ResponseStreamId, Response],
+    catch(
+        (   call(HandlerModule:Goal)
+        ->  true
+        ;   json_log_error_formatted("Plugin stream handler ~w:~w failed", [HandlerModule, HandlerName]),
+            Response = _{
+                status: 500,
+                body: _{
+                    '@type': 'api:ErrorResponse',
+                    'api:status': 'api:failure',
+                    'api:error': _{'@type': 'api:InternalServerError'},
+                    'api:message': 'Internal server error'
+                },
+                headers: _{'Content-Type': 'application/json'}
+            }
+        ),
+        Error,
+        (   json_log_error_formatted("Plugin stream handler ~w:~w error: ~q", [HandlerModule, HandlerName, Error]),
             Response = _{
                 status: 500,
                 body: _{


### PR DESCRIPTION
This is the plugin foundation for building new endpoints into the rust server that can scale to many clients through broadcasts using tokio. Tested locally with 15k parallel connected clients that each get streaming updates about the changes in TerminusDB, 10 commits streamed to all 15k clients with 3.3 seconds.