### PR TITLE
docs: document protoc and make install-deps prerequisites for macOS build

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -162,7 +162,19 @@ The fastest way to start developing is using the test server script after clonin
 
 #### Manual Build
 
+**Prerequisites for a fresh clone:**
+
+- `protoc` (the Protocol Buffers compiler) — e.g. `brew install protobuf` on macOS. Without it,
+  `cargo build` fails inside a transitive dependency with
+  `Could not find protoc installation`.
+- `make install-deps` must be run once, **before** the first `make dev`, to fetch the SWI-Prolog
+  `tus` pack. Without it, the Prolog bootstrap fails with
+  `` source_sink `library(tus)' does not exist ``.
+
 ```bash
+# One-time: fetch Prolog dependencies (tus pack, etc.)
+make install-deps
+
 # Build Rust library and create development binary
 make dev
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -159,7 +159,10 @@ For local development on macOS, use the development build target which avoids co
   `` source_sink `library(tus)' does not exist ``.
 
 ```bash
+# For first time setup
+brew install protobuf
 make install-deps
+# Produce the dev build
 make dev
 ```
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -148,9 +148,18 @@ This significantly reduces build time but should **only be used for development*
 
 ### Development Build (Recommended)
 
-For local development on macOS, use the development build target which avoids code signing issues:
+For local development on macOS, use the development build target which avoids code signing issues.
+
+**Prerequisites for a fresh clone:**
+
+- `protoc` (the Protocol Buffers compiler), e.g. `brew install protobuf`. Without it, `cargo
+  build` fails inside a transitive dependency with `Could not find protoc installation`.
+- `make install-deps` must be run once, **before** the first `make dev`, to fetch the SWI-Prolog
+  `tus` pack. Without it, the Prolog bootstrap fails with
+  `` source_sink `library(tus)' does not exist ``.
 
 ```bash
+make install-deps
 make dev
 ```
 
@@ -168,6 +177,7 @@ This creates a `terminusdb` binary that:
 - Dynamically links to SWI-Prolog libraries (no stripping)
 - Faster to rebuild during development
 - Requires SWI-Prolog to be installed (via Homebrew recommended)
+- Requires `protoc` to be installed (via Homebrew recommended: `brew install protobuf`)
 
 Run the development binary:
 


### PR DESCRIPTION
## Summary

Fixes #2500.

A fresh clone of `main` fails `make dev` twice on macOS before succeeding, on two undocumented prerequisites:

1. **Missing `protoc`.** `cargo build` fails inside `terminusdb-grpc-labelstore-proto`'s build script with `Could not find protoc installation`. Neither `GETTING_STARTED.md` nor `docs/CONTRIBUTING.md` mention `protoc` anywhere.
2. **Missing SWI-Prolog `tus` pack.** After installing `protoc`, the Rust layer compiles but the Prolog bootstrap fails with `` source_sink `library(tus)' does not exist ``. `make install-deps` fetches this pack, but neither doc's macOS build instructions say it needs to run *before* the first `make dev` — it's easy to miss since `make dev`'s own error message doesn't point at the fix.

## Changes

- `GETTING_STARTED.md` — "Manual Build" section: added a prerequisites note (`protoc`, `make install-deps` ordering) and an explicit `make install-deps` step in the code block.
- `docs/CONTRIBUTING.md` — "Building on macOS" → "Development Build (Recommended)" section: same prerequisites note, `make install-deps` added to the code block, and a `protoc` bullet added alongside the existing SWI-Prolog requirement.

## Test plan

- [x] Verified against a fresh clone at `a08d9ff2ad981ba7f7d99620d134ef598a36fc3f`: `brew install protobuf` + `make install-deps` + `make dev` builds cleanly, and the resulting binary's `/api/info` reports the matching git hash.
- [x] Docs-only change — no code paths affected.