### PR TITLE
Fix field-level `@unfold` being silently ignored for `List` and multi-dim `Array` properties

### DIFF
--- a/src/rust/terminusdb-community/src/doc/mod.rs
+++ b/src/rust/terminusdb-community/src/doc/mod.rs
@@ -500,18 +500,32 @@ impl<L: Layer + Clone> DocumentContext<L> {
                     if let Some(rdf_type_id) = self.rdf.type_() {
                         if let Some(t) = self.layer().single_triple_sp(next_obj, rdf_type_id) {
                             if Some(t.object) == self.sys.array() {
+                                // capture the parent document's type/predicate before get_array_iter
+                                // clears out cur's fields, so field-level @unfold still applies to
+                                // the array's elements.
+                                let parent_type_id = cur.document_type_id();
+                                let predicate_id = cur.current_predicate();
                                 let array_iter = self.get_array_iter(cur);
                                 stack.push(StackEntry::Array(ArrayStackEntry {
                                     collect: Vec::new(),
                                     entries: array_iter,
+                                    parent_type_id,
+                                    predicate_id,
                                 }));
                                 continue;
                             } else if Some(t.object) == self.rdf.list() {
+                                // same as above: capture before pushing, so field-level @unfold
+                                // still applies to the list's elements (they sit behind the
+                                // rdf:first/rdf:rest Cons chain, not a direct edge from the parent).
+                                let parent_type_id = cur.document_type_id();
+                                let predicate_id = cur.current_predicate();
                                 let list_iter = self.get_list_iter(next_obj);
                                 stack.push(StackEntry::List {
                                     collect: Vec::new(),
                                     entries: list_iter,
                                     json: is_json,
+                                    parent_type_id,
+                                    predicate_id,
                                 });
                                 continue;
                             }
@@ -657,6 +671,8 @@ enum StackEntry<'a, L: Layer> {
         collect: Vec<Value>,
         entries: Peekable<RdfListIterator<'a, L>>,
         json: bool,
+        parent_type_id: Option<u64>,
+        predicate_id: Option<u64>,
     },
     Array(ArrayStackEntry<'a, L>),
 }
@@ -690,7 +706,8 @@ impl<'a, L: Layer> StackEntry<'a, L> {
     fn document_type_id(&self) -> Option<u64> {
         match self {
             Self::Document { type_id, .. } => *type_id,
-            _ => None,
+            Self::List { parent_type_id, .. } => *parent_type_id,
+            Self::Array(a) => a.parent_type_id,
         }
     }
 
@@ -699,7 +716,8 @@ impl<'a, L: Layer> StackEntry<'a, L> {
             Self::Document { fields, .. } => {
                 fields.as_mut().and_then(|f| f.peek().map(|t| t.predicate))
             }
-            _ => None,
+            Self::List { predicate_id, .. } => *predicate_id,
+            Self::Array(a) => a.predicate_id,
         }
     }
 }
@@ -707,6 +725,8 @@ impl<'a, L: Layer> StackEntry<'a, L> {
 struct ArrayStackEntry<'a, L: Layer> {
     collect: Vec<(Vec<usize>, Value)>,
     entries: ArrayIterator<'a, L>,
+    parent_type_id: Option<u64>,
+    predicate_id: Option<u64>,
 }
 
 pub struct ArrayIterator<'a, L: Layer> {

--- a/tests/test/field-level-unfold.js
+++ b/tests/test/field-level-unfold.js
@@ -207,6 +207,135 @@ describe('Field-Level Unfold', function () {
     })
   })
 
