### PR TITLE
Upgrade swipl to 10.0.2 for thread safety

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # Community-only Docker build.
 # Set the swipl version by argument (see Makefile for the default!)
-ARG SWIPL_VERSION=10.0.1
+ARG SWIPL_VERSION=10.0.2
 ARG SKIP_TESTS=false
 ARG TDB_ADMIN_VERSION=v0.1.1-rc3
 ARG TDB_DATA_VERSION=v0.1.0-rc2

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DIST ?= community
 # Default was 9.2.9
-SWIPL_VERSION ?= 10.0.1
+SWIPL_VERSION ?= 10.0.2
 
 # Version-tagged release of tdb-admin to download for the embedded admin panel.
 # Must match a tag in https://github.com/terminusdb-org/tdb-admin/releases

--- a/docker/debug/Dockerfile
+++ b/docker/debug/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 
-ARG SWIPL_VERSION=10.0.1
+ARG SWIPL_VERSION=10.0.2
 ARG DIST=community
 ARG SKIP_TESTS=false
 ARG TDB_ADMIN_VERSION=v0.1.1-rc3


### PR DESCRIPTION
## Summary

This is an upgrade of SWI-Prolog to 10.0.2 to fix atom-GC crash during concurrent plunit tests. The Docker build on arm64 had a one time crash during `make test` with a fatal SWI-Prolog assertion in the garbage collector:

```
ERROR: /tmp/src/swipl-10.0.1/src/pl-rec.c:1761: scanAtomsRecord: Assertion failed: 0
Thread: 2 (gc)
```

The crash traces through `markAtomsFindall` → `markAtomsRecord` → `scanAtomsRecord`,
meaning the atom-GC thread was scanning a findall segstack and read an unknown record
opcode — the buffer was being concurrently mutated. This was already fixed in swipl upstreams.

## Root cause

The `woql` plunit suite runs with `concurrent(true)`, so several worker threads execute
`findall/3` at the same time while the atom-GC thread asynchronously scans their
segstacks. SWI-Prolog 10.0.0 and 10.0.1 have a race condition in `updateAlerted()`
(`src/pl-wam.c`): the final `ld->alerted = mask` store is non-atomic. When an external
thread (the GC thread signalling atom-GC) calls `updateAlerted()` concurrently with the
target thread, the plain store can lose the atom-GC signal bit. The target thread then
keeps mutating its findall segstack without honoring the GC suspension request, and the
GC thread scans a half-written record, hitting `assert(0)` at `pl-rec.c:1763`.

This is fixed upstream in SWI-Prolog 10.0.2 by commit `cf780c04` (Jan Wielemaker,
2026-03-06), which wraps the body of `updateAlerted()` in a compare-and-swap loop so the
`ld->alerted` update is atomic.

## Change

Bump `SWIPL_VERSION` from `10.0.1` to `10.0.2` in the three files that pin it:

- `Makefile`
- `Dockerfile`
- `docker/debug/Dockerfile`

No source code or Rust changes are required. The `swipl-rs` crate already handles the
SWI-Prolog 10 `int`→`bool` ABI change via its `FliResult` / `FliSuccess` trait, so the
foreign library remains compatible with 10.0.2.