+  describe('List Property Retrieval with @unfold', function () {
+    before(async function () {
+      agent.dbName = 'field_unfold_list_retrieval_test'
+      await db.create(agent, { label: 'Field Unfold List Retrieval Test' })
+
+      const schema = [
+        {
+          '@type': 'Class',
+          '@id': 'Element',
+          data: 'xsd:string',
+        },
+        {
+          '@type': 'Class',
+          '@id': 'Sequence',
+          elements: {
+            '@type': 'List',
+            '@class': 'Element',
+            '@unfold': true,
+          },
+        },
+      ]
+
+      await document.insert(agent, { schema })
+
+      const instances = [
+        { '@type': 'Element', '@id': 'Element/e1', data: 'first' },
+        { '@type': 'Element', '@id': 'Element/e2', data: 'second' },
+        {
+          '@type': 'Sequence',
+          '@id': 'Sequence/s1',
+          elements: ['Element/e1', 'Element/e2'],
+        },
+      ]
+
+      await document.insert(agent, { instance: instances })
+    })
+
+    after(async function () {
+      await db.delete(agent)
+    })
+
+    it('should unfold List property with @unfold: true when unfold=true', async function () {
+      const r = await document.get(agent, { queryString: 'id=Sequence/s1&unfold=true' })
+      expect(r.status).to.equal(200)
+      expect(r.body.elements).to.be.an('array').with.lengthOf(2)
+      expect(r.body.elements[0]).to.be.an('object')
+      expect(r.body.elements[0]['@id']).to.equal('Element/e1')
+      expect(r.body.elements[0].data).to.equal('first')
+      expect(r.body.elements[1]['@id']).to.equal('Element/e2')
+      expect(r.body.elements[1].data).to.equal('second')
+    })
+
+    it('should NOT unfold List property when unfold=false', async function () {
+      const r = await document.get(agent, { queryString: 'id=Sequence/s1&unfold=false' })
+      expect(r.status).to.equal(200)
+      expect(r.body.elements).to.deep.equal(['Element/e1', 'Element/e2'])
+    })
+  })
+
+  describe('2D Array Property Retrieval with @unfold', function () {
+    before(async function () {
+      agent.dbName = 'field_unfold_array2d_retrieval_test'
+      await db.create(agent, { label: 'Field Unfold 2D Array Retrieval Test' })
+
+      const schema = [
+        {
+          '@type': 'Class',
+          '@id': 'Cell',
+          data: 'xsd:string',
+        },
+        {
+          '@type': 'Class',
+          '@id': 'Grid',
+          cells: {
+            '@type': 'Array',
+            '@dimensions': 2,
+            '@class': 'Cell',
+            '@unfold': true,
+          },
+        },
+      ]
+
+      await document.insert(agent, { schema })
+
+      const instances = [
+        { '@type': 'Cell', '@id': 'Cell/c00', data: '00' },
+        { '@type': 'Cell', '@id': 'Cell/c01', data: '01' },
+        { '@type': 'Cell', '@id': 'Cell/c10', data: '10' },
+        { '@type': 'Cell', '@id': 'Cell/c11', data: '11' },
+        {
+          '@type': 'Grid',
+          '@id': 'Grid/g1',
+          cells: [
+            ['Cell/c00', 'Cell/c01'],
+            ['Cell/c10', 'Cell/c11'],
+          ],
+        },
+      ]
+
+      await document.insert(agent, { instance: instances })
+    })
+
+    after(async function () {
+      await db.delete(agent)
+    })
+
+    it('should unfold 2D Array property with @unfold: true when unfold=true', async function () {
+      const r = await document.get(agent, { queryString: 'id=Grid/g1&unfold=true' })
+      expect(r.status).to.equal(200)
+      expect(r.body.cells).to.be.an('array').with.lengthOf(2)
+      expect(r.body.cells[0][0]).to.be.an('object')
+      expect(r.body.cells[0][0]['@id']).to.equal('Cell/c00')
+      expect(r.body.cells[0][0].data).to.equal('00')
+      expect(r.body.cells[0][1]['@id']).to.equal('Cell/c01')
+      expect(r.body.cells[1][0]['@id']).to.equal('Cell/c10')
+      expect(r.body.cells[1][1]['@id']).to.equal('Cell/c11')
+      expect(r.body.cells[1][1].data).to.equal('11')
+    })
+
+    it('should NOT unfold 2D Array property when unfold=false', async function () {
+      const r = await document.get(agent, { queryString: 'id=Grid/g1&unfold=false' })
+      expect(r.status).to.equal(200)
+      expect(r.body.cells).to.deep.equal([
+        ['Cell/c00', 'Cell/c01'],
+        ['Cell/c10', 'Cell/c11'],
+      ])
+    })
+  })
+
   describe('Interaction with class-level @unfoldable', function () {
     before(async function () {
       agent.dbName = 'field_unfold_interaction_test'


### PR DESCRIPTION
Fixes #2512.

`@unfold` (#2321) is checked in `doc/mod.rs` via a `(parent_type_id, predicate_id)` pair looked up on the enclosing document frame. `Set`/`Optional`/`Cardinality` values sit as direct triples on the document, so this worked. `List` and `Array` values instead sit behind an intermediate `StackEntry::List`/`StackEntry::Array` frame (the RDF Cons chain, or the array's index triples), and those frames didn't carry the parent's type/predicate forward — so field-level `@unfold` was silently disabled for anything nested inside a `List` or `Array`.

This threads the parent type/predicate through those frames so nested elements can still match against `unfold_pairs`, per @hoijnet's [confirmation](https://github.com/terminusdb/terminusdb/issues/2512#issuecomment-5463157961) that `List`/`Array` should have parity with `Optional`/`Set`/`Cardinality`.

Adds integration tests for `List` retrieval and a 2D `Array` case (as requested), closing the CI gap where the existing tests only asserted the schema round-trip, never that unfolding actually happened at read time.